### PR TITLE
defect_ref option added to set_state_options

### DIFF
--- a/dymos/docs/user_guide/phases/variables.rst
+++ b/dymos/docs/user_guide/phases/variables.rst
@@ -52,6 +52,14 @@ phase method `set_state_options`.  The following options are valid:
     _ForDocs
     state_options
 
+The Radau Pseudospectral and Gauss Lobatto phases types in |project| use differential defects to
+approximate the evolution of the state variables with respect to time.  In addition to scaling
+the state values, scaling the defect constraints correctly is important to good performance of
+the collocation algorithms.  This is accomplished with the `defect_scaler` or `defect_ref` options.
+As the name implies, `defect_scaler` is multiplied by the defect value to provide the defect
+constraint value to the optimizer.  Alternatively, the user can specify `defect_ref`.  If provided,
+`defect_ref` overrides `defect_scaler` and is the value of the defect seen as `1` by the optimizer.
+
 
 Controls and Design Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/dymos/examples/min_time_climb/test/test_doc_min_time_climb.py
+++ b/dymos/examples/min_time_climb/test/test_doc_min_time_climb.py
@@ -28,7 +28,7 @@ class TestMinTimeClimbForDocs(unittest.TestCase):
 
         phase = Phase('gauss-lobatto',
                       ode_class=MinTimeClimbODE,
-                      num_segments=15,
+                      num_segments=12,
                       compressed=True,
                       transcription_order=3)
 
@@ -38,19 +38,19 @@ class TestMinTimeClimbForDocs(unittest.TestCase):
                                duration_ref=100.0)
 
         phase.set_state_options('r', fix_initial=True, lower=0, upper=1.0E6,
-                                scaler=1.0E-3, defect_scaler=1.0E-2, units='m')
+                                ref=1.0E3, defect_ref=1000.0, units='m')
 
         phase.set_state_options('h', fix_initial=True, lower=0, upper=20000.0,
-                                scaler=1.0E-3, defect_scaler=1.0E-3, units='m')
+                                ref=1.0E2, defect_ref=100.0, units='m')
 
         phase.set_state_options('v', fix_initial=True, lower=10.0,
-                                scaler=1.0E-2, defect_scaler=1.0E-2, units='m/s')
+                                ref=1.0E2, defect_ref=0.1, units='m/s')
 
         phase.set_state_options('gam', fix_initial=True, lower=-1.5, upper=1.5,
                                 ref=1.0, defect_scaler=1.0, units='rad')
 
         phase.set_state_options('m', fix_initial=True, lower=10.0, upper=1.0E5,
-                                scaler=1.0E-3, defect_scaler=1.0E-3)
+                                ref=1.0E3, defect_ref=0.1)
 
         rate_continuity = True
 
@@ -95,7 +95,7 @@ class TestMinTimeClimbForDocs(unittest.TestCase):
         # Test the results
         assert_rel_error(self, p.model.phase0.get_values('time')[-1], 321.0, tolerance=2)
 
-        exp_out = phase.simulate(times=np.linspace(0, p['phase0.t_duration'], 100))
+        exp_out = phase.simulate(times=50)
 
         fig, axes = plt.subplots(2, 1, sharex=True)
 

--- a/dymos/phases/optimizer_based/components/collocation_comp.py
+++ b/dymos/phases/optimizer_based/components/collocation_comp.py
@@ -71,7 +71,9 @@ class CollocationComp(ExplicitComponent):
                 desc='Interior defects of state {0}'.format(state_name),
                 units=units)
 
-            if 'defect_scaler' in options:
+            if 'defect_ref' in options and options['defect_ref'] is not None:
+                def_scl = 1.0 / options['defect_ref']
+            elif 'defect_scaler' in options:
                 def_scl = options['defect_scaler']
             else:
                 def_scl = 1.0

--- a/dymos/phases/optimizer_based/optimizer_based_phase_base.py
+++ b/dymos/phases/optimizer_based/optimizer_based_phase_base.py
@@ -256,7 +256,6 @@ class OptimizerBasedPhaseBase(PhaseBase):
         Setup the Collocation and Continuity components as necessary.
         """
         grid_data = self.grid_data
-        compressed = self.options['compressed']
         num_seg = grid_data.num_segments
 
         time_units = self.time_options['units']

--- a/dymos/phases/options.py
+++ b/dymos/phases/options.py
@@ -270,8 +270,15 @@ class StateOptionsDictionary(OptionsDictionary):
         self.declare(name='defect_scaler',
                      types=(Iterable, Number), default=1.0,
                      allow_none=True,
-                     desc='Scaler of the state variable defect at the collocation nodes. This '
+                     desc='Scaler of the state variable defects at the collocation nodes. This '
                           'option is invalid if opt=False.')
+
+        self.declare(name='defect_ref',
+                     types=(Iterable, Number), default=None,
+                     allow_none=True,
+                     desc='Unit-reference value of the state defects at the collocation nodes. This'
+                          ' option is invalid if opt=False.  If provide, this option overrides'
+                          ' defect_scaler.')
 
         self.declare(name='continuity', types=(bool, dict), default=True,
                      desc='Enforce continuity of state values at segment boundaries. This '

--- a/dymos/phases/phase_base.py
+++ b/dymos/phases/phase_base.py
@@ -90,7 +90,7 @@ class PhaseBase(Group):
     def set_state_options(self, name, units=_unspecified, val=1.0,
                           fix_initial=False, fix_final=False, initial_bounds=None,
                           final_bounds=None, lower=None, upper=None, scaler=None, adder=None,
-                          ref=None, ref0=None, defect_scaler=1.0):
+                          ref=None, ref0=None, defect_scaler=1.0, defect_ref=None):
         """
         Set options that apply the EOM state variable of the given name.
 
@@ -126,6 +126,9 @@ class PhaseBase(Group):
             The unit-reference value of the state at the nodes of the phase
         defect_scaler : float or ndarray (1.0)
             The scaler of the state defect at the collocation nodes of the phase.
+        defect_ref : float or ndarray (1.0)
+            The unit-reference value of the state defect at the collocation nodes of the phase. If
+            provided, this value overrides defect_scaler.
 
         """
         if units is not _unspecified:
@@ -142,6 +145,7 @@ class PhaseBase(Group):
         self.state_options[name]['ref'] = ref
         self.state_options[name]['ref0'] = ref0
         self.state_options[name]['defect_scaler'] = defect_scaler
+        self.state_options[name]['defect_ref'] = defect_ref
 
     def add_control(self, name, val=0.0, units=0, opt=True, lower=None, upper=None,
                     fix_initial=False, fix_final=False,


### PR DESCRIPTION
`set_state_options` now allows the user to specify a `defect_ref` as an alternative to `defect_scaler`.  If given, it overrides `defect_scaler`.

Resolves #56 