### PR TITLE
Added node subsets, state_disc, control_disc, and segment_ends.  

### DIFF
--- a/docs/source/user_guide/phases/transcriptions/figures/radau-pseudospectral/plot_radau-pseudospectral.py
+++ b/docs/source/user_guide/phases/transcriptions/figures/radau-pseudospectral/plot_radau-pseudospectral.py
@@ -17,7 +17,7 @@ p['phase0.t_initial'] = 1.0
 p['phase0.t_duration'] = 9.0
 p.run_model()
 
-t_disc = phase.get_values('time', nodes='disc')
+t_disc = phase.get_values('time', nodes='state_disc')
 t_col = phase.get_values('time', nodes='col')
 t_all = phase.get_values('time', nodes='all')
 

--- a/dymos/examples/brachistochrone/ex_brachistochrone.py
+++ b/dymos/examples/brachistochrone/ex_brachistochrone.py
@@ -94,10 +94,10 @@ def brachistochrone_min_time(
     p['phase0.t_duration'] = 2.0
 
     if transcription != 'glm':
-        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='disc')
-        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='disc')
-        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='disc')
-        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='all')
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_disc')
+        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_disc')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_disc')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='control_disc')
     else:
         phase.set_values('x', [0, 10])
         phase.set_values('y', [10, 5])

--- a/dymos/examples/brachistochrone/test/test_doc_brach_run_simul_derivs.py
+++ b/dymos/examples/brachistochrone/test/test_doc_brach_run_simul_derivs.py
@@ -54,10 +54,10 @@ class TestBrachistochroneSimulDerivsRunExample(unittest.TestCase):
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 2.0
 
-        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='disc')
-        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='disc')
-        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='disc')
-        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='all')
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_disc')
+        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_disc')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_disc')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='control_disc')
 
         # Solve for the optimal trajectory
         p.run_driver()

--- a/dymos/examples/brachistochrone/test/test_doc_brach_run_without_simul_derivs.py
+++ b/dymos/examples/brachistochrone/test/test_doc_brach_run_without_simul_derivs.py
@@ -50,10 +50,10 @@ class TestBrachistochroneWithoutSimulDerivsRunExample(unittest.TestCase):
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 2.0
 
-        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='disc')
-        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='disc')
-        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='disc')
-        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='all')
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_disc')
+        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_disc')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_disc')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='control_disc')
 
         # Solve for the optimal trajectory
         p.run_driver()

--- a/dymos/examples/brachistochrone/test/test_doc_brachistochrone.py
+++ b/dymos/examples/brachistochrone/test/test_doc_brachistochrone.py
@@ -53,10 +53,10 @@ class TestBrachistochroneExample(unittest.TestCase):
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 2.0
 
-        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='disc')
-        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='disc')
-        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='disc')
-        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='all')
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_disc')
+        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_disc')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_disc')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='control_disc')
 
         # Solve for the optimal trajectory
         p.run_driver()

--- a/dymos/examples/brachistochrone/test/test_doc_brachistochrone_implicit_recorder.py
+++ b/dymos/examples/brachistochrone/test/test_doc_brachistochrone_implicit_recorder.py
@@ -68,10 +68,10 @@ class TestBrachistochroneRecordingExample(unittest.TestCase):
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 2.0
 
-        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='disc')
-        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='disc')
-        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='disc')
-        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='all')
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_disc')
+        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_disc')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_disc')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='control_disc')
 
         # Solve for the optimal trajectory
         p.run_driver()

--- a/dymos/examples/brachistochrone/test/test_path_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_path_constraints.py
@@ -51,10 +51,10 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 2.0
 
-        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='disc')
-        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='disc')
-        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='disc')
-        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='all')
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_disc')
+        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_disc')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_disc')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='control_disc')
 
         # Solve for the optimal trajectory
         p.run_driver()
@@ -106,10 +106,10 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 2.0
 
-        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='disc')
-        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='disc')
-        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='disc')
-        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='all')
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_disc')
+        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_disc')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_disc')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='control_disc')
 
         # Solve for the optimal trajectory
         p.run_driver()
@@ -160,10 +160,10 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 2.0
 
-        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='disc')
-        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='disc')
-        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='disc')
-        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='all')
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_disc')
+        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_disc')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_disc')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='control_disc')
 
         # Solve for the optimal trajectory
         p.run_driver()
@@ -215,10 +215,10 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 2.0
 
-        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='disc')
-        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='disc')
-        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='disc')
-        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='all')
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_disc')
+        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_disc')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_disc')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='control_disc')
 
         # Solve for the optimal trajectory
         p.run_driver()

--- a/dymos/examples/double_integrator/ex_double_integrator.py
+++ b/dymos/examples/double_integrator/ex_double_integrator.py
@@ -64,9 +64,9 @@ def double_integrator_direct_collocation(transcription='gauss-lobatto', top_leve
     p['phase0.t_initial'] = 0.0
     p['phase0.t_duration'] = 1.0
 
-    p['phase0.states:x'] = phase.interpolate(ys=[0, 0.25], nodes='disc')
-    p['phase0.states:v'] = phase.interpolate(ys=[0, 0], nodes='disc')
-    p['phase0.controls:u'] = phase.interpolate(ys=[1, -1], nodes='all')
+    p['phase0.states:x'] = phase.interpolate(ys=[0, 0.25], nodes='state_disc')
+    p['phase0.states:v'] = phase.interpolate(ys=[0, 0], nodes='state_disc')
+    p['phase0.controls:u'] = phase.interpolate(ys=[1, -1], nodes='control_disc')
 
     p.run_driver()
 

--- a/dymos/examples/min_time_climb/ex_min_time_climb.py
+++ b/dymos/examples/min_time_climb/ex_min_time_climb.py
@@ -111,12 +111,12 @@ def min_time_climb(optimizer='SLSQP', num_seg=3, transcription='gauss-lobatto',
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 298.46902
 
-        p['phase0.states:r'] = phase.interpolate(ys=[0.0, 111319.54], nodes='disc')
-        p['phase0.states:h'] = phase.interpolate(ys=[100.0, 20000.0], nodes='disc')
-        p['phase0.states:v'] = phase.interpolate(ys=[135.964, 283.159], nodes='disc')
-        p['phase0.states:gam'] = phase.interpolate(ys=[0.0, 0.0], nodes='disc')
-        p['phase0.states:m'] = phase.interpolate(ys=[19030.468, 16841.431], nodes='disc')
-        p['phase0.controls:alpha'] = phase.interpolate(ys=[0.0, 0.0], nodes='all')
+        p['phase0.states:r'] = phase.interpolate(ys=[0.0, 111319.54], nodes='state_disc')
+        p['phase0.states:h'] = phase.interpolate(ys=[100.0, 20000.0], nodes='state_disc')
+        p['phase0.states:v'] = phase.interpolate(ys=[135.964, 283.159], nodes='state_disc')
+        p['phase0.states:gam'] = phase.interpolate(ys=[0.0, 0.0], nodes='state_disc')
+        p['phase0.states:m'] = phase.interpolate(ys=[19030.468, 16841.431], nodes='state_disc')
+        p['phase0.controls:alpha'] = phase.interpolate(ys=[0.0, 0.0], nodes='control_disc')
     else:
         p.setup(force_alloc_complex=force_alloc_complex)
         p.final_setup()

--- a/dymos/examples/ssto/test/test_ex_ssto_earth.py
+++ b/dymos/examples/ssto/test/test_ex_ssto_earth.py
@@ -43,12 +43,13 @@ class TestExampleSSTOEarth(unittest.TestCase):
 
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 150.0
-        p['phase0.states:x'] = p.model.phase0.interpolate(ys=[0, 1.15E5], nodes='disc')
-        p['phase0.states:y'] = p.model.phase0.interpolate(ys=[0, 1.85E5], nodes='disc')
-        p['phase0.states:vx'] = p.model.phase0.interpolate(ys=[0, 7796.6961], nodes='disc')
-        p['phase0.states:vy'] = p.model.phase0.interpolate(ys=[1.0E-6, 0], nodes='disc')
-        p['phase0.states:m'] = p.model.phase0.interpolate(ys=[117000, 1163], nodes='disc')
-        p['phase0.controls:theta'] = p.model.phase0.interpolate(ys=[1.5, -0.76], nodes='all')
+        p['phase0.states:x'] = p.model.phase0.interpolate(ys=[0, 1.15E5], nodes='state_disc')
+        p['phase0.states:y'] = p.model.phase0.interpolate(ys=[0, 1.85E5], nodes='state_disc')
+        p['phase0.states:vx'] = p.model.phase0.interpolate(ys=[0, 7796.6961], nodes='state_disc')
+        p['phase0.states:vy'] = p.model.phase0.interpolate(ys=[1.0E-6, 0], nodes='state_disc')
+        p['phase0.states:m'] = p.model.phase0.interpolate(ys=[117000, 1163], nodes='state_disc')
+        p['phase0.controls:theta'] = p.model.phase0.interpolate(ys=[1.5, -0.76],
+                                                                nodes='control_disc')
 
         # p.run_model()
 
@@ -83,12 +84,12 @@ class TestExampleSSTOEarth(unittest.TestCase):
         phase = p.model.phase0
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 150.0
-        p['phase0.states:x'] = phase.interpolate(ys=[0, 1.15E5], nodes='disc')
-        p['phase0.states:y'] = phase.interpolate(ys=[0, 1.85E5], nodes='disc')
-        p['phase0.states:vx'] = phase.interpolate(ys=[0, 7796.6961], nodes='disc')
-        p['phase0.states:vy'] = phase.interpolate(ys=[1.0E-6, 0], nodes='disc')
-        p['phase0.states:m'] = phase.interpolate(ys=[117000, 1163], nodes='disc')
-        p['phase0.controls:theta'] = phase.interpolate(ys=[1.5, -0.76], nodes='all')
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 1.15E5], nodes='state_disc')
+        p['phase0.states:y'] = phase.interpolate(ys=[0, 1.85E5], nodes='state_disc')
+        p['phase0.states:vx'] = phase.interpolate(ys=[0, 7796.6961], nodes='state_disc')
+        p['phase0.states:vy'] = phase.interpolate(ys=[1.0E-6, 0], nodes='state_disc')
+        p['phase0.states:m'] = phase.interpolate(ys=[117000, 1163], nodes='state_disc')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[1.5, -0.76], nodes='control_disc')
 
         p.run_driver()
 

--- a/dymos/examples/ssto/test/test_ex_ssto_moon.py
+++ b/dymos/examples/ssto/test/test_ex_ssto_moon.py
@@ -65,12 +65,12 @@ class TestExampleSSTOMoon(unittest.TestCase):
 
         phase = p.model.phase0
         if transcription != 'glm':
-            p['phase0.states:x'] = phase.interpolate(ys=[0, 350000.0], nodes='disc')
-            p['phase0.states:y'] = phase.interpolate(ys=[0, 185000.0], nodes='disc')
-            p['phase0.states:vx'] = phase.interpolate(ys=[0, 1627.0], nodes='disc')
-            p['phase0.states:vy'] = phase.interpolate(ys=[1.0E-6, 0], nodes='disc')
-            p['phase0.states:m'] = phase.interpolate(ys=[50000, 50000], nodes='disc')
-            p['phase0.controls:theta'] = phase.interpolate(ys=[1.5, -0.76], nodes='all')
+            p['phase0.states:x'] = phase.interpolate(ys=[0, 350000.0], nodes='state_disc')
+            p['phase0.states:y'] = phase.interpolate(ys=[0, 185000.0], nodes='state_disc')
+            p['phase0.states:vx'] = phase.interpolate(ys=[0, 1627.0], nodes='state_disc')
+            p['phase0.states:vy'] = phase.interpolate(ys=[1.0E-6, 0], nodes='state_disc')
+            p['phase0.states:m'] = phase.interpolate(ys=[50000, 50000], nodes='state_disc')
+            p['phase0.controls:theta'] = phase.interpolate(ys=[1.5, -0.76], nodes='control_disc')
         else:
             p['phase0.states:x'] = phase.interpolate(ys=[0, 350000.0])
             p['phase0.states:y'] = phase.interpolate(ys=[0, 185000.0])
@@ -98,12 +98,12 @@ class TestExampleSSTOMoon(unittest.TestCase):
 
         phase = p.model.phase0
 
-        p['phase0.states:x'] = phase.interpolate(ys=[0, 350000.0], nodes='disc')
-        p['phase0.states:y'] = phase.interpolate(ys=[0, 185000.0], nodes='disc')
-        p['phase0.states:vx'] = phase.interpolate(ys=[0, 1627.0], nodes='disc')
-        p['phase0.states:vy'] = phase.interpolate(ys=[1.0E-6, 0], nodes='disc')
-        p['phase0.states:m'] = phase.interpolate(ys=[50000, 50000], nodes='disc')
-        p['phase0.controls:theta'] = phase.interpolate(ys=[1.5, -0.76], nodes='all')
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 350000.0], nodes='state_disc')
+        p['phase0.states:y'] = phase.interpolate(ys=[0, 185000.0], nodes='state_disc')
+        p['phase0.states:vx'] = phase.interpolate(ys=[0, 1627.0], nodes='state_disc')
+        p['phase0.states:vy'] = phase.interpolate(ys=[1.0E-6, 0], nodes='state_disc')
+        p['phase0.states:m'] = phase.interpolate(ys=[50000, 50000], nodes='state_disc')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[1.5, -0.76], nodes='control_disc')
 
         p.run_driver()
 

--- a/dymos/examples/ssto/test/test_ex_ssto_moon_linear_tangent.py
+++ b/dymos/examples/ssto/test/test_ex_ssto_moon_linear_tangent.py
@@ -35,11 +35,11 @@ class TestExampleSSTOMoonLinearTangent(unittest.TestCase):
         phase = p.model.phase0
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 500.0
-        p['phase0.states:x'] = phase.interpolate(ys=[0, 350000.0], nodes='disc')
-        p['phase0.states:y'] = phase.interpolate(ys=[0, 185000.0], nodes='disc')
-        p['phase0.states:vx'] = phase.interpolate(ys=[0, 1627.0], nodes='disc')
-        p['phase0.states:vy'] = phase.interpolate(ys=[1.0E-6, 0], nodes='disc')
-        p['phase0.states:m'] = phase.interpolate(ys=[50000, 50000], nodes='disc')
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 350000.0], nodes='state_disc')
+        p['phase0.states:y'] = phase.interpolate(ys=[0, 185000.0], nodes='state_disc')
+        p['phase0.states:vx'] = phase.interpolate(ys=[0, 1627.0], nodes='state_disc')
+        p['phase0.states:vy'] = phase.interpolate(ys=[1.0E-6, 0], nodes='state_disc')
+        p['phase0.states:m'] = phase.interpolate(ys=[50000, 50000], nodes='state_disc')
         p['phase0.controls:a_ctrl'] = -0.01
         p['phase0.controls:b_ctrl'] = 3.0
 
@@ -74,11 +74,11 @@ class TestExampleSSTOMoonLinearTangent(unittest.TestCase):
         phase = p.model.phase0
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 500.0
-        p['phase0.states:x'] = phase.interpolate(ys=[0, 350000.0], nodes='disc')
-        p['phase0.states:y'] = phase.interpolate(ys=[0, 185000.0], nodes='disc')
-        p['phase0.states:vx'] = phase.interpolate(ys=[0, 1627.0], nodes='disc')
-        p['phase0.states:vy'] = phase.interpolate(ys=[1.0E-6, 0], nodes='disc')
-        p['phase0.states:m'] = phase.interpolate(ys=[50000, 50000], nodes='disc')
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 350000.0], nodes='state_disc')
+        p['phase0.states:y'] = phase.interpolate(ys=[0, 185000.0], nodes='state_disc')
+        p['phase0.states:vx'] = phase.interpolate(ys=[0, 1627.0], nodes='state_disc')
+        p['phase0.states:vy'] = phase.interpolate(ys=[1.0E-6, 0], nodes='state_disc')
+        p['phase0.states:m'] = phase.interpolate(ys=[50000, 50000], nodes='state_disc')
         p['phase0.controls:a_ctrl'] = -0.01
         p['phase0.controls:b_ctrl'] = 3.0
 

--- a/dymos/glm/glm_phase.py
+++ b/dymos/glm/glm_phase.py
@@ -130,7 +130,7 @@ class GLMPhase(PhaseBase):
                     self.connect(
                         'controls:{0}'.format(name),
                         'continuity_constraint.controls:{}'.format(name),
-                        src_indices=grid_data.subset_node_indices['disc'])
+                        src_indices=grid_data.subset_node_indices['state_disc'])
                     continuity = True
 
                     # TODO: once controls are nonlinear, we can support rate continuity.

--- a/dymos/models/eom/test/test_flight_path_eom_2d.py
+++ b/dymos/models/eom/test/test_flight_path_eom_2d.py
@@ -80,10 +80,10 @@ class TestFlightPathEOM2D(unittest.TestCase):
         self.p['phase0.t_initial'] = 0.0
         self.p['phase0.t_duration'] = t_duration
 
-        self.p['phase0.states:r'] = phase.interpolate(ys=[0, 700.0], nodes='disc')
-        self.p['phase0.states:h'] = phase.interpolate(ys=[0, 0], nodes='disc')
-        self.p['phase0.states:v'] = phase.interpolate(ys=[v0, v0], nodes='disc')
-        self.p['phase0.states:gam'] = phase.interpolate(ys=[gam0, -gam0], nodes='disc')
+        self.p['phase0.states:r'] = phase.interpolate(ys=[0, 700.0], nodes='state_disc')
+        self.p['phase0.states:h'] = phase.interpolate(ys=[0, 0], nodes='state_disc')
+        self.p['phase0.states:v'] = phase.interpolate(ys=[v0, v0], nodes='state_disc')
+        self.p['phase0.states:gam'] = phase.interpolate(ys=[gam0, -gam0], nodes='state_disc')
 
         self.p.run_model()
 
@@ -108,10 +108,10 @@ class TestFlightPathEOM2D(unittest.TestCase):
         self.p['phase0.t_duration'] = t_duration
 
         self.p['phase0.states:r'] = phase.interpolate(ys=[0, v0 * np.cos(gam0) * t_duration],
-                                                      nodes='disc')
-        self.p['phase0.states:h'] = phase.interpolate(ys=[0, 0], nodes='disc')
-        self.p['phase0.states:v'] = phase.interpolate(ys=[v0, v0], nodes='disc')
-        self.p['phase0.states:gam'] = phase.interpolate(ys=[gam0, -gam0], nodes='disc')
+                                                      nodes='state_disc')
+        self.p['phase0.states:h'] = phase.interpolate(ys=[0, 0], nodes='state_disc')
+        self.p['phase0.states:v'] = phase.interpolate(ys=[v0, v0], nodes='state_disc')
+        self.p['phase0.states:gam'] = phase.interpolate(ys=[gam0, -gam0], nodes='state_disc')
 
         self.p.run_driver()
 
@@ -135,10 +135,10 @@ class TestFlightPathEOM2D(unittest.TestCase):
         self.p['phase0.t_duration'] = t_duration
 
         self.p['phase0.states:r'] = phase.interpolate(ys=[0, v0 * np.cos(gam0) * t_duration],
-                                                      nodes='disc')
-        self.p['phase0.states:h'] = phase.interpolate(ys=[0, 0], nodes='disc')
-        self.p['phase0.states:v'] = phase.interpolate(ys=[v0, v0], nodes='disc')
-        self.p['phase0.states:gam'] = phase.interpolate(ys=[gam0, -gam0], nodes='disc')
+                                                      nodes='state_disc')
+        self.p['phase0.states:h'] = phase.interpolate(ys=[0, 0], nodes='state_disc')
+        self.p['phase0.states:v'] = phase.interpolate(ys=[v0, v0], nodes='state_disc')
+        self.p['phase0.states:gam'] = phase.interpolate(ys=[gam0, -gam0], nodes='state_disc')
 
         self.p.run_model()
 

--- a/dymos/phases/components/continuity_comp.py
+++ b/dymos/phases/components/continuity_comp.py
@@ -33,8 +33,8 @@ class ContinuityComp(ExplicitComponent):
     def _setup_value_continuity(self):
         state_options = self.metadata['state_options']
         control_options = self.metadata['control_options']
-        segment_indices = self.metadata['grid_data'].subset_segment_indices['disc']
-        num_disc_nodes = self.metadata['grid_data'].subset_num_nodes['disc']
+        segment_indices = self.metadata['grid_data'].subset_segment_indices['state_disc']
+        num_disc_nodes = self.metadata['grid_data'].subset_num_nodes['state_disc']
         num_segments = self.metadata['grid_data'].num_segments
 
         self.jacs = {}

--- a/dymos/phases/components/control_rate_comp.py
+++ b/dymos/phases/components/control_rate_comp.py
@@ -128,7 +128,7 @@ class ControlRateComp(ExplicitComponent):
         self.sizes = {}
         self.num_nodes = num_nodes
 
-        _, self.D = self.metadata['grid_data'].phase_lagrange_matrices('all', 'all')
+        _, self.D = self.metadata['grid_data'].phase_lagrange_matrices('control_disc', 'all')
         self.D2 = np.dot(self.D, self.D)
 
         self._setup_controls()

--- a/dymos/phases/components/path_constraint_comp.py
+++ b/dymos/phases/components/path_constraint_comp.py
@@ -89,7 +89,7 @@ class GaussLobattoPathConstraintComp(PathConstraintCompBase):
         grid_data = self.metadata['grid_data']
 
         num_nodes = grid_data.num_nodes
-        num_disc_nodes = grid_data.subset_num_nodes['disc']
+        num_state_disc_nodes = grid_data.subset_num_nodes['state_disc']
         num_col_nodes = grid_data.subset_num_nodes['col']
         for (name, kwargs) in self._path_constraints:
             input_kwargs = {k: kwargs[k] for k in ('units', 'desc', 'var_set')}
@@ -106,7 +106,7 @@ class GaussLobattoPathConstraintComp(PathConstraintCompBase):
                 col_input_name = 'col_values:{0}'.format(name)
 
                 self.add_input(disc_input_name,
-                               shape=(num_disc_nodes,) + shape,
+                               shape=(num_state_disc_nodes,) + shape,
                                **input_kwargs)
 
                 self.add_input(col_input_name,
@@ -146,16 +146,16 @@ class GaussLobattoPathConstraintComp(PathConstraintCompBase):
                     cols=np.arange(all_size),
                     val=1.0)
             else:
-                disc_shape = (num_disc_nodes,) + shape
+                disc_shape = (num_state_disc_nodes,) + shape
                 col_shape = (num_col_nodes,) + shape
 
                 var_size = np.prod(shape)
                 disc_size = np.prod(disc_shape)
                 col_size = np.prod(col_shape)
 
-                disc_row_starts = grid_data.subset_node_indices['disc'] * var_size
+                state_disc_row_starts = grid_data.subset_node_indices['state_disc'] * var_size
                 disc_rows = []
-                for i in disc_row_starts:
+                for i in state_disc_row_starts:
                     disc_rows.extend(range(i, i + var_size))
                 disc_rows = np.asarray(disc_rows, dtype=int)
 
@@ -182,7 +182,7 @@ class GaussLobattoPathConstraintComp(PathConstraintCompBase):
                     val=1.0)
 
     def compute(self, inputs, outputs):
-        disc_indices = self.metadata['grid_data'].subset_node_indices['disc']
+        disc_indices = self.metadata['grid_data'].subset_node_indices['state_disc']
         col_indices = self.metadata['grid_data'].subset_node_indices['col']
         for (disc_input_name, col_input_name, all_inp_name, src_all, output_name, _) in self._vars:
             if src_all:

--- a/dymos/phases/components/tests/test_continuity_comp.py
+++ b/dymos/phases/components/tests/test_continuity_comp.py
@@ -86,14 +86,12 @@ class TestContinuityComp(unittest.TestCase):
         for state in ('x', 'y'):
             assert_almost_equal(self.p['cnty_comp.defect_states:{0}'.format(state)][0, ...],
                                 self.p[state][2, ...] - self.p[state][3, ...])
-        for state in ('x', 'y'):
             assert_almost_equal(self.p['cnty_comp.defect_states:{0}'.format(state)][1, ...],
                                 self.p[state][4, ...] - self.p[state][5, ...])
 
         for state in ('u', 'v'):
             assert_almost_equal(self.p['cnty_comp.defect_controls:{0}'.format(state)][0, ...],
                                 self.p[state][4, ...] - self.p[state][5, ...])
-        for state in ('u', 'v'):
             assert_almost_equal(self.p['cnty_comp.defect_controls:{0}'.format(state)][1, ...],
                                 self.p[state][7, ...] - self.p[state][8, ...])
 

--- a/dymos/phases/components/tests/test_control_rate_comp.py
+++ b/dymos/phases/components/tests/test_control_rate_comp.py
@@ -81,8 +81,8 @@ class TestControlRateComp(unittest.TestCase):
         ivc = IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
-        ivc.add_output('controls:a', val=np.zeros(gd.subset_num_nodes['all']), units='m')
-        ivc.add_output('controls:b', val=np.zeros(gd.subset_num_nodes['all']), units='m')
+        ivc.add_output('controls:a', val=np.zeros(gd.subset_num_nodes['control_disc']), units='m')
+        ivc.add_output('controls:b', val=np.zeros(gd.subset_num_nodes['control_disc']), units='m')
         ivc.add_output('t_initial', val=0.0, units='s')
         ivc.add_output('t_duration', val=10.0, units='s')
 
@@ -150,7 +150,8 @@ class TestControlRateComp(unittest.TestCase):
         ivc = IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
-        ivc.add_output('controls:a', val=np.zeros((gd.subset_num_nodes['all'], 3)), units='m')
+        ivc.add_output('controls:a', val=np.zeros((gd.subset_num_nodes['control_disc'], 3)),
+                       units='m')
         ivc.add_output('t_initial', val=0.0, units='s')
         ivc.add_output('t_duration', val=10.0, units='s')
 
@@ -228,7 +229,8 @@ class TestControlRateComp(unittest.TestCase):
         ivc = IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
-        ivc.add_output('controls:a', val=np.zeros((gd.subset_num_nodes['all'], 3, 1)), units='m')
+        ivc.add_output('controls:a', val=np.zeros((gd.subset_num_nodes['control_disc'], 3, 1)),
+                       units='m')
         ivc.add_output('t_initial', val=0.0, units='s')
         ivc.add_output('t_duration', val=10.0, units='s')
 
@@ -306,7 +308,8 @@ class TestControlRateComp(unittest.TestCase):
         ivc = IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
-        ivc.add_output('controls:a', val=np.zeros((gd.subset_num_nodes['all'], 2, 2)), units='m')
+        ivc.add_output('controls:a', val=np.zeros((gd.subset_num_nodes['control_disc'], 2, 2)),
+                       units='m')
         ivc.add_output('t_initial', val=0.0, units='s')
         ivc.add_output('t_duration', val=10.0, units='s')
 
@@ -393,8 +396,8 @@ class TestControlRateComp(unittest.TestCase):
         ivc = IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
-        ivc.add_output('controls:a', val=np.zeros(gd.subset_num_nodes['all']), units='m')
-        ivc.add_output('controls:b', val=np.zeros(gd.subset_num_nodes['all']), units='m')
+        ivc.add_output('controls:a', val=np.zeros(gd.subset_num_nodes['control_disc']), units='m')
+        ivc.add_output('controls:b', val=np.zeros(gd.subset_num_nodes['control_disc']), units='m')
         ivc.add_output('t_initial', val=0.0, units='s')
         ivc.add_output('t_duration', val=10.0, units='s')
 
@@ -461,7 +464,8 @@ class TestControlRateComp(unittest.TestCase):
         ivc = IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
-        ivc.add_output('controls:a', val=np.zeros((gd.subset_num_nodes['all'], 3)), units='m')
+        ivc.add_output('controls:a', val=np.zeros((gd.subset_num_nodes['control_disc'], 3)),
+                       units='m')
         ivc.add_output('t_initial', val=0.0, units='s')
         ivc.add_output('t_duration', val=10.0, units='s')
 
@@ -539,7 +543,8 @@ class TestControlRateComp(unittest.TestCase):
         ivc = IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
-        ivc.add_output('controls:a', val=np.zeros((gd.subset_num_nodes['all'], 3, 1)), units='m')
+        ivc.add_output('controls:a', val=np.zeros((gd.subset_num_nodes['control_disc'], 3, 1)),
+                       units='m')
         ivc.add_output('t_initial', val=0.0, units='s')
         ivc.add_output('t_duration', val=10.0, units='s')
 
@@ -617,7 +622,8 @@ class TestControlRateComp(unittest.TestCase):
         ivc = IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
-        ivc.add_output('controls:a', val=np.zeros((gd.subset_num_nodes['all'], 2, 2)), units='m')
+        ivc.add_output('controls:a', val=np.zeros((gd.subset_num_nodes['control_disc'], 2, 2)),
+                       units='m')
         ivc.add_output('t_initial', val=0.0, units='s')
         ivc.add_output('t_duration', val=10.0, units='s')
 

--- a/dymos/phases/components/tests/test_path_constraint_comp.py
+++ b/dymos/phases/components/tests/test_path_constraint_comp.py
@@ -189,13 +189,13 @@ class TestPathConstraintCompRadau(unittest.TestCase):
         p = self.p
         gd = self.gd
         assert_almost_equal(p['a_disc'],
-                            p['path_constraints.path:a'][gd.subset_node_indices['disc'], ...])
+                            p['path_constraints.path:a'][gd.subset_node_indices['state_disc'], ...])
 
         assert_almost_equal(p['b_disc'],
-                            p['path_constraints.path:b'][gd.subset_node_indices['disc'], ...])
+                            p['path_constraints.path:b'][gd.subset_node_indices['state_disc'], ...])
 
         assert_almost_equal(p['c_disc'],
-                            p['path_constraints.path:c'][gd.subset_node_indices['disc'], ...])
+                            p['path_constraints.path:c'][gd.subset_node_indices['state_disc'], ...])
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024, edgeitems=1000)

--- a/dymos/phases/optimizer_based/components/state_interp_comp.py
+++ b/dymos/phases/optimizer_based/components/state_interp_comp.py
@@ -49,7 +49,7 @@ class StateInterpComp(ExplicitComponent):
     def setup(self):
         time_units = self.metadata['time_units']
 
-        num_disc_nodes = self.metadata['grid_data'].subset_num_nodes['disc']
+        num_disc_nodes = self.metadata['grid_data'].subset_num_nodes['state_disc']
         num_col_nodes = self.metadata['grid_data'].subset_num_nodes['col']
 
         state_options = self.metadata['state_options']
@@ -103,9 +103,9 @@ class StateInterpComp(ExplicitComponent):
             self.xdotc_str[state_name] = 'staterate_col:{0}'.format(state_name)
 
         if transcription == 'gauss-lobatto':
-            Ai, Bi, Ad, Bd = self.metadata['grid_data'].phase_hermite_matrices('disc', 'col')
+            Ai, Bi, Ad, Bd = self.metadata['grid_data'].phase_hermite_matrices('state_disc', 'col')
         elif transcription == 'radau-ps':
-            Ai, Ad = self.metadata['grid_data'].phase_lagrange_matrices('disc', 'col')
+            Ai, Ad = self.metadata['grid_data'].phase_lagrange_matrices('state_disc', 'col')
             Bi = Bd = np.zeros(shape=(num_col_nodes, num_disc_nodes))
         else:
             raise ValueError('unhandled transcription type: '

--- a/dymos/phases/optimizer_based/components/test/test_state_interp_comp.py
+++ b/dymos/phases/optimizer_based/components/test/test_state_interp_comp.py
@@ -54,18 +54,21 @@ class TestStateInterpComp(unittest.TestCase):
         X_ivc = IndepVarComp()
         p.model.add_subsystem('X_ivc', X_ivc, promotes=['state_disc:x', 'state_disc:v'])
 
-        X_ivc.add_output('state_disc:x', val=np.zeros(gd.subset_num_nodes['disc']), units='m')
-        X_ivc.add_output('state_disc:v', val=np.zeros(gd.subset_num_nodes['disc']), units='m/s')
+        X_ivc.add_output('state_disc:x', val=np.zeros(gd.subset_num_nodes['state_disc']),
+                         units='m')
+
+        X_ivc.add_output('state_disc:v', val=np.zeros(gd.subset_num_nodes['state_disc']),
+                         units='m/s')
 
         F_ivc = IndepVarComp()
         p.model.add_subsystem('F_ivc', F_ivc, promotes=['staterate_disc:x', 'staterate_disc:v'])
 
         F_ivc.add_output('staterate_disc:x',
-                         val=np.zeros(gd.subset_num_nodes['disc']),
+                         val=np.zeros(gd.subset_num_nodes['state_disc']),
                          units='m/s')
 
         F_ivc.add_output('staterate_disc:v',
-                         val=np.zeros(gd.subset_num_nodes['disc']),
+                         val=np.zeros(gd.subset_num_nodes['state_disc']),
                          units='m/s**2')
 
         dt_dtau_ivc = IndepVarComp()
@@ -163,13 +166,13 @@ class TestStateInterpComp(unittest.TestCase):
         p.model.add_subsystem('X_ivc', X_ivc, promotes=['state_disc:pos'])
 
         X_ivc.add_output('state_disc:pos',
-                         val=np.zeros((gd.subset_num_nodes['disc'], 2)), units='m')
+                         val=np.zeros((gd.subset_num_nodes['state_disc'], 2)), units='m')
 
         F_ivc = IndepVarComp()
         p.model.add_subsystem('F_ivc', F_ivc, promotes=['staterate_disc:pos'])
 
         F_ivc.add_output('staterate_disc:pos',
-                         val=np.zeros((gd.subset_num_nodes['disc'], 2)),
+                         val=np.zeros((gd.subset_num_nodes['state_disc'], 2)),
                          units='m/s')
 
         dt_dtau_ivc = IndepVarComp()
@@ -273,13 +276,13 @@ class TestStateInterpComp(unittest.TestCase):
         p.model.add_subsystem('X_ivc', X_ivc, promotes=['state_disc:pos'])
 
         X_ivc.add_output('state_disc:pos',
-                         val=np.zeros((gd.subset_num_nodes['disc'], 2)), units='m')
+                         val=np.zeros((gd.subset_num_nodes['state_disc'], 2)), units='m')
 
         F_ivc = IndepVarComp()
         p.model.add_subsystem('F_ivc', F_ivc, promotes=['staterate_disc:pos'])
 
         F_ivc.add_output('staterate_disc:pos',
-                         val=np.zeros((gd.subset_num_nodes['disc'], 2)),
+                         val=np.zeros((gd.subset_num_nodes['state_disc'], 2)),
                          units='m/s')
 
         dt_dtau_ivc = IndepVarComp()
@@ -329,8 +332,11 @@ class TestStateInterpComp(unittest.TestCase):
         X_ivc = IndepVarComp()
         p.model.add_subsystem('X_ivc', X_ivc, promotes=['state_disc:x', 'state_disc:v'])
 
-        X_ivc.add_output('state_disc:x', val=np.zeros(gd.subset_num_nodes['disc']), units='m')
-        X_ivc.add_output('state_disc:v', val=np.zeros(gd.subset_num_nodes['disc']), units='m/s')
+        X_ivc.add_output('state_disc:x', val=np.zeros(gd.subset_num_nodes['state_disc']),
+                         units='m')
+
+        X_ivc.add_output('state_disc:v', val=np.zeros(gd.subset_num_nodes['state_disc']),
+                         units='m/s')
 
         dt_dtau_ivc = IndepVarComp()
         dt_dtau_ivc.add_output('dt_dstau', val=0.0*np.zeros(gd.subset_num_nodes['col']), units='s')

--- a/dymos/phases/optimizer_based/tests/test_simulate.py
+++ b/dymos/phases/optimizer_based/tests/test_simulate.py
@@ -74,10 +74,10 @@ class TestSimulateRecording(unittest.TestCase):
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 2.0
 
-        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='disc')
-        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='disc')
-        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='disc')
-        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='all')
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_disc')
+        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_disc')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_disc')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='control_disc')
 
         p.run_driver()
 
@@ -149,10 +149,10 @@ class TestSimulateRecording(unittest.TestCase):
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 2.0
 
-        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='disc')
-        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='disc')
-        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='disc')
-        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='all')
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_disc')
+        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_disc')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_disc')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='control_disc')
 
         p.run_driver()
 

--- a/dymos/utils/misc.py
+++ b/dymos/utils/misc.py
@@ -43,18 +43,37 @@ class CoerceDesvar(object):
     Check the desvar options for the appropriate shape and resize
     accordingly with opt_initial and opt_final options.
     """
-
     def __init__(self, num_input_nodes, desvar_indices, options):
-        self.num_disc_nodes = num_input_nodes
+        self.num_input_nodes = num_input_nodes
         self.desvar_indices = desvar_indices
         self.options = options
 
     def __call__(self, option):
+        """
+        Test that the given opption has a shape that is compliant with the number of input
+        nodes for the design variable.
+
+        Parameters
+        ----------
+        option : str
+            The name of the option whose value(s) are desired.
+
+        Returns
+        -------
+        The value of the desvar option
+
+        Raises
+        ------
+        ValueError
+            If the number of values in the option is not compliant with the number of input
+            nodes for the design variable.
+
+        """
         val = self.options[option]
         if val is None or np.isscalar(val):
             return val
         else:
-            if len(val) != self.num_disc_nodes:
+            if len(val) != self.num_input_nodes:
                 raise ValueError('array-valued option {0} must have length '
-                                 'num_disc_nodes ({1})'.format(option, val))
+                                 'num_input_nodes ({1})'.format(option, val))
             return val[self.desvar_indices]


### PR DESCRIPTION
'state_disc' is identical to the now-deprecated 'disc' subset.  The subset 'control_disc' is used, for instance, when interpolating a control guess.  Currently, it is equivalent to subset 'all' for Gauss-Lobatto and Radau-PS.  Subset 'segment_ends' is used internally when we need to pass around values at the end of segments.