### PR TITLE
Fix for opt_duration=False errors

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.0
+current_version = 0.9.1
 commit = False
 tag = False
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,7 +71,7 @@ author = u'Rob Falck and John Hwang'
 # built documents.
 #
 # The short X.Y version.
-version = u'0.9.0'
+version = u'0.9.1'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/source/user_guide/phases/variables.rst
+++ b/docs/source/user_guide/phases/variables.rst
@@ -17,7 +17,11 @@ In |project|, time is characterized by two variables:
 * `t_initial` - The initial time of the phase
 * `t_duration` - The duration of the phase
 
-The bounds, scaling, and units of these variables may be set using `set_time_options`.
+The bounds, scaling, and units of these variables may be set using `set_time_options`.  In addition,
+the user can specify that the initial time or duration of a phase is to be connected to some
+external output by specifying `input_initial = True` or `input_duration = True`.  In the case of
+fixed initial time or duration, or input initial time or duration, the optimization-related options
+have no effect and a warning will be raised if they are used.
 
 .. embed-options::
     dymos.phases.options

--- a/dymos/__init__.py
+++ b/dymos/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
-__version__ = '0.9.0'
+__version__ = '0.9.1'
 
 from .ode_options import ODEOptions, declare_time, declare_state, declare_parameter
 from .phases.phase_factory import Phase

--- a/dymos/examples/aircraft_steady_flight/ex_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/ex_aircraft_steady_flight.py
@@ -82,7 +82,7 @@ def ex_aircraft_steady_flight(optimizer='SLSQP', transcription='gauss-lobatto'):
 
     p.model.linear_solver = DirectSolver(assemble_jac=True)
 
-    p.setup(mode='fwd')
+    p.setup()
 
     p['phase0.t_initial'] = 0.0
     p['phase0.t_duration'] = 3600.0

--- a/dymos/examples/aircraft_steady_flight/flight_equlibrium/test/test_flight_equilibrium_group.py
+++ b/dymos/examples/aircraft_steady_flight/flight_equlibrium/test/test_flight_equilibrium_group.py
@@ -55,7 +55,7 @@ class TestFlightEquilibriumGroup(unittest.TestCase):
         cls.p.model.connect('W_total', 'flight_equilibrium.W_total')
         cls.p.model.connect('q', ('aero.q', 'flight_equilibrium.q'))
 
-        cls.p.setup(check=True, mode='fwd', force_alloc_complex=True)
+        cls.p.setup(check=True, force_alloc_complex=True)
 
         cls.p.run_model()
 

--- a/dymos/examples/aircraft_steady_flight/propulsion/test/test_propulsion_group.py
+++ b/dymos/examples/aircraft_steady_flight/propulsion/test/test_propulsion_group.py
@@ -32,7 +32,7 @@ class TestPropulsionComp(unittest.TestCase):
         cls.p.model.connect('pres', 'propulsion.pres')
         cls.p.model.connect('CT', 'propulsion.CT')
 
-        cls.p.setup(mode='fwd', force_alloc_complex=True)
+        cls.p.setup(force_alloc_complex=True)
 
         cls.p.run_model()
 

--- a/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
@@ -79,7 +79,7 @@ class TestAircraftCruise(unittest.TestCase):
         p.model.linear_solver = DirectSolver(assemble_jac=True)
         p.model.options['assembled_jac_type'] = 'csc'
 
-        p.setup(mode='fwd')
+        p.setup()
 
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 1.515132 * 3600.0

--- a/dymos/examples/aircraft_steady_flight/test/test_aircraft_ode.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_aircraft_ode.py
@@ -50,7 +50,7 @@ class TestAircraftODEGroup(unittest.TestCase):
         cls.p.model.linear_solver = DirectSolver(assemble_jac=True)
         cls.p.model.options['assembled_jac_type'] = 'csc'
 
-        cls.p.setup(check=True, mode='fwd')
+        cls.p.setup(check=True)
 
         cls.p.run_model()
 

--- a/dymos/examples/aircraft_steady_flight/test/test_doc_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_doc_aircraft_steady_flight.py
@@ -77,7 +77,7 @@ class TestSteadyAircraftFlightForDocs(unittest.TestCase):
 
         p.model.linear_solver = DirectSolver(assemble_jac=True)
 
-        p.setup(mode='fwd')
+        p.setup()
 
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 3600.0

--- a/dymos/examples/brachistochrone/ex_brachistochrone.py
+++ b/dymos/examples/brachistochrone/ex_brachistochrone.py
@@ -56,7 +56,7 @@ def brachistochrone_min_time(
 
     p.model.options['assembled_jac_type'] = top_level_jacobian.lower()
     p.model.linear_solver = DirectSolver(assemble_jac=True)
-    p.setup(mode='fwd', check=True)
+    p.setup(check=True)
 
     p['phase0.t_initial'] = 0.0
     p['phase0.t_duration'] = 2.0

--- a/dymos/examples/brachistochrone/ex_brachistochrone.py
+++ b/dymos/examples/brachistochrone/ex_brachistochrone.py
@@ -40,7 +40,7 @@ def brachistochrone_min_time(
 
     p.model.add_subsystem('phase0', phase)
 
-    phase.set_time_options(opt_initial=False, duration_bounds=(.5, 10))
+    phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
 
     phase.set_state_options('x', fix_initial=True, fix_final=True)
     phase.set_state_options('y', fix_initial=True, fix_final=True)

--- a/dymos/examples/brachistochrone/test/test_doc_brach_run_simul_derivs.py
+++ b/dymos/examples/brachistochrone/test/test_doc_brach_run_simul_derivs.py
@@ -43,7 +43,7 @@ class TestBrachistochroneSimulDerivsRunExample(unittest.TestCase):
         p.model.linear_solver = DirectSolver(assemble_jac=True)
         p.model.options['assembled_jac_type'] = 'csc'
 
-        p.setup(mode='fwd')
+        p.setup()
 
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 2.0

--- a/dymos/examples/brachistochrone/test/test_doc_brach_run_without_simul_derivs.py
+++ b/dymos/examples/brachistochrone/test/test_doc_brach_run_without_simul_derivs.py
@@ -41,7 +41,7 @@ class TestBrachistochroneWithoutSimulDerivsRunExample(unittest.TestCase):
         p.model.linear_solver = DirectSolver(assemble_jac=True)
         p.model.options['assembled_jac_type'] = 'csc'
 
-        p.setup(mode='fwd')
+        p.setup()
 
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 2.0

--- a/dymos/examples/brachistochrone/test/test_doc_brachistochrone.py
+++ b/dymos/examples/brachistochrone/test/test_doc_brachistochrone.py
@@ -47,7 +47,7 @@ class TestBrachistochroneExample(unittest.TestCase):
         p.model.linear_solver = DirectSolver(assemble_jac=True)
         p.model.options['assembled_jac_type'] = 'csc'
 
-        p.setup(mode='rev')
+        p.setup()
 
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 2.0

--- a/dymos/examples/brachistochrone/test/test_doc_brachistochrone_implicit_recorder.py
+++ b/dymos/examples/brachistochrone/test/test_doc_brachistochrone_implicit_recorder.py
@@ -62,7 +62,7 @@ class TestBrachistochroneRecordingExample(unittest.TestCase):
         p.model.add_recorder(rec)
         phase.add_recorder(rec)
 
-        p.setup(mode='rev')
+        p.setup()
 
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 2.0

--- a/dymos/examples/brachistochrone/test/test_path_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_path_constraints.py
@@ -38,7 +38,7 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
         p.model.linear_solver = DirectSolver(assemble_jac=True)
         p.model.options['assembled_jac_type'] = 'csc'
 
-        p.setup(mode='fwd')
+        p.setup()
 
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 2.0
@@ -88,7 +88,7 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
         p.model.linear_solver = DirectSolver(assemble_jac=True)
         p.model.options['assembled_jac_type'] = 'csc'
 
-        p.setup(mode='fwd')
+        p.setup()
 
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 2.0
@@ -138,7 +138,7 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
         p.model.linear_solver = DirectSolver(assemble_jac=True)
         p.model.options['assembled_jac_type'] = 'csc'
 
-        p.setup(mode='fwd')
+        p.setup()
 
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 2.0
@@ -188,7 +188,7 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
         p.model.linear_solver = DirectSolver(assemble_jac=True)
         p.model.options['assembled_jac_type'] = 'csc'
 
-        p.setup(mode='fwd')
+        p.setup()
 
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 2.0

--- a/dymos/examples/double_integrator/ex_double_integrator.py
+++ b/dymos/examples/double_integrator/ex_double_integrator.py
@@ -20,7 +20,7 @@ def double_integrator_direct_collocation(transcription='gauss-lobatto', top_leve
 
     p.model.add_subsystem('phase0', phase)
 
-    phase.set_time_options(opt_initial=False, opt_duration=False)
+    phase.set_time_options(fix_initial=True, fix_duration=True)
 
     phase.set_state_options('x', fix_initial=True)
     phase.set_state_options('v', fix_initial=True, fix_final=True)

--- a/dymos/examples/double_integrator/ex_double_integrator.py
+++ b/dymos/examples/double_integrator/ex_double_integrator.py
@@ -20,7 +20,7 @@ def double_integrator_direct_collocation(transcription='gauss-lobatto', top_leve
 
     p.model.add_subsystem('phase0', phase)
 
-    phase.set_time_options(initial_bounds=(0, 0), duration_bounds=(1.0, 1.0))
+    phase.set_time_options(opt_initial=False, opt_duration=False)
 
     phase.set_state_options('x', fix_initial=True)
     phase.set_state_options('v', fix_initial=True, fix_final=True)
@@ -49,5 +49,4 @@ def double_integrator_direct_collocation(transcription='gauss-lobatto', top_leve
 
 
 if __name__ == '__main__':
-    prob = double_integrator_direct_collocation(transcription='radau-ps', optimizer='SLSQP',
-                                                compressed=True)
+    prob = double_integrator_direct_collocation(transcription='radau-ps', compressed=True)

--- a/dymos/examples/double_integrator/ex_double_integrator.py
+++ b/dymos/examples/double_integrator/ex_double_integrator.py
@@ -34,7 +34,7 @@ def double_integrator_direct_collocation(transcription='gauss-lobatto', top_leve
     p.model.linear_solver = DirectSolver(assemble_jac=True)
     p.model.options['assembled_jac_type'] = top_level_jacobian.lower()
 
-    p.setup(mode='fwd', check=True)
+    p.setup(check=True)
 
     p['phase0.t_initial'] = 0.0
     p['phase0.t_duration'] = 1.0

--- a/dymos/examples/double_integrator/test/test_doc_double_integrator.py
+++ b/dymos/examples/double_integrator/test/test_doc_double_integrator.py
@@ -40,7 +40,7 @@ class TestDoubleIntegratorForDocs(unittest.TestCase):
 
         p.model.linear_solver = DirectSolver(assemble_jac=True)
 
-        p.setup(mode='fwd', check=True)
+        p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 1.0

--- a/dymos/examples/double_integrator/test/test_ex_double_integrator.py
+++ b/dymos/examples/double_integrator/test/test_ex_double_integrator.py
@@ -82,7 +82,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         p.model.linear_solver = DirectSolver(assemble_jac=True)
         p.model.options['assembled_jac_type'] = 'csc'
 
-        p.setup(mode='fwd', check=True)
+        p.setup(check=True)
 
         p['t0'] = 0.0
         p['tp'] = 1.0
@@ -145,7 +145,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         p.model.linear_solver = DirectSolver(assemble_jac=True)
         p.model.options['assembled_jac_type'] = 'csc'
 
-        p.setup(mode='fwd', check=True)
+        p.setup(check=True)
 
         p['t0'] = 0.0
         p['tp'] = 1.0
@@ -213,7 +213,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         p.model.linear_solver = DirectSolver(assemble_jac=True)
         p.model.options['assembled_jac_type'] = 'csc'
 
-        p.setup(mode='fwd', check=True)
+        p.setup(check=True)
 
         p['t0'] = 0.0
         p['tp'] = 1.0
@@ -273,7 +273,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         p.model.linear_solver = DirectSolver(assemble_jac=True)
         p.model.options['assembled_jac_type'] = 'csc'
 
-        p.setup(mode='fwd', check=True)
+        p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 1.0
@@ -348,7 +348,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         p.model.linear_solver = DirectSolver(assemble_jac=True)
         p.model.options['assembled_jac_type'] = 'csc'
 
-        p.setup(mode='fwd', check=True)
+        p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 1.0

--- a/dymos/examples/double_integrator/test/test_ex_double_integrator.py
+++ b/dymos/examples/double_integrator/test/test_ex_double_integrator.py
@@ -1,7 +1,9 @@
 from __future__ import print_function, absolute_import, division
 
 import itertools
+import sys
 import unittest
+
 from numpy.testing import assert_almost_equal
 
 from parameterized import parameterized
@@ -11,6 +13,9 @@ from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver, Inde
 from dymos import Phase
 from dymos.examples.double_integrator.double_integrator_ode import DoubleIntegratorODE
 import dymos.examples.double_integrator.ex_double_integrator as ex_double_integrator
+
+PY_MAJOR, PY_MINOR, _, _, _ = sys.version_info
+PY_VERSION = PY_MAJOR + 0.1 * PY_MINOR
 
 
 class TestDoubleIntegratorExample(unittest.TestCase):
@@ -93,6 +98,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
 
         p.run_driver()
 
+    @unittest.skipIf(PY_VERSION < 3.3, 'assertWarns not available in this version of Python')
     def test_ex_double_integrator_input_and_fixed_times_warns(self, transcription='radau-ps'):
         """
         Tests that time optimization options cause a ValueError to be raised when t_initial and
@@ -156,6 +162,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
 
         p.run_driver()
 
+    @unittest.skipIf(PY_VERSION < 3.3, 'assertWarns not available in this version of Python')
     def test_ex_double_integrator_input_times_warns(self, transcription='radau-ps'):
         """
         Tests that time optimization options cause a ValueError to be raised when t_initial and
@@ -224,6 +231,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
 
         p.run_driver()
 
+    @unittest.skipIf(PY_VERSION < 3.3, 'assertWarns not available in this version of Python')
     def test_ex_double_integrator_fixed_times_warns(self, transcription='radau-ps'):
         """
         Tests that time optimization options cause a ValueError to be raised when t_initial and
@@ -284,6 +292,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
 
         p.run_driver()
 
+    @unittest.skipIf(PY_VERSION < 3.3, 'assertWarns not available in this version of Python')
     def test_ex_double_integrator_deprecated_time_options(self, transcription='radau-ps'):
         """
         Tests that time optimization options cause a ValueError to be raised when t_initial and

--- a/dymos/examples/double_integrator/test/test_ex_double_integrator.py
+++ b/dymos/examples/double_integrator/test/test_ex_double_integrator.py
@@ -6,6 +6,10 @@ from numpy.testing import assert_almost_equal
 
 from parameterized import parameterized
 
+from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver, IndepVarComp
+
+from dymos import Phase
+from dymos.examples.double_integrator.double_integrator_ode import DoubleIntegratorODE
 import dymos.examples.double_integrator.ex_double_integrator as ex_double_integrator
 
 
@@ -37,3 +41,245 @@ class TestDoubleIntegratorExample(unittest.TestCase):
 
         assert_almost_equal(v0, 0.0)
         assert_almost_equal(vf, 0.0)
+
+    def test_ex_double_integrator_input_times(self, transcription='radau-ps',
+                                              compressed=True):
+        """
+        Tests that externally connected t_initial and t_duration function as expected.
+        """
+
+        p = Problem(model=Group())
+        p.driver = ScipyOptimizeDriver()
+        p.driver.options['dynamic_simul_derivs'] = True
+
+        times_ivc = p.model.add_subsystem('times_ivc', IndepVarComp(),
+                                          promotes_outputs=['t0', 'tp'])
+        times_ivc.add_output(name='t0', val=0.0, units='s')
+        times_ivc.add_output(name='tp', val=1.0, units='s')
+
+        phase = Phase(transcription,
+                      ode_class=DoubleIntegratorODE,
+                      num_segments=20,
+                      transcription_order=3,
+                      compressed=compressed)
+
+        p.model.add_subsystem('phase0', phase)
+
+        p.model.connect('t0', 'phase0.t_initial')
+        p.model.connect('tp', 'phase0.t_duration')
+
+        phase.set_time_options(input_initial=True, input_duration=True)
+
+        phase.set_state_options('x', fix_initial=True)
+        phase.set_state_options('v', fix_initial=True, fix_final=True)
+
+        phase.add_control('u', units='m/s**2', scaler=0.01, continuity=False, rate_continuity=False,
+                          rate2_continuity=False, lower=-1.0, upper=1.0)
+
+        # Maximize distance travelled in one second.
+        phase.add_objective('x', loc='final', scaler=-1)
+
+        p.model.linear_solver = DirectSolver(assemble_jac=True)
+        p.model.options['assembled_jac_type'] = 'csc'
+
+        p.setup(mode='fwd', check=True)
+
+        p['t0'] = 0.0
+        p['tp'] = 1.0
+
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 0.25], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 0], nodes='state_input')
+        p['phase0.controls:u'] = phase.interpolate(ys=[1, -1], nodes='control_input')
+
+        p.run_driver()
+
+    def test_ex_double_integrator_input_and_fixed_times_warns(self, transcription='radau-ps'):
+        """
+        Tests that time optimization options cause a ValueError to be raised when t_initial and
+        t_duration are connected to external sources.
+        """
+
+        p = Problem(model=Group())
+        p.driver = ScipyOptimizeDriver()
+        p.driver.options['dynamic_simul_derivs'] = True
+
+        times_ivc = p.model.add_subsystem('times_ivc', IndepVarComp(),
+                                          promotes_outputs=['t0', 'tp'])
+        times_ivc.add_output(name='t0', val=0.0, units='s')
+        times_ivc.add_output(name='tp', val=1.0, units='s')
+
+        phase = Phase(transcription,
+                      ode_class=DoubleIntegratorODE,
+                      num_segments=20,
+                      transcription_order=3,
+                      compressed=True)
+
+        p.model.add_subsystem('phase0', phase)
+
+        p.model.connect('t0', 'phase0.t_initial')
+        p.model.connect('tp', 'phase0.t_duration')
+
+        with self.assertWarns(RuntimeWarning) as w:
+            phase.set_time_options(input_initial=True, fix_initial=True, input_duration=True,
+                                   fix_duration=True)
+
+        self.assertTrue(len(w.warnings) == 2,
+                        'Expected 2 warnings, got {0}'.format(len(w.warnings)))
+
+        expected = 'Phase "phase0" initial time is an externally-connected input, therefore ' \
+                   'fix_initial has no effect.'
+        self.assertEqual(str(w.warnings[0].message), expected)
+        expected = 'Phase "phase0" time duration is an externally-connected input, ' \
+                   'therefore fix_duration has no effect.'
+        self.assertEqual(str(w.warnings[1].message), expected)
+
+        phase.set_state_options('x', fix_initial=True)
+        phase.set_state_options('v', fix_initial=True, fix_final=True)
+
+        phase.add_control('u', units='m/s**2', scaler=0.01, continuity=False, rate_continuity=False,
+                          rate2_continuity=False, lower=-1.0, upper=1.0)
+
+        # Maximize distance travelled in one second.
+        phase.add_objective('x', loc='final', scaler=-1)
+
+        p.model.linear_solver = DirectSolver(assemble_jac=True)
+        p.model.options['assembled_jac_type'] = 'csc'
+
+        p.setup(mode='fwd', check=True)
+
+        p['t0'] = 0.0
+        p['tp'] = 1.0
+
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 0.25], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 0], nodes='state_input')
+        p['phase0.controls:u'] = phase.interpolate(ys=[1, -1], nodes='control_input')
+
+        p.run_driver()
+
+    def test_ex_double_integrator_input_times_warns(self, transcription='radau-ps'):
+        """
+        Tests that time optimization options cause a ValueError to be raised when t_initial and
+        t_duration are connected to external sources.
+        """
+
+        p = Problem(model=Group())
+        p.driver = ScipyOptimizeDriver()
+        p.driver.options['dynamic_simul_derivs'] = True
+
+        times_ivc = p.model.add_subsystem('times_ivc', IndepVarComp(),
+                                          promotes_outputs=['t0', 'tp'])
+        times_ivc.add_output(name='t0', val=0.0, units='s')
+        times_ivc.add_output(name='tp', val=1.0, units='s')
+
+        phase = Phase(transcription,
+                      ode_class=DoubleIntegratorODE,
+                      num_segments=20,
+                      transcription_order=3,
+                      compressed=True)
+
+        p.model.add_subsystem('phase0', phase)
+
+        p.model.connect('t0', 'phase0.t_initial')
+        p.model.connect('tp', 'phase0.t_duration')
+
+        with self.assertWarns(RuntimeWarning) as cm:
+            phase.set_time_options(input_initial=True, initial_bounds=(-5, 5), initial_ref0=1,
+                                   initial_ref=10, initial_adder=0, initial_scaler=1,
+                                   input_duration=True, duration_bounds=(-5, 5), duration_ref0=1,
+                                   duration_ref=10, duration_adder=0, duration_scaler=1)
+
+        self.assertTrue(len(cm.warnings) == 2,
+                        msg='Expected 2 warnings, got {0}'.format(len(cm.warnings)))
+
+        self.assertEqual(str(cm.warnings[0].message),
+                         'Phase time options have no effect because input_initial=True for phase '
+                         '"phase0": initial_bounds, initial_scaler, initial_adder, initial_ref, '
+                         'initial_ref0')
+
+        self.assertEqual(str(cm.warnings[1].message),
+                         'Phase time options have no effect because input_duration=True for phase '
+                         '"phase0": duration_bounds, duration_scaler, duration_adder, duration_ref,'
+                         ' duration_ref0')
+
+        phase.set_state_options('x', fix_initial=True)
+        phase.set_state_options('v', fix_initial=True, fix_final=True)
+
+        phase.add_control('u', units='m/s**2', scaler=0.01, continuity=False, rate_continuity=False,
+                          rate2_continuity=False, lower=-1.0, upper=1.0)
+
+        # Maximize distance travelled in one second.
+        phase.add_objective('x', loc='final', scaler=-1)
+
+        p.model.linear_solver = DirectSolver(assemble_jac=True)
+        p.model.options['assembled_jac_type'] = 'csc'
+
+        p.setup(mode='fwd', check=True)
+
+        p['t0'] = 0.0
+        p['tp'] = 1.0
+
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 0.25], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 0], nodes='state_input')
+        p['phase0.controls:u'] = phase.interpolate(ys=[1, -1], nodes='control_input')
+
+        p.run_driver()
+
+    def test_ex_double_integrator_fixed_times_warns(self, transcription='radau-ps'):
+        """
+        Tests that time optimization options cause a ValueError to be raised when t_initial and
+        t_duration are connected to external sources.
+        """
+
+        p = Problem(model=Group())
+        p.driver = ScipyOptimizeDriver()
+        p.driver.options['dynamic_simul_derivs'] = True
+
+        phase = Phase(transcription,
+                      ode_class=DoubleIntegratorODE,
+                      num_segments=20,
+                      transcription_order=3,
+                      compressed=True)
+
+        p.model.add_subsystem('phase0', phase)
+
+        with self.assertWarns(RuntimeWarning) as cm:
+            phase.set_time_options(fix_initial=True, initial_bounds=(-5, 5), initial_ref0=1,
+                                   initial_ref=10, initial_adder=0, initial_scaler=1,
+                                   fix_duration=True, duration_bounds=(-5, 5), duration_ref0=1,
+                                   duration_ref=10, duration_adder=0, duration_scaler=1)
+
+        self.assertTrue(len(cm.warnings) == 2,
+                        msg='Expected 2 warnings, got {0}'.format(len(cm.warnings)))
+
+        self.assertEqual(str(cm.warnings[0].message),
+                         'Phase time options have no effect because fix_initial=True for phase '
+                         '"phase0": initial_bounds, initial_scaler, initial_adder, initial_ref, '
+                         'initial_ref0')
+
+        self.assertEqual(str(cm.warnings[1].message),
+                         'Phase time options have no effect because fix_duration=True for phase '
+                         '"phase0": duration_bounds, duration_scaler, duration_adder, duration_ref,'
+                         ' duration_ref0')
+
+        phase.set_state_options('x', fix_initial=True)
+        phase.set_state_options('v', fix_initial=True, fix_final=True)
+
+        phase.add_control('u', units='m/s**2', scaler=0.01, continuity=False, rate_continuity=False,
+                          rate2_continuity=False, lower=-1.0, upper=1.0)
+
+        # Maximize distance travelled in one second.
+        phase.add_objective('x', loc='final', scaler=-1)
+
+        p.model.linear_solver = DirectSolver(assemble_jac=True)
+        p.model.options['assembled_jac_type'] = 'csc'
+
+        p.setup(mode='fwd', check=True)
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 1.0
+
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 0.25], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 0], nodes='state_input')
+        p['phase0.controls:u'] = phase.interpolate(ys=[1, -1], nodes='control_input')
+
+        p.run_driver()

--- a/dymos/examples/double_integrator/test/test_ex_double_integrator.py
+++ b/dymos/examples/double_integrator/test/test_ex_double_integrator.py
@@ -283,3 +283,78 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         p['phase0.controls:u'] = phase.interpolate(ys=[1, -1], nodes='control_input')
 
         p.run_driver()
+
+    def test_ex_double_integrator_deprecated_time_options(self, transcription='radau-ps'):
+        """
+        Tests that time optimization options cause a ValueError to be raised when t_initial and
+        t_duration are connected to external sources.
+        """
+
+        p = Problem(model=Group())
+        p.driver = ScipyOptimizeDriver()
+        p.driver.options['dynamic_simul_derivs'] = True
+
+        phase = Phase(transcription,
+                      ode_class=DoubleIntegratorODE,
+                      num_segments=20,
+                      transcription_order=3,
+                      compressed=True)
+
+        p.model.add_subsystem('phase0', phase)
+
+        with self.assertWarns(RuntimeWarning) as cm:
+            phase.set_time_options(opt_initial=False, initial_bounds=(-5, 5), initial_ref0=1,
+                                   initial_ref=10, initial_adder=0, initial_scaler=1,
+                                   opt_duration=False, duration_bounds=(-5, 5), duration_ref0=1,
+                                   duration_ref=10, duration_adder=0, duration_scaler=1)
+
+        for w in cm.warnings:
+            print(w.message)
+
+        self.assertTrue(len(cm.warnings) == 4,
+                        msg='Expected 4 warnings, got {0}'.format(len(cm.warnings)))
+
+        self.assertEqual(str(cm.warnings[0].message), 'opt_initial has been deprecated in favor of '
+                                                      'fix_initial, which has the opposite meaning.'
+                                                      ' If the user desires to input the initial '
+                                                      'phase time from an exterior source, set '
+                                                      'input_initial=True.')
+
+        self.assertEqual(str(cm.warnings[1].message), 'opt_duration has been deprecated in favor '
+                                                      'of fix_duration, which has the opposite '
+                                                      'meaning. If the user desires to input the '
+                                                      'phase duration from an exterior source, '
+                                                      'set input_duration=True.')
+
+        self.assertEqual(str(cm.warnings[2].message),
+                         'Phase time options have no effect because fix_initial=True for phase '
+                         '"phase0": initial_bounds, initial_scaler, initial_adder, initial_ref, '
+                         'initial_ref0')
+
+        self.assertEqual(str(cm.warnings[3].message),
+                         'Phase time options have no effect because fix_duration=True for phase '
+                         '"phase0": duration_bounds, duration_scaler, duration_adder, duration_ref,'
+                         ' duration_ref0')
+
+        phase.set_state_options('x', fix_initial=True)
+        phase.set_state_options('v', fix_initial=True, fix_final=True)
+
+        phase.add_control('u', units='m/s**2', scaler=0.01, continuity=False, rate_continuity=False,
+                          rate2_continuity=False, lower=-1.0, upper=1.0)
+
+        # Maximize distance travelled in one second.
+        phase.add_objective('x', loc='final', scaler=-1)
+
+        p.model.linear_solver = DirectSolver(assemble_jac=True)
+        p.model.options['assembled_jac_type'] = 'csc'
+
+        p.setup(mode='fwd', check=True)
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 1.0
+
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 0.25], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 0], nodes='state_input')
+        p['phase0.controls:u'] = phase.interpolate(ys=[1, -1], nodes='control_input')
+
+        p.run_driver()

--- a/dymos/examples/min_time_climb/ex_min_time_climb.py
+++ b/dymos/examples/min_time_climb/ex_min_time_climb.py
@@ -41,7 +41,7 @@ def min_time_climb(optimizer='SLSQP', num_seg=3, transcription='gauss-lobatto',
 
     p.model.add_subsystem('phase0', phase)
 
-    phase.set_time_options(opt_initial=False, duration_bounds=(50, 400),
+    phase.set_time_options(fix_initial=True, duration_bounds=(50, 400),
                            duration_ref=100.0)
 
     phase.set_state_options('r', fix_initial=True, lower=0, upper=1.0E6,

--- a/dymos/examples/min_time_climb/ex_min_time_climb.py
+++ b/dymos/examples/min_time_climb/ex_min_time_climb.py
@@ -81,7 +81,7 @@ def min_time_climb(optimizer='SLSQP', num_seg=3, transcription='gauss-lobatto',
     p.model.options['assembled_jac_type'] = top_level_jacobian.lower()
     p.model.linear_solver = DirectSolver(assemble_jac=True)
 
-    p.setup(mode='fwd', check=True, force_alloc_complex=force_alloc_complex)
+    p.setup(check=True, force_alloc_complex=force_alloc_complex)
 
     p['phase0.t_initial'] = 0.0
     p['phase0.t_duration'] = 298.46902

--- a/dymos/examples/min_time_climb/test/test_doc_min_time_climb.py
+++ b/dymos/examples/min_time_climb/test/test_doc_min_time_climb.py
@@ -34,7 +34,7 @@ class TestMinTimeClimbForDocs(unittest.TestCase):
 
         p.model.add_subsystem('phase0', phase)
 
-        phase.set_time_options(opt_initial=False, duration_bounds=(50, 400),
+        phase.set_time_options(fix_initial=True, duration_bounds=(50, 400),
                                duration_ref=100.0)
 
         phase.set_state_options('r', fix_initial=True, lower=0, upper=1.0E6,

--- a/dymos/examples/min_time_climb/test/test_doc_min_time_climb.py
+++ b/dymos/examples/min_time_climb/test/test_doc_min_time_climb.py
@@ -77,7 +77,7 @@ class TestMinTimeClimbForDocs(unittest.TestCase):
         p.model.options['assembled_jac_type'] = 'csc'
         p.model.linear_solver = DirectSolver(assemble_jac=True)
 
-        p.setup(mode='fwd', check=True)
+        p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 500

--- a/dymos/examples/ssto/ex_ssto_moon_linear_tangent.py
+++ b/dymos/examples/ssto/ex_ssto_moon_linear_tangent.py
@@ -76,7 +76,7 @@ def ssto_moon_linear_tangent(transcription='gauss-lobatto', num_seg=10, transcri
     p.model.options['assembled_jac_type'] = 'csc'
     p.model.linear_solver = DirectSolver(assemble_jac=True)
 
-    p.setup(mode='fwd', force_alloc_complex=True)
+    p.setup(force_alloc_complex=True)
 
     p['phase0.t_initial'] = 0.0
     p['phase0.t_duration'] = 500.0

--- a/dymos/examples/ssto/test/test_ex_ssto_earth.py
+++ b/dymos/examples/ssto/test/test_ex_ssto_earth.py
@@ -25,19 +25,16 @@ class TestExampleSSTOEarth(unittest.TestCase):
     @parameterized.expand(
         itertools.product(['gauss-lobatto', 'radau-ps'],  # transcription
                           ['csc'],  # jacobian
-                          ['fwd'],  # derivative_mode
                           ), testcase_func_name=lambda f, n, p: '_'.join(['test_results',
                                                                           p.args[0],
-                                                                          p.args[1],
-                                                                          p.args[2]])
+                                                                          p.args[1]])
     )
-    def test_results(self, transcription='gauss-lobatto', jacobian='csc', derivative_mode='fwd',
-                     compressed=True):
+    def test_results(self, transcription='gauss-lobatto', jacobian='csc', compressed=True):
 
         p = ex_ssto_earth.ssto_earth(transcription, num_seg=10, transcription_order=5,
                                      top_level_jacobian=jacobian, compressed=compressed)
 
-        p.setup(mode=derivative_mode, check=True)
+        p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0
         p['phase0.t_duration'] = 150.0
@@ -77,7 +74,7 @@ class TestExampleSSTOEarth(unittest.TestCase):
         p = ex_ssto_earth.ssto_earth('gauss-lobatto', num_seg=20, transcription_order=5,
                                      top_level_jacobian='csc')
 
-        p.setup(mode='fwd')
+        p.setup()
 
         phase = p.model.phase0
         p['phase0.t_initial'] = 0.0

--- a/dymos/phases/components/tests/test_continuity_comp.py
+++ b/dymos/phases/components/tests/test_continuity_comp.py
@@ -114,7 +114,7 @@ class TestContinuityComp(unittest.TestCase):
         self.p.model.connect('v_rate2', 'cnty_comp.control_rates:v_rate2', src_indices=src_idxs_v,
                              flat_src_indices=True)
 
-        self.p.setup(mode='fwd', check=True, force_alloc_complex=True)
+        self.p.setup(check=True, force_alloc_complex=True)
 
         self.p['x'] = np.random.rand(*self.p['x'].shape)
         self.p['y'] = np.random.rand(*self.p['y'].shape)

--- a/dymos/phases/components/tests/test_endpoint_conditions_comp.py
+++ b/dymos/phases/components/tests/test_endpoint_conditions_comp.py
@@ -89,7 +89,7 @@ class TestEndpointConditionComp(unittest.TestCase):
         p.model.linear_solver = DirectSolver(assemble_jac=True)
         p.model.options['assembled_jac_type'] = 'dense'
 
-        p.setup(mode='fwd', force_alloc_complex=True)
+        p.setup(force_alloc_complex=True)
 
         p['phase:time'] = np.linspace(0, 500, n)
         p['phase:time'] = np.linspace(0, 500, n)
@@ -203,7 +203,7 @@ class TestEndpointConditionComp(unittest.TestCase):
         p.model.linear_solver = DirectSolver(assemble_jac=True)
         p.model.options['assembled_jac_type'] = 'csc'
 
-        p.setup(mode='fwd', force_alloc_complex=True)
+        p.setup(force_alloc_complex=True)
 
         p['phase:time'] = np.linspace(0, 500, n)
         p['phase:pos'][:, 0] = np.linspace(0, 10, n)

--- a/dymos/phases/components/tests/test_path_constraint_comp.py
+++ b/dymos/phases/components/tests/test_path_constraint_comp.py
@@ -82,7 +82,7 @@ class TestPathConstraintCompGL(unittest.TestCase):
         self.p.model.connect('b_ctrl', 'path_constraints.all_values:b_ctrl')
         self.p.model.connect('c_ctrl', 'path_constraints.all_values:c_ctrl')
 
-        self.p.setup(mode='fwd')
+        self.p.setup()
 
         self.p['a_disc'] = np.random.rand(*self.p['a_disc'].shape)
         self.p['a_col'] = np.random.rand(*self.p['a_col'].shape)
@@ -181,7 +181,7 @@ class TestPathConstraintCompRadau(unittest.TestCase):
         self.p.model.connect('b_disc', 'path_constraints.all_values:b')
         self.p.model.connect('c_disc', 'path_constraints.all_values:c')
 
-        self.p.setup(mode='fwd')
+        self.p.setup()
 
         self.p.run_model()
 

--- a/dymos/phases/components/tests/test_phase_linkage_comp.py
+++ b/dymos/phases/components/tests/test_phase_linkage_comp.py
@@ -63,7 +63,7 @@ class TestPhaseLinkageComp(unittest.TestCase):
                              src_indices=np.arange(0, 9, dtype=int).reshape((3, 3)),
                              flat_src_indices=True)
 
-        self.p.setup(mode='fwd')
+        self.p.setup()
 
         self.p['phase0:x'] = np.random.rand(*self.p['phase0:x'].shape)
         self.p['phase0:u'] = np.random.rand(*self.p['phase0:u'].shape)

--- a/dymos/phases/optimizer_based/gauss_lobatto_phase.py
+++ b/dymos/phases/optimizer_based/gauss_lobatto_phase.py
@@ -263,7 +263,8 @@ class GaussLobattoPhase(OptimizerBasedPhaseBase):
                                GaussLobattoContinuityComp(grid_data=grid_data,
                                                           state_options=self.state_options,
                                                           control_options=self.control_options,
-                                                          time_units=self.time_options['units']))
+                                                          time_units=self.time_options['units']),
+                               promotes_inputs=['t_duration'])
 
     def add_objective(self, name, loc='final', index=None, shape=(1,), ref=None, ref0=None,
                       adder=None, scaler=None, parallel_deriv_color=None,

--- a/dymos/phases/optimizer_based/optimizer_based_phase_base.py
+++ b/dymos/phases/optimizer_based/optimizer_based_phase_base.py
@@ -353,7 +353,6 @@ class OptimizerBasedPhaseBase(PhaseBase):
 
         # Add the continuity constraint component if necessary
         if num_seg > 1:
-            self.connect('t_duration', 'continuity_comp.t_duration')
 
             for name, options in iteritems(self.state_options):
                 # The sub-indices of state_disc indices that are segment ends

--- a/dymos/phases/optimizer_based/radau_pseudospectral_phase.py
+++ b/dymos/phases/optimizer_based/radau_pseudospectral_phase.py
@@ -235,7 +235,8 @@ class RadauPseudospectralPhase(OptimizerBasedPhaseBase):
                                RadauPSContinuityComp(grid_data=grid_data,
                                                      state_options=self.state_options,
                                                      control_options=self.control_options,
-                                                     time_units=self.time_options['units']))
+                                                     time_units=self.time_options['units']),
+                               promotes_inputs=['t_duration'])
 
     def add_objective(self, name, loc='final', index=None, shape=(1,), ref=None, ref0=None,
                       adder=None, scaler=None, parallel_deriv_color=None,

--- a/dymos/phases/optimizer_based/tests/test_simulate.py
+++ b/dymos/phases/optimizer_based/tests/test_simulate.py
@@ -62,7 +62,7 @@ class TestSimulateRecording(unittest.TestCase):
 
         p.model.linear_solver = DirectSolver()
 
-        p.setup(mode='fwd')
+        p.setup()
 
         p.setup()
 
@@ -130,7 +130,7 @@ class TestSimulateRecording(unittest.TestCase):
         p.model.options['assembled_jac_type'] = top_level_jacobian.lower()
         p.model.linear_solver = DirectSolver(assemble_jac=True)
 
-        p.setup(mode='fwd')
+        p.setup()
 
         p.setup()
 

--- a/dymos/phases/options.py
+++ b/dymos/phases/options.py
@@ -285,14 +285,6 @@ class TimeOptionsDictionary(OptionsDictionary):
         self.declare('units', types=string_types, allow_none=True,
                      default='s', desc='Units for the integration variable')
 
-        self.declare(name='opt_initial', types=bool, default=None, allow_none=True,
-                     desc='If False, the initial value of time is not a design variable. This'
-                          'option is deprecated in favor of fix_initial')
-
-        self.declare(name='opt_duration', types=bool, default=None, allow_none=True,
-                     desc='If False, the phase duration is not a design variable. This option'
-                          'is deprecated in favor of fix_duration')
-
         self.declare(name='fix_initial', types=bool, default=False,
                      desc='If True, the initial value of time is not a design variable.')
 

--- a/dymos/phases/options.py
+++ b/dymos/phases/options.py
@@ -23,11 +23,6 @@ class ControlOptionsDictionary(OptionsDictionary):
 
         self.declare(name='desc', types=string_types, default='',
                      desc='The description of the control variable.')
-        #
-        # self.declare(name='dynamic', types=bool, default=True,
-        #              desc='If True, the control is vectorized, providing a value at '
-        #                   'each node in the phase.  If False, the control is static, '
-        #                   'providing a single value to be broadcast to all nodes in the phase.')
 
         self.declare(name='opt', default=True, types=bool,
                      desc='If True, the control value will be a design variable '
@@ -290,13 +285,27 @@ class TimeOptionsDictionary(OptionsDictionary):
         self.declare('units', types=string_types, allow_none=True,
                      default='s', desc='Units for the integration variable')
 
-        self.declare(name='opt_initial', types=bool, default=True,
-                     desc='If False, the initial value of time is not a design variable'
-                          'of the phase and may be connected externally.')
+        self.declare(name='opt_initial', types=bool, default=None, allow_none=True,
+                     desc='If False, the initial value of time is not a design variable. This'
+                          'option is deprecated in favor of fix_initial')
 
-        self.declare(name='opt_duration', types=bool, default=True,
-                     desc='If False, the  phase duration is not a design variable'
-                          'of the phase and may be connected externally.')
+        self.declare(name='opt_duration', types=bool, default=None, allow_none=True,
+                     desc='If False, the phase duration is not a design variable. This option'
+                          'is deprecated in favor of fix_duration')
+
+        self.declare(name='fix_initial', types=bool, default=False,
+                     desc='If True, the initial value of time is not a design variable.')
+
+        self.declare(name='fix_duration', types=bool, default=False,
+                     desc='If True, the  phase duration is not a design variable.')
+
+        self.declare(name='input_initial', types=bool, default=False,
+                     desc='If True, the initial value of time (t_initial) is expected to be '
+                          'connected to an external output source.')
+
+        self.declare(name='input_duration', types=bool, default=False,
+                     desc='If True, the phase duration (t_duration) is expected to be '
+                          'connected to an external output source.')
 
         self.declare('initial', types=Number,
                      desc='Value of the integration variable at the start of the phase.')

--- a/dymos/phases/phase_base.py
+++ b/dymos/phases/phase_base.py
@@ -655,10 +655,10 @@ class PhaseBase(Group):
             self.time_options['fix_duration'] = fix_duration
 
         # Don't allow the user to provide desvar options if the time is not a desvar or is input.
-        if input_initial and fix_initial:
+        if input_initial and self.time_options['fix_initial']:
             warnings.warn('Phase "{0}" initial time is an externally-connected input, '
                           'therefore fix_initial has no effect.'.format(self.name), RuntimeWarning)
-        elif input_initial or fix_initial:
+        elif input_initial or self.time_options['fix_initial']:
             illegal_options = []
             if initial_bounds != (None, None):
                 illegal_options.append('initial_bounds')
@@ -676,11 +676,11 @@ class PhaseBase(Group):
                       '"{0}": {1}'.format(self.name, ', '.join(illegal_options), reason)
                 warnings.warn(msg, RuntimeWarning)
 
-        if input_duration and fix_duration:
+        if input_duration and self.time_options['fix_duration']:
             warnings.warn('Phase "{0}" time duration is an externally-connected input, '
                           'therefore fix_duration has no effect.'.format(self.name),
                           RuntimeWarning)
-        elif input_duration or fix_duration:
+        elif input_duration or self.time_options['fix_duration']:
             illegal_options = []
             if duration_bounds != (None, None):
                 illegal_options.append('duration_bounds')

--- a/dymos/utils/misc.py
+++ b/dymos/utils/misc.py
@@ -41,7 +41,7 @@ def get_rate_units(units, time_units, deriv=1):
 class CoerceDesvar(object):
     """
     Check the desvar options for the appropriate shape and resize
-    accordingly with opt_initial and opt_final options.
+    accordingly with options.
     """
     def __init__(self, num_input_nodes, desvar_indices, options):
         self.num_input_nodes = num_input_nodes

--- a/dymos/utils/simulation/scipy_ode_integrator.py
+++ b/dymos/utils/simulation/scipy_ode_integrator.py
@@ -106,7 +106,7 @@ class ScipyODEIntegrator(object):
         # Flag that is set to true if has_controls is called
         self._has_dynamic_controls = False
 
-    def setup(self, check=False, mode='fwd'):
+    def setup(self, check=False):
         """
         Call setup on the ScipyODEIntegrator's problem instance.
 
@@ -159,7 +159,7 @@ class ScipyODEIntegrator(object):
         order += ['ode', 'state_rate_collector']
         model.set_order(order)
 
-        self.prob.setup(check=check, mode=mode)
+        self.prob.setup(check=check)
 
     def set_interpolant(self, name, interpolant):
         """

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 
 setup(name='dymos',
-    version='0.9.0',
+    version='0.9.1',
     description='Open-Source Optimization of Dynamic Multidiscplinary Systems',
     url='https://github.com/OpenMDAO/dymos',
     classifiers=[


### PR DESCRIPTION
Fixes the opt_duration=False errors.

Specifying an externally-sourced initial time or duration of a phase is now done with the `input_initial` or `input_duration` arguments to `set_time_options`.

Because those variables are now "owned" by the phase unless `input_initial`/`input_duration` are True, we can also go back to the nomenclature of `fix_initial`/`fix_duration`, which was an inconsistency in the API.  In the meantime, `opt_initial`/`opt_duration` will still work but raise deprecation warnings.

Fixes #61 