### PR TITLE
re-working the caching and making of pyoptsparse with SNOPT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,12 @@ install:
     git clone https://github.com/OpenMDAO/pyoptsparse.git;
     cd pyoptsparse;
 
+    if [ "$SNOPT_LOCATION" ] && [ "${PY:0:1}" = "3" ]; then
+      cd pyoptsparse/pySNOPT;
+      scp -r "$SNOPT_LOCATION" .;
+      cd ../..;
+    fi
+
     python setup.py install;
     cd ..;
 


### PR DESCRIPTION
Due to other factors, SNOPT is only currently working on the 3.6 machine.  But this PR is getting SNOPT code, building pyoptsparse with SNOPT, and passing tests