### PR TITLE
changes for initial and duration arguments in set_time_options 

### DIFF
--- a/dymos/phases/options.py
+++ b/dymos/phases/options.py
@@ -344,7 +344,7 @@ class TimeOptionsDictionary(OptionsDictionary):
                      desc='If True, the phase duration (t_duration) is expected to be '
                           'connected to an external output source.')
 
-        self.declare('initial', types=Number,
+        self.declare('initial_val', types=Number, default=0.0,
                      desc='Value of the integration variable at the start of the phase.')
 
         self.declare('initial_bounds', types=Iterable, default=(None, None),
@@ -363,7 +363,7 @@ class TimeOptionsDictionary(OptionsDictionary):
         self.declare('initial_ref', types=Number, allow_none=True, default=None,
                      desc='Unit-reference value for the initial value of the integration variable.')
 
-        self.declare('duration', types=Number,
+        self.declare('duration_val', types=Number, default=1.0,
                      desc='Value of the duration of the integration variable across the phase.')
 
         self.declare('duration_bounds', types=Iterable, default=(None, None),

--- a/dymos/phases/phase_base.py
+++ b/dymos/phases/phase_base.py
@@ -751,9 +751,9 @@ class PhaseBase(Group):
 
     def set_time_options(self, opt_initial=None, opt_duration=None, fix_initial=False,
                          fix_duration=False, input_initial=False, input_duration=False,
-                         initial=0.0, initial_bounds=(None, None), initial_scaler=None,
+                         initial_val=0.0, initial_bounds=(None, None), initial_scaler=None,
                          initial_adder=None, initial_ref=None, initial_ref0=None,
-                         duration=1.0, duration_bounds=(None, None),
+                         duration_val=1.0, duration_bounds=(None, None),
                          duration_scaler=None, duration_adder=None, duration_ref=None,
                          duration_ref0=None):
         """
@@ -777,7 +777,7 @@ class PhaseBase(Group):
         input_duration : bool
             If True, the user is expected to link phase.t_duration to an external output source.
             Providing input_duration=True makes all time duration optimization settings irrelevant.
-        initial : float
+        initial_val : float
             Default value of the time at the start of the phase.
         initial_bounds : Iterable of size 2
             Tuple of (lower, upper) bounds for time at the start of the phase.
@@ -789,7 +789,7 @@ class PhaseBase(Group):
             Zero-reference value for the initial value of time.
         initial_ref : float
             Unit-reference value for the initial value of time.
-        duration : float
+        duration_val : float
             Value of the duration of time across the phase.
         duration_bounds : Iterable of size 2
             Tuple of (lower, upper) bounds for the duration of time
@@ -864,7 +864,7 @@ class PhaseBase(Group):
                 warnings.warn(msg, RuntimeWarning)
 
         self.time_options['input_initial'] = input_initial
-        self.time_options['initial'] = initial
+        self.time_options['initial_val'] = initial_val
         self.time_options['initial_bounds'] = initial_bounds
         self.time_options['initial_scaler'] = initial_scaler
         self.time_options['initial_adder'] = initial_adder
@@ -872,7 +872,7 @@ class PhaseBase(Group):
         self.time_options['initial_ref0'] = initial_ref0
 
         self.time_options['input_duration'] = input_duration
-        self.time_options['duration'] = duration
+        self.time_options['duration_val'] = duration_val
         self.time_options['duration_bounds'] = duration_bounds
         self.time_options['duration_scaler'] = duration_scaler
         self.time_options['duration_adder'] = duration_adder
@@ -981,6 +981,8 @@ class PhaseBase(Group):
         time_units = self.time_options['units']
 
         indeps = []
+        default_vals = {'t_initial': self.time_options['initial_val'],
+                        't_duration': self.time_options['duration_val']}
         externals = []
         comps = []
 
@@ -999,7 +1001,7 @@ class PhaseBase(Group):
         if indeps:
             indep = IndepVarComp()
             for var in indeps:
-                indep.add_output(var, val=1.0, units=time_units)
+                indep.add_output(var, val=default_vals[var], units=time_units)
             self.add_subsystem('time_extents', indep, promotes_outputs=['*'])
             comps += ['time_extents']
 

--- a/dymos/phases/tests/test_input_parameter_connections.py
+++ b/dymos/phases/tests/test_input_parameter_connections.py
@@ -17,10 +17,9 @@ class MyComp(ExplicitComponent):
     def setup(self):
         nn = self.options['num_nodes']
         n_traj = self.options['n_traj']
-        self.add_input('time', val=np.zeros(nn))
-        self.add_input('alpha', shape=np.zeros((n_traj, 2)).shape)
-
-        self.add_output('y', val=np.zeros(nn))
+        self.add_input('time', val=np.zeros(nn), units='s')
+        self.add_input('alpha', shape=np.zeros((n_traj, 2)).shape, units='m')
+        self.add_output('y', val=np.zeros(nn), units='1/s')
 
     def compute(self, inputs, outputs):
         pass

--- a/dymos/phases/tests/test_set_time_options.py
+++ b/dymos/phases/tests/test_set_time_options.py
@@ -83,8 +83,8 @@ class TestPhaseTimeOptions(unittest.TestCase):
         p.model.linear_solver = DirectSolver()
         p.setup(check=True)
 
-        assert_rel_error(p['phase0.t_initial'], 0.01)
-        assert_rel_error(p['phase0.t_duration'], 1.9)
+        assert_rel_error(self, p['phase0.t_initial'], 0.01)
+        assert_rel_error(self, p['phase0.t_duration'], 1.9)
 
     def test_ex_double_integrator_input_and_fixed_times_warns(self, transcription='radau-ps'):
         """

--- a/dymos/phases/tests/test_set_time_options.py
+++ b/dymos/phases/tests/test_set_time_options.py
@@ -5,6 +5,7 @@ import unittest
 import warnings
 
 from openmdao.api import Problem, Group, IndepVarComp, ScipyOptimizeDriver, DirectSolver
+from openmdao.utils.assert_utils import assert_rel_error
 
 from dymos import Phase
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
@@ -48,6 +49,42 @@ class TestPhaseTimeOptions(unittest.TestCase):
                          msg='set_time_options failed to raise two warnings')
         self.assertEqual(str(ctx[0].message), expected_msg0)
         self.assertEqual(str(ctx[1].message), expected_msg1)
+
+    def test_initial_val_and_final_val_stick(self):
+        p = Problem(model=Group())
+
+        p.driver = ScipyOptimizeDriver()
+        p.driver.options['dynamic_simul_derivs'] = True
+
+        phase = Phase('gauss-lobatto',
+                      ode_class=BrachistochroneODE,
+                      num_segments=8,
+                      transcription_order=3)
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(fix_initial=False, fix_duration=False,
+                               initial_val=0.01, duration_val=1.9)
+
+        phase.set_state_options('x', fix_initial=True, fix_final=True)
+        phase.set_state_options('y', fix_initial=True, fix_final=True)
+        phase.set_state_options('v', fix_initial=True, fix_final=False)
+
+        phase.add_control('theta', continuity=True, rate_continuity=True,
+                          units='deg', lower=0.01, upper=179.9)
+
+        phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
+
+        # Minimize time at the end of the phase
+        phase.add_objective('time', loc='final', scaler=10)
+
+        phase.add_boundary_constraint('time', loc='initial', equals=0)
+
+        p.model.linear_solver = DirectSolver()
+        p.setup(check=True)
+
+        assert_rel_error(p['phase0.t_initial'], 0.01)
+        assert_rel_error(p['phase0.t_duration'], 1.9)
 
     def test_ex_double_integrator_input_and_fixed_times_warns(self, transcription='radau-ps'):
         """


### PR DESCRIPTION
changed default time arguments to initial_val and duration_val.  fixed it so that they are set as the default values for t_initial and t_duration.

Resolves #120 