### PR TITLE
ODE targets for t_initial and t_duration

### DIFF
--- a/dymos/ode_options.py
+++ b/dymos/ode_options.py
@@ -15,15 +15,15 @@ class _ODETimeOptionsDictionary(OptionsDictionary):
     """
     def __init__(self, read_only=False):
         super(_ODETimeOptionsDictionary, self).__init__(read_only)
-        self.declare('targets', default=[], types=Iterable,
+        self.declare('targets', default=[], types=Iterable, allow_none=True,
                      desc='Target path(s) for the time variable, relative to the top-level system.')
-        self.declare('time_phase_targets', default=[], types=Iterable,
+        self.declare('time_phase_targets', default=[], types=Iterable, allow_none=True,
                      desc='Target path(s) for the time_phase variable '
                           '(the current phase elapsed time), relative to the top-level system.')
-        self.declare('t_initial_targets', default=[], types=Iterable,
+        self.declare('t_initial_targets', default=[], types=Iterable, allow_none=True,
                      desc='Target path(s) for the t_initial variable relative to the top-level '
                           'system.')
-        self.declare('t_duration_targets', default=[], types=Iterable,
+        self.declare('t_duration_targets', default=[], types=Iterable, allow_none=True,
                      desc='Target path(s) for the t_duration variable relative to the top-level '
                           'system.')
         self.declare('units', default=None, types=string_types, allow_none=True,
@@ -81,15 +81,22 @@ class declare_time(object):
     This decorator can be stacked with `declare_state` and `declare_parameter`
     to provide all necessary ODE metadata for system.
     """
-    def __init__(self, targets=None, units=None):
+    def __init__(self, targets=None, units=None, time_phase_targets=None, t_initial_targets=None,
+                 t_duration_targets=None):
         self.targets = targets
+        self.time_phase_targets = time_phase_targets
+        self.t_initial_targets = t_initial_targets
+        self.t_duration_targets = t_duration_targets
         self.units = units
 
     def __call__(self, system_class):
         if not hasattr(system_class, 'ode_options'):
             setattr(system_class, 'ode_options', ODEOptions())
 
-        system_class.ode_options.declare_time(targets=self.targets, units=self.units)
+        system_class.ode_options.declare_time(targets=self.targets, units=self.units,
+                                              time_phase_targets=self.time_phase_targets,
+                                              t_initial_targets=self.t_initial_targets,
+                                              t_duration_targets=self.t_duration_targets)
         return system_class
 
 
@@ -212,7 +219,8 @@ class ODEOptions(object):
         # If no issues have been found, extend the existing list of targets
         self._target_paths.extend(targets)
 
-    def declare_time(self, targets=None, units=None):
+    def declare_time(self, targets=None, units=None, time_phase_targets=None,
+                     t_initial_targets=None, t_duration_targets=None):
         """
         Specify the targets and units of time or the time-like variable.
 
@@ -230,6 +238,28 @@ class ODEOptions(object):
             self._time_options['targets'] = targets
         elif targets is not None:
             raise ValueError('targets must be of type string_types or Iterable or None')
+
+        if isinstance(time_phase_targets, string_types):
+            self._time_options['time_phase_targets'] = [time_phase_targets]
+        elif isinstance(time_phase_targets, Iterable):
+            self._time_options['time_phase_targets'] = time_phase_targets
+        elif time_phase_targets is not None:
+            raise ValueError('time_phase_targets must be of type string_types or Iterable or None')
+
+        if isinstance(t_initial_targets, string_types):
+            self._time_options['t_initial_targets'] = [t_initial_targets]
+        elif isinstance(t_initial_targets, Iterable):
+            self._time_options['t_initial_targets'] = t_initial_targets
+        elif t_initial_targets is not None:
+            raise ValueError('t_initial_targets must be of type string_types or Iterable or None')
+
+        if isinstance(t_duration_targets, string_types):
+            self._time_options['t_duration_targets'] = [t_duration_targets]
+        elif isinstance(t_duration_targets, Iterable):
+            self._time_options['t_duration_targets'] = t_duration_targets
+        elif t_duration_targets is not None:
+            raise ValueError('t_duration_targets must be of type string_types or Iterable or None')
+
         if units is not None:
             self._time_options['units'] = units
 

--- a/dymos/ode_options.py
+++ b/dymos/ode_options.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 from collections import Iterable
-from six import string_types, iteritems
+from six import string_types
 import numpy as np
 
 from openmdao.utils.options_dictionary import OptionsDictionary
@@ -20,6 +20,12 @@ class _ODETimeOptionsDictionary(OptionsDictionary):
         self.declare('time_phase_targets', default=[], types=Iterable,
                      desc='Target path(s) for the time_phase variable '
                           '(the current phase elapsed time), relative to the top-level system.')
+        self.declare('t_initial_targets', default=[], types=Iterable,
+                     desc='Target path(s) for the t_initial variable relative to the top-level '
+                          'system.')
+        self.declare('t_duration_targets', default=[], types=Iterable,
+                     desc='Target path(s) for the t_duration variable relative to the top-level '
+                          'system.')
         self.declare('units', default=None, types=string_types, allow_none=True,
                      desc='Units for time.')
 

--- a/dymos/phases/optimizer_based/gauss_lobatto_phase.py
+++ b/dymos/phases/optimizer_based/gauss_lobatto_phase.py
@@ -93,6 +93,26 @@ class GaussLobattoPhase(OptimizerBasedPhaseBase):
                          ['rhs_disc.{0}'.format(t) for t in tgts],
                          src_indices=self.grid_data.subset_node_indices['state_disc'])
 
+        if self.time_options['t_initial_targets']:
+            tgts = self.time_options['t_initial_targets']
+            self.connect('t_initial',
+                         ['rhs_col.{0}'.format(t) for t in tgts],
+                         src_indices=np.zeros(self.grid_data.subset_num_nodes['col'], dtype=int))
+            self.connect('t_initial',
+                         ['rhs_disc.{0}'.format(t) for t in tgts],
+                         src_indices=np.zeros(self.grid_data.subset_num_nodes['state_disc'],
+                                              dtype=int))
+
+        if self.time_options['t_duration_targets']:
+            tgts = self.time_options['t_duration_targets']
+            self.connect('t_duration',
+                         ['rhs_col.{0}'.format(t) for t in tgts],
+                         src_indices=np.zeros(self.grid_data.subset_num_nodes['col'], dtype=int))
+            self.connect('t_duration',
+                         ['rhs_disc.{0}'.format(t) for t in tgts],
+                         src_indices=np.zeros(self.grid_data.subset_num_nodes['state_disc'],
+                                              dtype=int))
+
         return comps
 
     def _setup_controls(self):

--- a/dymos/phases/optimizer_based/gauss_lobatto_phase.py
+++ b/dymos/phases/optimizer_based/gauss_lobatto_phase.py
@@ -96,22 +96,16 @@ class GaussLobattoPhase(OptimizerBasedPhaseBase):
         if self.time_options['t_initial_targets']:
             tgts = self.time_options['t_initial_targets']
             self.connect('t_initial',
-                         ['rhs_col.{0}'.format(t) for t in tgts],
-                         src_indices=np.zeros(self.grid_data.subset_num_nodes['col'], dtype=int))
+                         ['rhs_col.{0}'.format(t) for t in tgts])
             self.connect('t_initial',
-                         ['rhs_disc.{0}'.format(t) for t in tgts],
-                         src_indices=np.zeros(self.grid_data.subset_num_nodes['state_disc'],
-                                              dtype=int))
+                         ['rhs_disc.{0}'.format(t) for t in tgts])
 
         if self.time_options['t_duration_targets']:
             tgts = self.time_options['t_duration_targets']
             self.connect('t_duration',
-                         ['rhs_col.{0}'.format(t) for t in tgts],
-                         src_indices=np.zeros(self.grid_data.subset_num_nodes['col'], dtype=int))
+                         ['rhs_col.{0}'.format(t) for t in tgts])
             self.connect('t_duration',
-                         ['rhs_disc.{0}'.format(t) for t in tgts],
-                         src_indices=np.zeros(self.grid_data.subset_num_nodes['state_disc'],
-                                              dtype=int))
+                         ['rhs_disc.{0}'.format(t) for t in tgts])
 
         return comps
 

--- a/dymos/phases/optimizer_based/radau_pseudospectral_phase.py
+++ b/dymos/phases/optimizer_based/radau_pseudospectral_phase.py
@@ -86,14 +86,12 @@ class RadauPseudospectralPhase(OptimizerBasedPhaseBase):
         if self.time_options['t_initial_targets']:
             tgts = self.time_options['t_initial_targets']
             self.connect('t_initial',
-                         ['rhs_all.{0}'.format(t) for t in tgts],
-                         src_indices=np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int))
+                         ['rhs_all.{0}'.format(t) for t in tgts])
 
         if self.time_options['t_duration_targets']:
             tgts = self.time_options['t_duration_targets']
             self.connect('t_duration',
-                         ['rhs_all.{0}'.format(t) for t in tgts],
-                         src_indices=np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int))
+                         ['rhs_all.{0}'.format(t) for t in tgts])
         return comps
 
     def _setup_controls(self):

--- a/dymos/phases/optimizer_based/radau_pseudospectral_phase.py
+++ b/dymos/phases/optimizer_based/radau_pseudospectral_phase.py
@@ -82,6 +82,18 @@ class RadauPseudospectralPhase(OptimizerBasedPhaseBase):
             self.connect('time_phase',
                          ['rhs_all.{0}'.format(t) for t in self.time_options['time_phase_targets']],
                          src_indices=self.grid_data.subset_node_indices['all'])
+
+        if self.time_options['t_initial_targets']:
+            tgts = self.time_options['t_initial_targets']
+            self.connect('t_initial',
+                         ['rhs_all.{0}'.format(t) for t in tgts],
+                         src_indices=np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int))
+
+        if self.time_options['t_duration_targets']:
+            tgts = self.time_options['t_duration_targets']
+            self.connect('t_duration',
+                         ['rhs_all.{0}'.format(t) for t in tgts],
+                         src_indices=np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int))
         return comps
 
     def _setup_controls(self):

--- a/dymos/phases/options.py
+++ b/dymos/phases/options.py
@@ -391,6 +391,14 @@ class TimeOptionsDictionary(OptionsDictionary):
                      desc='targets in the ODE to which the elapsed duration of the phase is '
                           'connected')
 
+        self.declare(name='t_initial_targets', types=Iterable, allow_none=True, default=None,
+                     desc='targets in the ODE to which the initial time of the phase is '
+                          'connected')
+
+        self.declare(name='t_duration_targets', types=Iterable, allow_none=True, default=None,
+                     desc='targets in the ODE to which the total duration of the phase is '
+                          'connected')
+
 
 class _ForDocs(object):  # pragma: no cover
     """

--- a/dymos/phases/phase_base.py
+++ b/dymos/phases/phase_base.py
@@ -75,6 +75,10 @@ class PhaseBase(Group):
         self.time_options['targets'] = self.ode_options._time_options['targets']
         self.time_options['time_phase_targets'] = \
             self.ode_options._time_options['time_phase_targets']
+        self.time_options['t_initial_targets'] = \
+            self.ode_options._time_options['t_initial_targets']
+        self.time_options['t_duration_targets'] = \
+            self.ode_options._time_options['t_duration_targets']
 
     def initialize(self):
         self.options.declare('num_segments', types=int, desc='Number of segments')

--- a/dymos/phases/runge_kutta/runge_kutta_phase.py
+++ b/dymos/phases/runge_kutta/runge_kutta_phase.py
@@ -134,23 +134,15 @@ class RungeKuttaPhase(PhaseBase):
 
         if self.time_options['t_initial_targets']:
             time_phase_tgts = self.time_options['t_initial_targets']
-            self.connect('t_initial',
-                         ['rk_solve_group.ode.{0}'.format(t) for t in time_phase_tgts],
-                         src_indices=np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int))
-            self.connect('t_initial',
-                         ['ode.{0}'.format(t) for t in time_phase_tgts],
-                         src_indices=np.zeros(self.grid_data.subset_num_nodes['segment_ends'],
-                                              dtype=int))
+            self.connect('t_initial', ['rk_solve_group.ode.{0}'.format(t) for t in time_phase_tgts])
+            self.connect('t_initial', ['ode.{0}'.format(t) for t in time_phase_tgts])
 
         if self.time_options['t_duration_targets']:
             time_phase_tgts = self.time_options['t_duration_targets']
             self.connect('t_duration',
-                         ['rk_solve_group.ode.{0}'.format(t) for t in time_phase_tgts],
-                         src_indices=np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int))
+                         ['rk_solve_group.ode.{0}'.format(t) for t in time_phase_tgts])
             self.connect('t_duration',
-                         ['ode.{0}'.format(t) for t in time_phase_tgts],
-                         src_indices=np.zeros(self.grid_data.subset_num_nodes['segment_ends'],
-                                              dtype=int))
+                         ['ode.{0}'.format(t) for t in time_phase_tgts])
 
         return comps
 

--- a/dymos/phases/runge_kutta/runge_kutta_phase.py
+++ b/dymos/phases/runge_kutta/runge_kutta_phase.py
@@ -132,6 +132,26 @@ class RungeKuttaPhase(PhaseBase):
                          ['ode.{0}'.format(t) for t in time_phase_tgts],
                          src_indices=self.grid_data.subset_node_indices['segment_ends'])
 
+        if self.time_options['t_initial_targets']:
+            time_phase_tgts = self.time_options['t_initial_targets']
+            self.connect('t_initial',
+                         ['rk_solve_group.ode.{0}'.format(t) for t in time_phase_tgts],
+                         src_indices=np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int))
+            self.connect('t_initial',
+                         ['ode.{0}'.format(t) for t in time_phase_tgts],
+                         src_indices=np.zeros(self.grid_data.subset_num_nodes['segment_ends'],
+                                              dtype=int))
+
+        if self.time_options['t_duration_targets']:
+            time_phase_tgts = self.time_options['t_duration_targets']
+            self.connect('t_duration',
+                         ['rk_solve_group.ode.{0}'.format(t) for t in time_phase_tgts],
+                         src_indices=np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int))
+            self.connect('t_duration',
+                         ['ode.{0}'.format(t) for t in time_phase_tgts],
+                         src_indices=np.zeros(self.grid_data.subset_num_nodes['segment_ends'],
+                                              dtype=int))
+
         return comps
 
     def _setup_rhs(self):

--- a/dymos/phases/simulation/ode_integration_interface.py
+++ b/dymos/phases/simulation/ode_integration_interface.py
@@ -59,9 +59,6 @@ class ODEIntegrationInterface(object):
         self.traj_parameter_options = traj_parameter_options
         self.control_interpolants = {}
 
-        # Stored initial value of time so that time_phase can be calculated
-        self.t_initial = 0.0
-
         pos = 0
 
         for state, options in iteritems(state_options):
@@ -86,9 +83,9 @@ class ODEIntegrationInterface(object):
         ivc = IndepVarComp()
         time_units = ode_class.ode_options._time_options['units']
         ivc.add_output('time', val=0.0, units=time_units)
-        ivc.add_output('time_phase', val=0.0, units=time_units)
-        ivc.add_output('t_initial', val=0.0, units=time_units)
-        ivc.add_output('t_duration', val=0.0, units=time_units)
+        ivc.add_output('time_phase', val=-88.0, units=time_units)
+        ivc.add_output('t_initial', val=-99.0, units=time_units)
+        ivc.add_output('t_duration', val=-111.0, units=time_units)
 
         model.add_subsystem('time_input', ivc, promotes_outputs=['*'])
 
@@ -100,11 +97,11 @@ class ODEIntegrationInterface(object):
 
         model.connect('t_initial',
                       ['ode.{0}'.format(tgt) for tgt in
-                       self.ode_options._time_options['t_initial_targets']])
+                       ode_class.ode_options._time_options['t_initial_targets']])
 
         model.connect('t_duration',
                       ['ode.{0}'.format(tgt) for tgt in
-                       self.ode_options._time_options['t_duration_targets']])
+                       ode_class.ode_options._time_options['t_duration_targets']])
 
         # The States Comp
         for name, options in iteritems(self.state_options):
@@ -282,7 +279,7 @@ class ODEIntegrationInterface(object):
 
         """
         self.prob['time'] = t
-        self.prob['time_phase'] = t - self.t_initial
+        self.prob['time_phase'] = t - self.prob['t_initial']
         self._unpack_state_vec(x)
         self.prob.run_model()
         xdot = self._pack_state_rate_vec()

--- a/dymos/phases/simulation/ode_integration_interface.py
+++ b/dymos/phases/simulation/ode_integration_interface.py
@@ -98,13 +98,13 @@ class ODEIntegrationInterface(object):
         model.connect('time_phase', ['ode.{0}'.format(tgt) for tgt in
                                      ode_class.ode_options._time_options['time_phase_targets']])
 
-        # self.prob.model.connect('t_initial',
-        #                         ['ode.{0}'.format(tgt) for tgt in
-        #                          self.ode_options._time_options['t_initial_targets']])
-        #
-        # self.prob.model.connect('t_duration',
-        #                         ['ode.{0}'.format(tgt) for tgt in
-        #                          self.ode_options._time_options['t_duration_targets']])
+        model.connect('t_initial',
+                      ['ode.{0}'.format(tgt) for tgt in
+                       self.ode_options._time_options['t_initial_targets']])
+
+        model.connect('t_duration',
+                      ['ode.{0}'.format(tgt) for tgt in
+                       self.ode_options._time_options['t_duration_targets']])
 
         # The States Comp
         for name, options in iteritems(self.state_options):

--- a/dymos/phases/simulation/simulation_phase.py
+++ b/dymos/phases/simulation/simulation_phase.py
@@ -167,8 +167,32 @@ class SimulationPhase(Group):
                        val=time_vals - time_vals[0],
                        units=time_units)
 
+        ivc.add_output('t_initial',
+                       val=time_vals[0],
+                       units=time_units)
+
+        ivc.add_output('t_duration',
+                       val=time_vals[-1] - time_vals[0],
+                       units=time_units)
+
         if self.time_options['targets']:
             self.connect('time', ['ode.{0}'.format(tgt) for tgt in self.time_options['targets']])
+
+        if self.time_options['time_phase_targets']:
+            self.connect('time_phase', ['ode.{0}'.format(tgt)
+                                        for tgt in self.time_options['time_phase_targets']])
+
+        if self.time_options['t_initial_targets']:
+            self.connect('t_initial', ['ode.{0}'.format(tgt)
+                                       for tgt in self.time_options['t_initial_targets']])
+            for i in range(num_seg):
+                self.connect(src_name='t_initial', tgt_name='segment_{0}.t_initial'.format(i))
+
+        if self.time_options['t_duration_targets']:
+            self.connect('t_duration', ['ode.{0}'.format(tgt)
+                                        for tgt in self.time_options['t_duration_targets']])
+            for i in range(num_seg):
+                self.connect(src_name='t_duration', tgt_name='segment_{0}.t_duration'.format(i))
 
     def _setup_states(self, ivc):
         gd = self.options['grid_data']
@@ -201,7 +225,6 @@ class SimulationPhase(Group):
     def _setup_controls(self, ivc):
         gd = self.options['grid_data']
         nn = gd.subset_num_nodes['all']
-        ncin = gd.subset_num_nodes['control_input']
         num_seg = gd.num_segments
 
         if self.control_options:

--- a/dymos/phases/tests/test_time_targets.py
+++ b/dymos/phases/tests/test_time_targets.py
@@ -1,0 +1,298 @@
+from __future__ import print_function, absolute_import, division
+
+import itertools
+import unittest
+
+from numpy.testing import assert_almost_equal
+
+import matplotlib
+matplotlib.use('Agg')
+
+from parameterized import parameterized
+
+from openmdao.api import Problem, Group, pyOptSparseDriver, ScipyOptimizeDriver, DirectSolver
+from openmdao.utils.assert_utils import assert_rel_error
+
+import numpy as np
+from openmdao.api import ExplicitComponent
+from dymos import declare_time, declare_state, declare_parameter, Phase
+
+
+@declare_time(units='s', time_phase_targets=['time_phase'], t_duration_targets=['t_duration'],
+              t_initial_targets=['t_initial'], targets=['time'])
+@declare_state('x', rate_source='xdot', units='m')
+@declare_state('y', rate_source='ydot', units='m')
+@declare_state('v', rate_source='vdot', targets=['v'], units='m/s')
+@declare_parameter('theta', targets=['theta'], units='rad')
+@declare_parameter('g', units='m/s**2', targets=['g'])
+class _BrachistochroneTestODE(ExplicitComponent):
+
+    def initialize(self):
+        self.options.declare('num_nodes', types=int)
+
+    def setup(self):
+        nn = self.options['num_nodes']
+
+        # Inputs
+        self.add_input('v', val=np.zeros(nn), desc='velocity', units='m/s')
+
+        self.add_input('g', val=9.80665 * np.ones(nn), desc='grav. acceleration', units='m/s/s')
+
+        self.add_input('theta', val=np.zeros(nn), desc='angle of wire', units='rad')
+
+        self.add_input('t_initial', val=-88.0, desc='start time of phase', units='s')
+
+        self.add_input('t_duration', val=-89.0, desc='total duration of phase', units='s')
+
+        self.add_input('time_phase', val=np.zeros(nn), desc='elapsed time of phase', units='s')
+
+        self.add_input('time', val=np.zeros(nn), desc='time of phase', units='s')
+
+        self.add_output('xdot', val=np.zeros(nn), desc='velocity component in x', units='m/s')
+
+        self.add_output('ydot', val=np.zeros(nn), desc='velocity component in y', units='m/s')
+
+        self.add_output('vdot', val=np.zeros(nn), desc='acceleration magnitude', units='m/s**2')
+
+        self.add_output('check', val=np.zeros(nn), desc='check solution: v/sin(theta) = constant',
+                        units='m/s')
+
+        # Setup partials
+        arange = np.arange(self.options['num_nodes'])
+
+        self.declare_partials(of='vdot', wrt='g', rows=arange, cols=arange)
+        self.declare_partials(of='vdot', wrt='theta', rows=arange, cols=arange)
+
+        self.declare_partials(of='xdot', wrt='v', rows=arange, cols=arange)
+        self.declare_partials(of='xdot', wrt='theta', rows=arange, cols=arange)
+
+        self.declare_partials(of='ydot', wrt='v', rows=arange, cols=arange)
+        self.declare_partials(of='ydot', wrt='theta', rows=arange, cols=arange)
+
+        self.declare_partials(of='check', wrt='v', rows=arange, cols=arange)
+        self.declare_partials(of='check', wrt='theta', rows=arange, cols=arange)
+
+    def compute(self, inputs, outputs):
+        theta = inputs['theta']
+        cos_theta = np.cos(theta)
+        sin_theta = np.sin(theta)
+        g = inputs['g']
+        v = inputs['v']
+
+        outputs['vdot'] = g * cos_theta
+        outputs['xdot'] = v * sin_theta
+        outputs['ydot'] = -v * cos_theta
+        outputs['check'] = v / sin_theta
+
+    def compute_partials(self, inputs, jacobian):
+        theta = inputs['theta']
+        cos_theta = np.cos(theta)
+        sin_theta = np.sin(theta)
+        g = inputs['g']
+        v = inputs['v']
+
+        jacobian['vdot', 'g'] = cos_theta
+        jacobian['vdot', 'theta'] = -g * sin_theta
+
+        jacobian['xdot', 'v'] = sin_theta
+        jacobian['xdot', 'theta'] = v * cos_theta
+
+        jacobian['ydot', 'v'] = -cos_theta
+        jacobian['ydot', 'theta'] = v * sin_theta
+
+        jacobian['check', 'v'] = 1 / sin_theta
+        jacobian['check', 'theta'] = -v * cos_theta / sin_theta**2
+
+
+class TestPhaseTimeTargets(unittest.TestCase):
+
+    def _make_problem(self, transcription, num_seg, transcription_order=3):
+        p = Problem(model=Group())
+
+        p.driver = ScipyOptimizeDriver()
+
+        # Compute sparsity/coloring when run_driver is called
+        p.driver.options['dynamic_simul_derivs'] = True
+
+        if transcription == 'runge-kutta':
+            phase = Phase(transcription=transcription,
+                          ode_class=_BrachistochroneTestODE,
+                          num_segments=num_seg,
+                          method='rk4',
+                          compressed=True)
+        else:
+            phase = Phase(transcription=transcription,
+                          ode_class=_BrachistochroneTestODE,
+                          num_segments=num_seg,
+                          transcription_order=transcription_order,
+                          compressed=True)
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(initial_bounds=(1, 1), duration_bounds=(.5, 10))
+
+        phase.set_state_options('x', fix_initial=True)
+        phase.set_state_options('y', fix_initial=True)
+        phase.set_state_options('v', fix_initial=True)
+
+        phase.add_control('theta', units='deg', rate_continuity=True, lower=0.01, upper=179.9)
+
+        phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
+
+        phase.add_boundary_constraint('x', loc='final', equals=10)
+        phase.add_boundary_constraint('y', loc='final', equals=5)
+
+        # Minimize time at the end of the phase
+        phase.add_objective('time', loc='final', scaler=10)
+
+        p.model.linear_solver = DirectSolver()
+
+        p.setup()
+
+        p['phase0.t_initial'] = 1.0
+        p['phase0.t_duration'] = 3.0
+
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_input')
+        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='control_input')
+
+        return p
+
+    def test_gauss_lobatto(self):
+        num_seg = 20
+        p = self._make_problem('gauss-lobatto', num_seg)
+
+        # Solve for the optimal trajectory
+        p.run_driver()
+
+        gd = p.model.phase0.grid_data
+
+        time_all = p['phase0.time']
+        time_col = time_all[gd.subset_node_indices['col']]
+        time_disc = time_all[gd.subset_node_indices['disc']]
+        time_segends = time_all[gd.subset_node_indices['segment_ends']]
+
+        time_phase_all = p['phase0.time_phase']
+        time_phase_col = time_phase_all[gd.subset_node_indices['col']]
+        time_phase_disc = time_phase_all[gd.subset_node_indices['disc']]
+        time_phase_segends = time_phase_all[gd.subset_node_indices['segment_ends']]
+
+        assert_rel_error(self, p['phase0.rhs_disc.time_phase'][-1], 1.8016, tolerance=1.0E-3)
+
+        assert_rel_error(self, p['phase0.rhs_disc.t_initial'], p['phase0.t_initial'])
+        assert_rel_error(self, p['phase0.rhs_col.t_initial'], p['phase0.t_initial'])
+
+        assert_rel_error(self, p['phase0.rhs_disc.t_duration'], p['phase0.t_duration'])
+        assert_rel_error(self, p['phase0.rhs_col.t_duration'], p['phase0.t_duration'])
+
+        assert_rel_error(self, p['phase0.rhs_disc.time_phase'], time_phase_disc)
+        assert_rel_error(self, p['phase0.rhs_col.time_phase'], time_phase_col)
+
+        assert_rel_error(self, p['phase0.rhs_disc.time'], time_disc)
+        assert_rel_error(self, p['phase0.rhs_col.time'], time_col)
+
+        exp_out = p.model.phase0.simulate()
+
+        for iseg in range(num_seg):
+            seg_comp_i = exp_out.model.phase0._get_subsystem('segments.segment_{0}'.format(iseg))
+            t_initial_i = seg_comp_i.ode_integration_interface.prob.get_val('ode.t_initial')
+            t_duration_i = seg_comp_i.ode_integration_interface.prob.get_val('ode.t_duration')
+            time_phase_i = seg_comp_i.ode_integration_interface.prob.get_val('ode.time_phase')
+            time_i = seg_comp_i.ode_integration_interface.prob.get_val('ode.time')
+
+            # Since the phase has simulated, all times should be equal to their respective value
+            # at the end of each segment.
+            assert_rel_error(self, t_initial_i, p['phase0.t_initial'])
+            assert_rel_error(self, t_duration_i, p['phase0.t_duration'])
+            assert_rel_error(self, time_phase_i, time_phase_segends[2*iseg + 1], tolerance=1.0E-12)
+            assert_rel_error(self, time_i, time_segends[2*iseg + 1], tolerance=1.0E-12)
+
+    def test_radau(self):
+        num_seg = 20
+        p = self._make_problem('radau-ps', num_seg)
+
+        # Solve for the optimal trajectory
+        p.run_driver()
+
+        gd = p.model.phase0.grid_data
+
+        time_all = p['phase0.time']
+        time_segends = time_all[gd.subset_node_indices['segment_ends']]
+
+        time_phase_all = p['phase0.time_phase']
+        time_phase_segends = time_phase_all[gd.subset_node_indices['segment_ends']]
+
+        assert_rel_error(self, p['phase0.rhs_all.time_phase'][-1], 1.8016, tolerance=1.0E-3)
+
+        assert_rel_error(self, p['phase0.rhs_all.t_initial'], p['phase0.t_initial'])
+
+        assert_rel_error(self, p['phase0.rhs_all.t_duration'], p['phase0.t_duration'])
+
+        assert_rel_error(self, p['phase0.rhs_all.time_phase'], time_phase_all)
+
+        assert_rel_error(self, p['phase0.rhs_all.time'], time_all)
+
+        exp_out = p.model.phase0.simulate()
+
+        for iseg in range(num_seg):
+            seg_comp_i = exp_out.model.phase0._get_subsystem('segments.segment_{0}'.format(iseg))
+            t_initial_i = seg_comp_i.ode_integration_interface.prob.get_val('ode.t_initial')
+            t_duration_i = seg_comp_i.ode_integration_interface.prob.get_val('ode.t_duration')
+            time_phase_i = seg_comp_i.ode_integration_interface.prob.get_val('ode.time_phase')
+            time_i = seg_comp_i.ode_integration_interface.prob.get_val('ode.time')
+
+            # Since the phase has simulated, all times should be equal to their respective value
+            # at the end of each segment.
+            assert_rel_error(self, t_initial_i, p['phase0.t_initial'])
+            assert_rel_error(self, t_duration_i, p['phase0.t_duration'])
+            assert_rel_error(self, time_phase_i, time_phase_segends[2 * iseg + 1],
+                             tolerance=1.0E-12)
+            assert_rel_error(self, time_i, time_segends[2 * iseg + 1], tolerance=1.0E-12)
+
+    def test_runge_kutta(self):
+        num_seg = 20
+        p = self._make_problem('runge-kutta', num_seg)
+
+        # Solve for the optimal trajectory
+        p.run_driver()
+
+        gd = p.model.phase0.grid_data
+
+        time_all = p['phase0.time']
+        time_segends = time_all[gd.subset_node_indices['segment_ends']]
+
+        time_phase_all = p['phase0.time_phase']
+        time_phase_segends = time_phase_all[gd.subset_node_indices['segment_ends']]
+
+        assert_rel_error(self, p['phase0.rk_solve_group.ode.time_phase'][-1], 1.8016,
+                         tolerance=1.0E-3)
+
+        assert_rel_error(self, p['phase0.rk_solve_group.ode.t_initial'], p['phase0.t_initial'])
+
+        assert_rel_error(self, p['phase0.rk_solve_group.ode.t_duration'], p['phase0.t_duration'])
+
+        assert_rel_error(self, p['phase0.rk_solve_group.ode.time_phase'], time_phase_all)
+
+        assert_rel_error(self, p['phase0.rk_solve_group.ode.time'], time_all)
+
+        exp_out = p.model.phase0.simulate()
+
+        for iseg in range(num_seg):
+            seg_comp_i = exp_out.model.phase0._get_subsystem('segments.segment_{0}'.format(iseg))
+            t_initial_i = seg_comp_i.ode_integration_interface.prob.get_val('ode.t_initial')
+            t_duration_i = seg_comp_i.ode_integration_interface.prob.get_val('ode.t_duration')
+            time_phase_i = seg_comp_i.ode_integration_interface.prob.get_val('ode.time_phase')
+            time_i = seg_comp_i.ode_integration_interface.prob.get_val('ode.time')
+
+            # Since the phase has simulated, all times should be equal to their respective value
+            # at the end of each segment.
+            assert_rel_error(self, t_initial_i, p['phase0.t_initial'])
+            assert_rel_error(self, t_duration_i, p['phase0.t_duration'])
+            assert_rel_error(self, time_phase_i, time_phase_segends[2 * iseg + 1],
+                             tolerance=1.0E-12)
+            assert_rel_error(self, time_i, time_segends[2 * iseg + 1], tolerance=1.0E-12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dymos/phases/tests/test_time_targets.py
+++ b/dymos/phases/tests/test_time_targets.py
@@ -265,6 +265,8 @@ class TestPhaseTimeTargets(unittest.TestCase):
         time_phase_all = p['phase0.time_phase']
         time_phase_segends = time_phase_all[gd.subset_node_indices['segment_ends']]
 
+        # Test the iteration ODE
+
         assert_rel_error(self, p['phase0.rk_solve_group.ode.time_phase'][-1], 1.8016,
                          tolerance=1.0E-3)
 
@@ -275,6 +277,19 @@ class TestPhaseTimeTargets(unittest.TestCase):
         assert_rel_error(self, p['phase0.rk_solve_group.ode.time_phase'], time_phase_all)
 
         assert_rel_error(self, p['phase0.rk_solve_group.ode.time'], time_all)
+
+        # Now test the final ODE
+
+        assert_rel_error(self, p['phase0.ode.time_phase'][-1], 1.8016,
+                         tolerance=1.0E-3)
+
+        assert_rel_error(self, p['phase0.ode.t_initial'], p['phase0.t_initial'])
+
+        assert_rel_error(self, p['phase0.ode.t_duration'], p['phase0.t_duration'])
+
+        assert_rel_error(self, p['phase0.ode.time_phase'], time_phase_segends)
+
+        assert_rel_error(self, p['phase0.ode.time'], time_segends)
 
         exp_out = p.model.phase0.simulate()
 


### PR DESCRIPTION
Added ODE targets for t_initial and t_duration via the @declare_time decorator.  
Unlike time and time_phase, t_initial and t_duration are assumed to have **static** targets.
Added tests to ensure that ODE's get the correct value of t_initial, t_duration, time_phase, and time.

resolves #114, resolves #109 
