### PR TITLE
Input design parameters

### DIFF
--- a/dymos/docs/examples/commercial_aircraft.rst
+++ b/dymos/docs/examples/commercial_aircraft.rst
@@ -376,7 +376,9 @@ parameters.  More details on the various models involved can be found in the exa
 2. Building and running the problem
 -----------------------------------
 
-In the following code we define and solve the optimal control problem:
+In the following code we define and solve the optimal control problem.  Note that we demonstrate
+the use of externally-connected design parameters in this case.  The four design parameters have
+`input_value = True`, and are connected to a source provided by the `assumptions` IndepVarComp.
 
 .. embed-code::
     dymos.examples.aircraft_steady_flight.test.test_doc_aircraft_steady_flight.TestSteadyAircraftFlightForDocs.test_steady_aircraft_for_docs

--- a/dymos/docs/user_guide/phases/variables.rst
+++ b/dymos/docs/user_guide/phases/variables.rst
@@ -84,26 +84,16 @@ a phase is `add_control`. Valid options for controls and design parameters are a
     _ForDocs
     design_parameter_options
 
-Like states, *dynamic* controls are modeled as polynomials.  When
+Like states, *dynamic* controls are modeled as polynomials within each segment.  When
 transcribed to a nonlinear programming problem, a dynamic control is given a unique value at each
 node within the phase.  Design parameters are modeled as a singular value that is broadcast to all
 nodes in the phase before the ODE function is evaluated.  If you can parameterize your problem in
 such a way that static controls can be used, performance may be significantly better due to the
-size of the NLP problem being much smaller.
+size of the NLP problem being much smaller, despite the fact that they reduce the *sparsity* of
+the jacobian matrix of the resulting optimal control problem.
 
 .. note::
     The order of a dynamic control polynomial in a segment is one less than the state
     transcription order (i.e. a dynamic control in a phase with `transcription_order=3` will
     be represented by a second-order polynomial.
-
-Example: Solving the Linear Tangent Launch Vehicle Problem
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The following problem demonstrates the use of |project| to solve for the minimum time for a single
-stage launch vehicle to reach lunar orbit from the surface of the moon.  Optimal control theory
-dictates that the tangent of the pitch angle of the thrust vector varies linearly with time.
-Therefore, rather than using a dynamic control to specify the thrust angle at each instance in
-time, we can instead specify two paramters (`a` and `b`) as design parameters.  These parameters
-dictate the slope and intercept of the tangent of the thrust angle w.r.t. time.
-
 

--- a/dymos/examples/aircraft_steady_flight/ex_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/ex_aircraft_steady_flight.py
@@ -4,10 +4,10 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
+
 import numpy as np
 
-from openmdao.api import Problem, Group, ScipyOptimizeDriver, pyOptSparseDriver, DirectSolver, \
-    IndepVarComp, SqliteRecorder
+from openmdao.api import Problem, Group, pyOptSparseDriver, DirectSolver, IndepVarComp
 
 from dymos import Phase
 
@@ -67,9 +67,9 @@ def ex_aircraft_steady_flight(optimizer='SLSQP', transcription='gauss-lobatto'):
 
     phase.add_control('mach', units=None, opt=False, lower=0.8, upper=0.8, ref=1.0)
 
-    phase.add_design_parameter('S', units='m**2', opt=False)
-    phase.add_design_parameter('mass_empty', units='kg', opt=False)
-    phase.add_design_parameter('mass_payload', units='kg', opt=False)
+    phase.add_design_parameter('S', units='m**2', opt=False, input_value=True)
+    phase.add_design_parameter('mass_empty', units='kg', opt=False, input_value=True)
+    phase.add_design_parameter('mass_payload', units='kg', opt=False, input_value=True)
 
     phase.add_path_constraint('propulsion.tau', lower=0.01, upper=1.0)
     phase.add_path_constraint('alt_rate', units='ft/min', lower=-3000, upper=3000, ref=3000)

--- a/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
@@ -2,8 +2,6 @@ from __future__ import print_function, division, absolute_import
 
 import unittest
 
-import numpy as np
-
 from openmdao.api import Problem, Group, IndepVarComp, DirectSolver, \
     pyOptSparseDriver, ScipyOptimizeDriver
 from openmdao.utils.assert_utils import assert_rel_error
@@ -64,9 +62,9 @@ class TestAircraftCruise(unittest.TestCase):
 
         phase.add_control('mach', units=None, opt=False)
 
-        phase.add_design_parameter('S', units='m**2', opt=False)
-        phase.add_design_parameter('mass_empty', units='kg', opt=False)
-        phase.add_design_parameter('mass_payload', units='kg', opt=False)
+        phase.add_design_parameter('S', units='m**2', input_value=True)
+        phase.add_design_parameter('mass_empty', units='kg', input_value=True)
+        phase.add_design_parameter('mass_payload', units='kg', input_value=True)
 
         phase.add_path_constraint('propulsion.tau', lower=0.01, upper=1.0)
 

--- a/dymos/examples/aircraft_steady_flight/test/test_doc_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_doc_aircraft_steady_flight.py
@@ -44,6 +44,7 @@ class TestSteadyAircraftFlightForDocs(unittest.TestCase):
 
         # Pass design parameters in externally from an external source
         assumptions = p.model.add_subsystem('assumptions', IndepVarComp())
+        assumptions.add_output('mach', val=0.8, units=None)
         assumptions.add_output('S', val=427.8, units='m**2')
         assumptions.add_output('mass_empty', val=1.0, units='kg')
         assumptions.add_output('mass_payload', val=1.0, units='kg')
@@ -67,15 +68,15 @@ class TestSteadyAircraftFlightForDocs(unittest.TestCase):
                           rate2_continuity=True, rate2_continuity_scaler=1.0, ref=1.0,
                           fix_initial=True, fix_final=True)
 
-        phase.add_control('mach', units=None, opt=False)
-
-        phase.add_design_parameter('S', units='m**2', opt=False)
-        phase.add_design_parameter('mass_empty', units='kg', opt=False)
-        phase.add_design_parameter('mass_payload', units='kg', opt=False)
+        phase.add_design_parameter('mach', units=None, input_value=True)
+        phase.add_design_parameter('S', units='m**2', input_value=True)
+        phase.add_design_parameter('mass_empty', units='kg', input_value=True)
+        phase.add_design_parameter('mass_payload', units='kg', input_value=True)
 
         phase.add_path_constraint('propulsion.tau', lower=0.01, upper=1.0)
         phase.add_path_constraint('alt_rate', units='ft/min', lower=-3000, upper=3000, ref=3000)
 
+        p.model.connect('assumptions.mach', 'phase0.design_parameters:mach')
         p.model.connect('assumptions.S', 'phase0.design_parameters:S')
         p.model.connect('assumptions.mass_empty', 'phase0.design_parameters:mass_empty')
         p.model.connect('assumptions.mass_payload', 'phase0.design_parameters:mass_payload')
@@ -91,9 +92,9 @@ class TestSteadyAircraftFlightForDocs(unittest.TestCase):
         p['phase0.states:range'] = phase.interpolate(ys=(0, 1000.0), nodes='state_input')
         p['phase0.states:mass_fuel'] = phase.interpolate(ys=(30000, 0), nodes='state_input')
 
-        p['phase0.controls:mach'][:] = 0.8
         p['phase0.controls:alt'][:] = 10.0
 
+        p['assumptions.mach'][:] = 0.8
         p['assumptions.S'] = 427.8
         p['assumptions.mass_empty'] = 0.15E6
         p['assumptions.mass_payload'] = 84.02869 * 400

--- a/dymos/phases/components/design_parameter_input_comp.py
+++ b/dymos/phases/components/design_parameter_input_comp.py
@@ -28,7 +28,7 @@ class DesignParameterInputComp(ExplicitComponent):
 
     def setup(self):
         for param_name, options in iteritems(self.options['design_parameter_options']):
-            if options['opt']:
+            if not options['input_value']:
                 # Ignore this control if it is an optimal control
                 continue
             self._input_design_parameters.append(param_name)

--- a/dymos/phases/optimizer_based/gauss_lobatto_phase.py
+++ b/dymos/phases/optimizer_based/gauss_lobatto_phase.py
@@ -104,7 +104,7 @@ class GaussLobattoPhase(OptimizerBasedPhaseBase):
             map_indices_to_disc = np.zeros(self.grid_data.subset_num_nodes['state_disc'], dtype=int)
             map_indices_to_col = np.zeros(self.grid_data.subset_num_nodes['col'], dtype=int)
 
-            if options['opt']:
+            if not options['input_value']:
                 src_name = 'design_parameters:{0}'.format(name)
             else:
                 src_name = 'design_parameters:{0}_out'.format(name)

--- a/dymos/phases/optimizer_based/optimizer_based_phase_base.py
+++ b/dymos/phases/optimizer_based/optimizer_based_phase_base.py
@@ -115,19 +115,25 @@ class OptimizerBasedPhaseBase(PhaseBase):
         num_opt_controls = len([name for (name, options) in iteritems(self.control_options)
                                 if options['opt']])
 
+        num_design_params = len(self.design_parameter_options)
+
         num_opt_design_params = len([name for (name, options) in
                                      iteritems(self.design_parameter_options) if options['opt']])
 
         num_input_design_params = len([name for (name, options) in
                                        iteritems(self.design_parameter_options)
-                                       if not options['opt']])
+                                       if options['input_value']])
 
         num_controls = len(self.control_options)
 
-        indep_controls = ['indep_controls'] if num_opt_controls > 0 else []
-        indep_design_params = ['indep_design_params'] if num_opt_design_params > 0 else []
-        input_design_params = ['input_design_params'] if num_input_design_params > 0 else []
-        control_interp_comp = ['control_interp_comp'] if num_controls > 0 else []
+        indep_controls = ['indep_controls'] \
+            if num_opt_controls > 0 else []
+        indep_design_params = ['indep_design_params'] \
+            if num_input_design_params < num_design_params else []
+        input_design_params = ['input_design_params'] \
+            if num_input_design_params > 0 else []
+        control_interp_comp = ['control_interp_comp'] \
+            if num_controls > 0 else []
 
         order = self._time_extents + indep_controls + \
             indep_design_params + input_design_params + \

--- a/dymos/phases/optimizer_based/radau_pseudospectral_phase.py
+++ b/dymos/phases/optimizer_based/radau_pseudospectral_phase.py
@@ -80,7 +80,7 @@ class RadauPseudospectralPhase(OptimizerBasedPhaseBase):
 
             map_indices_to_all = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
 
-            if options['opt']:
+            if not options['input_value']:
                 src_name = 'design_parameters:{0}'.format(name)
             else:
                 src_name = 'design_parameters:{0}_out'.format(name)

--- a/dymos/phases/options.py
+++ b/dymos/phases/options.py
@@ -133,6 +133,10 @@ class DesignParameterOptionsDictionary(OptionsDictionary):
                           'for the optimization problem.  If False, allow the '
                           'control to be connected externally.')
 
+        self.declare(name='input_value', types=bool, default=False,
+                     desc='If True, the value of this design parameter is expected to be '
+                          'connected to an external output source.')
+
         self.declare(name='targets', types=Iterable, default=[],
                      desc='Used to store target information for ShootingPhase.  Should not be'
                           'set by the user in add_design_parameter.')

--- a/dymos/phases/phase_base.py
+++ b/dymos/phases/phase_base.py
@@ -296,7 +296,7 @@ class PhaseBase(Group):
         if units != 0:
             self.control_options[name]['units'] = units
 
-    def add_design_parameter(self, name, val=0.0, units=0, opt=True, input=False,
+    def add_design_parameter(self, name, val=0.0, units=0, opt=True, input_value=False,
                              lower=None, upper=None, scaler=None, adder=None, ref=None, ref0=None):
         """
         Declares that a parameter of the ODE is to potentially be used as an optimal control.
@@ -314,8 +314,12 @@ class PhaseBase(Group):
         opt : bool
             If True (default) the value(s) of this control will be design variables in
             the optimization problem, in the path 'phase_name.indep_controls.controls:control_name'.
-            If False, the this control will exist as a promoted input to control_interp_comp where
-            it may be connected to an external source, if desired.
+            If False, the this design parameter will still be owned by an IndepVarComp in the phase,
+            but it will not be a design parameter.
+        input_value : bool
+            If True, this design parameter will be connected to an external source outside of
+            the phase.  Providing input_value=True makes all optimization settings irrelevant and
+            overrides opt to False.
         lower : float or ndarray
             The lower bound of the control at the nodes of the phase.
         upper : float or ndarray
@@ -346,7 +350,7 @@ class PhaseBase(Group):
             raise ValueError(err_msg)
 
         # Don't allow the user to provide desvar options if the design parameter is not a desvar
-        if not opt:
+        if input_value or not opt:
             illegal_options = []
             if lower is not None:
                 illegal_options.append('lower')
@@ -361,11 +365,13 @@ class PhaseBase(Group):
             if ref0 is not None:
                 illegal_options.append('ref0')
             if illegal_options:
-                msg = 'Invalid options for non-optimal control:' + ', '.join(illegal_options)
+                msg = 'Invalid options for non-optimal/input design parameter "{0}":'.format(name) \
+                      + ', '.join(illegal_options)
                 warnings.warn(msg, RuntimeWarning)
 
         self.design_parameter_options[name]['val'] = val
-        self.design_parameter_options[name]['opt'] = opt
+        self.design_parameter_options[name]['opt'] = False if input_value else opt
+        self.design_parameter_options[name]['input_value'] = input_value
         self.design_parameter_options[name]['lower'] = lower
         self.design_parameter_options[name]['upper'] = upper
         self.design_parameter_options[name]['scaler'] = scaler
@@ -734,10 +740,10 @@ class PhaseBase(Group):
             else:
                 return 'input_control'
         elif var in self.design_parameter_options:
-            if self.design_parameter_options[var]['opt']:
-                return 'indep_design_parameter'
-            else:
+            if self.design_parameter_options[var]['input_value']:
                 return 'input_design_parameter'
+            else:
+                return 'indep_design_parameter'
         elif var.endswith('_rate'):
             if var[:-5] in self.control_options:
                 return 'control_rate'
@@ -911,16 +917,16 @@ class PhaseBase(Group):
         Adds an IndepVarComp if necessary and issues appropriate connections based
         on transcription.
         """
-        opt_design_params = [name for (name, opts) in iteritems(self.design_parameter_options)
-                             if opts['opt']]
+        input_design_params = [name for (name, opts) in iteritems(self.design_parameter_options)
+                               if opts['input_value']]
 
-        num_opt_design_params = len(opt_design_params)
+        num_design_params = len(self.design_parameter_options)
 
-        num_input_design_params = len(self.design_parameter_options) - num_opt_design_params
+        num_input_design_params = len(input_design_params)
 
         grid_data = self.grid_data
 
-        if num_opt_design_params > 0:
+        if num_input_design_params < num_design_params:
             indep = self.add_subsystem('indep_design_params', subsys=IndepVarComp(),
                                        promotes_outputs=['*'])
 
@@ -934,8 +940,6 @@ class PhaseBase(Group):
 
         for name, options in iteritems(self.design_parameter_options):
             if options['opt']:
-                num_input_nodes = 1
-
                 lb = -INF_BOUND if options['lower'] is None else options['lower']
                 ub = INF_BOUND if options['upper'] is None else options['upper']
 
@@ -947,9 +951,10 @@ class PhaseBase(Group):
                                     ref0=options['ref0'],
                                     ref=options['ref'])
 
+            if not options['input_value']:
                 indep.add_output(name='design_parameters:{0}'.format(name),
                                  val=options['val'],
-                                 shape=(num_input_nodes, np.prod(options['shape'])),
+                                 shape=(1, np.prod(options['shape'])),
                                  units=options['units'])
 
     def _setup_rhs(self):


### PR DESCRIPTION
`add_design_parameter` now supports the argument `input_value = bool`.  If True, the design parameter is expected to be connected to an external source.  This also overrides option `opt`, setting it to False.

If a design parameter is added to a phase with `opt=False` and `input_value=False`, the it is still provided by an IndepVarComp in the phase, but it is not added to the design variables for the problem.

Resolves #64 
