### PR TITLE
Static input parameter bug fix

### DIFF
--- a/benchmark/benchmark_brachistochrone.py
+++ b/benchmark/benchmark_brachistochrone.py
@@ -48,8 +48,7 @@ class BenchmarkBrachistochrone(unittest.TestCase):
                                                         optimizer='SNOPT',
                                                         num_segments=30,
                                                         transcription_order=3,
-                                                        compressed=True,
-                                                        dynamic_simul_derivs=True)
+                                                        compressed=True)
         self.run_asserts(p)
 
     def benchmark_radau_30_3_color_simul_uncompressed_snopt(self):
@@ -58,18 +57,7 @@ class BenchmarkBrachistochrone(unittest.TestCase):
                                                         optimizer='SNOPT',
                                                         num_segments=30,
                                                         transcription_order=3,
-                                                        compressed=False,
-                                                        dynamic_simul_derivs=True)
-        self.run_asserts(p)
-
-    def benchmark_radau_30_3_nocolor_nosimul_compressed_snopt(self):
-        ex_brachistochrone.SHOW_PLOTS = False
-        p = ex_brachistochrone.brachistochrone_min_time(transcription='radau-ps',
-                                                        optimizer='SNOPT',
-                                                        num_segments=30,
-                                                        transcription_order=3,
-                                                        compressed=True,
-                                                        dynamic_simul_derivs=False)
+                                                        compressed=False)
         self.run_asserts(p)
 
     def benchmark_gl_30_3_color_simul_compressed_snopt(self):
@@ -78,8 +66,7 @@ class BenchmarkBrachistochrone(unittest.TestCase):
                                                         optimizer='SNOPT',
                                                         num_segments=30,
                                                         transcription_order=3,
-                                                        compressed=True,
-                                                        dynamic_simul_derivs=True)
+                                                        compressed=True)
         self.run_asserts(p)
 
     def benchmark_gl_30_3_color_simul_uncompressed_snopt(self):
@@ -88,16 +75,5 @@ class BenchmarkBrachistochrone(unittest.TestCase):
                                                         optimizer='SNOPT',
                                                         num_segments=30,
                                                         transcription_order=3,
-                                                        compressed=False,
-                                                        dynamic_simul_derivs=True)
-        self.run_asserts(p)
-
-    def benchmark_gl_30_3_nocolor_nosimul_compressed_snopt(self):
-        ex_brachistochrone.SHOW_PLOTS = False
-        p = ex_brachistochrone.brachistochrone_min_time(transcription='gauss-lobatto',
-                                                        optimizer='SNOPT',
-                                                        num_segments=30,
-                                                        transcription_order=3,
-                                                        compressed=True,
-                                                        dynamic_simul_derivs=False)
+                                                        compressed=False)
         self.run_asserts(p)

--- a/dymos/examples/ssto/ex_ssto_moon_linear_tangent.py
+++ b/dymos/examples/ssto/ex_ssto_moon_linear_tangent.py
@@ -95,4 +95,4 @@ def ssto_moon_linear_tangent(transcription='gauss-lobatto', num_seg=10, transcri
 
 
 if __name__ == '__main__':
-    ssto_moon_linear_tangent(optimizer='SLSQP')
+    ssto_moon_linear_tangent(transcription='gauss-lobatto', optimizer='SLSQP')

--- a/dymos/phases/optimizer_based/gauss_lobatto_phase.py
+++ b/dymos/phases/optimizer_based/gauss_lobatto_phase.py
@@ -162,16 +162,12 @@ class GaussLobattoPhase(OptimizerBasedPhaseBase):
                 col_rows = np.zeros(self.grid_data.subset_num_nodes['col'], dtype=int)
                 disc_src_idxs = get_src_indices_by_row(disc_rows, shape)
                 col_src_idxs = get_src_indices_by_row(col_rows, shape)
+                if shape == (1,):
+                    disc_src_idxs = disc_src_idxs.ravel()
+                    col_src_idxs = col_src_idxs.ravel()
             else:
                 disc_src_idxs = np.squeeze(get_src_indices_by_row([0], shape), axis=0)
                 col_src_idxs = np.squeeze(get_src_indices_by_row([0], shape), axis=0)
-
-            if not dynamic:
-                disc_src_idxs = np.squeeze(disc_src_idxs, axis=0)
-                col_src_idxs = np.squeeze(col_src_idxs, axis=0)
-            elif shape == (1,):
-                disc_src_idxs = disc_src_idxs.ravel()
-                col_src_idxs = col_src_idxs.ravel()
 
             rhs_disc_tgts = ['rhs_disc.{0}'.format(t) for t in targets]
             connection_info.append((rhs_disc_tgts, disc_src_idxs))

--- a/dymos/phases/optimizer_based/gauss_lobatto_phase.py
+++ b/dymos/phases/optimizer_based/gauss_lobatto_phase.py
@@ -151,17 +151,33 @@ class GaussLobattoPhase(OptimizerBasedPhaseBase):
             given design variable is to be connected.
         """
         connection_info = []
-        map_indices_to_disc = np.zeros(self.grid_data.subset_num_nodes['state_disc'], dtype=int)
-        map_indices_to_col = np.zeros(self.grid_data.subset_num_nodes['col'], dtype=int)
 
         if name in self.ode_options._parameters:
             targets = self.ode_options._parameters[name]['targets']
+            dynamic = self.ode_options._parameters[name]['dynamic']
+            shape = self.ode_options._parameters[name]['shape']
+
+            if dynamic:
+                disc_rows = np.zeros(self.grid_data.subset_num_nodes['state_disc'], dtype=int)
+                col_rows = np.zeros(self.grid_data.subset_num_nodes['col'], dtype=int)
+                disc_src_idxs = get_src_indices_by_row(disc_rows, shape)
+                col_src_idxs = get_src_indices_by_row(col_rows, shape)
+            else:
+                disc_src_idxs = np.squeeze(get_src_indices_by_row([0], shape), axis=0)
+                col_src_idxs = np.squeeze(get_src_indices_by_row([0], shape), axis=0)
+
+            if not dynamic:
+                disc_src_idxs = np.squeeze(disc_src_idxs, axis=0)
+                col_src_idxs = np.squeeze(col_src_idxs, axis=0)
+            elif shape == (1,):
+                disc_src_idxs = disc_src_idxs.ravel()
+                col_src_idxs = col_src_idxs.ravel()
 
             rhs_disc_tgts = ['rhs_disc.{0}'.format(t) for t in targets]
-            connection_info.append((rhs_disc_tgts, map_indices_to_disc))
+            connection_info.append((rhs_disc_tgts, disc_src_idxs))
 
             rhs_col_tgts = ['rhs_col.{0}'.format(t) for t in targets]
-            connection_info.append((rhs_col_tgts, map_indices_to_col))
+            connection_info.append((rhs_col_tgts, col_src_idxs))
 
         return connection_info
 
@@ -328,12 +344,8 @@ class GaussLobattoPhase(OptimizerBasedPhaseBase):
                                                    shape=options['shape'],
                                                    units=units)
 
-            if self.ode_options._parameters[name]['dynamic']:
-                src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
-            else:
-                src_idxs_raw = np.zeros(1, dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
+            src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
+            src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
 
             self.connect(src_name='design_parameters:{0}'.format(name),
                          tgt_name='timeseries.all_values:design_parameters:{0}'.format(name),
@@ -346,12 +358,8 @@ class GaussLobattoPhase(OptimizerBasedPhaseBase):
                                                    shape=options['shape'],
                                                    units=units)
 
-            if self.ode_options._parameters[name]['dynamic']:
-                src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
-            else:
-                src_idxs_raw = np.zeros(1, dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
+            src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
+            src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
 
             self.connect(src_name='input_parameters:{0}_out'.format(name),
                          tgt_name='timeseries.all_values:input_parameters:{0}'.format(name),
@@ -359,18 +367,13 @@ class GaussLobattoPhase(OptimizerBasedPhaseBase):
 
         for name, options in iteritems(self.traj_parameter_options):
             units = options['units']
-            target_params = options['target_params']
             timeseries_comp._add_timeseries_output('traj_parameters:{0}'.format(name),
                                                    var_class=self._classify_var(name),
                                                    shape=options['shape'],
                                                    units=units)
 
-            if self.ode_options._parameters[name]['dynamic']:
-                src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
-            else:
-                src_idxs_raw = np.zeros(1, dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
+            src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
+            src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
 
             self.connect(src_name='traj_parameters:{0}_out'.format(name),
                          tgt_name='timeseries.all_values:traj_parameters:{0}'.format(name),

--- a/dymos/phases/optimizer_based/radau_pseudospectral_phase.py
+++ b/dymos/phases/optimizer_based/radau_pseudospectral_phase.py
@@ -126,14 +126,12 @@ class RadauPseudospectralPhase(OptimizerBasedPhaseBase):
             if self.ode_options._parameters[name]['dynamic']:
                 src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
                 src_idxs = get_src_indices_by_row(src_idxs_raw, shape)
+                if shape == (1,):
+                    src_idxs = src_idxs.ravel()
             else:
                 src_idxs_raw = np.zeros(1, dtype=int)
                 src_idxs = get_src_indices_by_row(src_idxs_raw, shape)
-
-            if not dynamic:
                 src_idxs = np.squeeze(src_idxs, axis=0)
-            elif shape == (1,):
-                src_idxs = src_idxs.ravel()
 
             rhs_all_tgts = ['rhs_all.{0}'.format(t) for t in targets]
             connection_info.append((rhs_all_tgts, src_idxs))

--- a/dymos/phases/optimizer_based/radau_pseudospectral_phase.py
+++ b/dymos/phases/optimizer_based/radau_pseudospectral_phase.py
@@ -307,12 +307,8 @@ class RadauPseudospectralPhase(OptimizerBasedPhaseBase):
                                                    shape=options['shape'],
                                                    units=units)
 
-            if self.ode_options._parameters[name]['dynamic']:
-                src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
-            else:
-                src_idxs_raw = np.zeros(1, dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
+            src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
+            src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
 
             self.connect(src_name='design_parameters:{0}'.format(name),
                          tgt_name='timeseries.all_values:design_parameters:{0}'.format(name),
@@ -322,14 +318,11 @@ class RadauPseudospectralPhase(OptimizerBasedPhaseBase):
             units = options['units']
             timeseries_comp._add_timeseries_output('input_parameters:{0}'.format(name),
                                                    var_class=self._classify_var(name),
+                                                   shape=options['shape'],
                                                    units=units)
 
-            if self.ode_options._parameters[name]['dynamic']:
-                src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
-            else:
-                src_idxs_raw = np.zeros(1, dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
+            src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
+            src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
 
             self.connect(src_name='input_parameters:{0}_out'.format(name),
                          tgt_name='timeseries.all_values:input_parameters:{0}'.format(name),

--- a/dymos/phases/phase_base.py
+++ b/dymos/phases/phase_base.py
@@ -1137,7 +1137,8 @@ class PhaseBase(Group):
             src_name = 'input_parameters:{0}_out'.format(name)
 
             for tgts, src_idxs in self._get_parameter_connections(name):
-                self.connect(src_name, [t for t in tgts], src_indices=src_idxs)
+                self.connect(src_name, [t for t in tgts],
+                             src_indices=src_idxs, flat_src_indices=True)
 
     def _setup_traj_input_parameters(self):
         """

--- a/dymos/phases/tests/test_input_parameter_connections.py
+++ b/dymos/phases/tests/test_input_parameter_connections.py
@@ -68,8 +68,8 @@ class TestStaticInputParameters(unittest.TestCase):
 
         try:
             p.setup()
-        except:
-            self.fail('Exception encountered in setup')
+        except Exception as e:
+            self.fail('Exception encountered in setup:\n' + str(e))
 
     def test_gauss_lobatto(self):
 
@@ -88,5 +88,5 @@ class TestStaticInputParameters(unittest.TestCase):
 
         try:
             p.setup()
-        except:
-            self.fail('Exception encountered in setup')
+        except Exception as e:
+            self.fail('Exception encountered in setup:\n' + str(e))

--- a/dymos/phases/tests/test_input_parameter_connections.py
+++ b/dymos/phases/tests/test_input_parameter_connections.py
@@ -1,0 +1,92 @@
+import numpy as np
+
+import unittest
+from openmdao.api import ExplicitComponent, Group, Problem
+from dymos import Phase, ODEOptions
+
+
+n_traj = 4
+
+
+class MyComp(ExplicitComponent):
+
+    def initialize(self):
+        self.options.declare('n_traj', types=int)
+        self.options.declare('num_nodes', types=int)
+
+    def setup(self):
+        nn = self.options['num_nodes']
+        n_traj = self.options['n_traj']
+        self.add_input('time', val=np.zeros(nn))
+        self.add_input('alpha', shape=np.zeros((n_traj, 2)).shape)
+
+        self.add_output('y', val=np.zeros(nn))
+
+    def compute(self, inputs, outputs):
+        pass
+
+    def compute_partials(self, inputs, partials):
+        pass
+
+
+class MyODE(Group):
+    ode_options = ODEOptions()
+    ode_options.declare_time(units='s', targets=['comp.time'])
+    ode_options.declare_state(name='F', rate_source='comp.y')
+    ode_options.declare_parameter(name='alpha', shape=(n_traj, 2), targets='comp.alpha',
+                                  dynamic=False)
+
+    def initialize(self):
+        self.options.declare('num_nodes', types=int)
+        self.options.declare('n_traj', default=2, types=int)
+
+    def setup(self):
+        nn = self.options['num_nodes']
+        n_traj = self.options['n_traj']
+
+        self.add_subsystem(name='comp',
+                           subsys=MyComp(num_nodes=nn,
+                                         n_traj=n_traj))
+
+
+class TestStaticInputParameters(unittest.TestCase):
+
+    def test_radau(self):
+
+        p = Problem(model=Group())
+
+        phase = Phase(transcription='radau-ps',
+                      ode_class=MyODE,
+                      ode_init_kwargs={'n_traj': n_traj},
+                      num_segments=25,
+                      transcription_order=3,
+                      compressed=True)
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.add_input_parameter('alpha', val=np.ones((n_traj, 2)), units='m')
+
+        try:
+            p.setup()
+        except:
+            self.fail('Exception encountered in setup')
+
+    def test_gauss_lobatto(self):
+
+        p = Problem(model=Group())
+
+        phase = Phase(transcription='gauss-lobatto',
+                      ode_class=MyODE,
+                      ode_init_kwargs={'n_traj': n_traj},
+                      num_segments=25,
+                      transcription_order=3,
+                      compressed=True)
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.add_input_parameter('alpha', val=np.ones((n_traj, 2)), units='m')
+
+        try:
+            p.setup()
+        except:
+            self.fail('Exception encountered in setup')


### PR DESCRIPTION
Fixed static, shaped input parameter connection issue in gauss-lobatto phase and a related one in the timeseries outputs.  Updated benchmarks to no longer bother with non-simultaneous derivatives.

There were a few minor issues with the demo code but even with things posed as expected, the problem persisted.  This test now exists in dymos/phases/tests/test_input_parameter_connections.py

Resolves #126 