### PR TITLE
RungeKuttaPhase updates

### DIFF
--- a/dymos/examples/brachistochrone/test/test_doc_brachistochrone_rk4.py
+++ b/dymos/examples/brachistochrone/test/test_doc_brachistochrone_rk4.py
@@ -102,16 +102,15 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         phase = Phase('runge-kutta',
                       ode_class=BrachistochroneODE,
                       num_segments=20,
-                      method='rk4',
-                      direction='backward')
+                      method='rk4')
 
         p.model.add_subsystem('phase0', phase)
 
         phase.set_time_options(initial_bounds=(0, 0), duration_bounds=(0.5, 2.0))
 
-        phase.set_state_options('x', fix_final=True)
-        phase.set_state_options('y', fix_final=True)
-        phase.set_state_options('v', fix_final=False)
+        phase.set_state_options('x', fix_initial=False, fix_final=True, time_direction='backward')
+        phase.set_state_options('y', fix_initial=False, fix_final=True, time_direction='backward')
+        phase.set_state_options('v', fix_initial=False, fix_final=False, time_direction='backward')
 
         phase.add_control('theta', units='deg', lower=0.01, upper=179.9, ref0=0, ref=180.0,
                           rate_continuity=True, rate2_continuity=True)

--- a/dymos/phases/options.py
+++ b/dymos/phases/options.py
@@ -318,6 +318,11 @@ class StateOptionsDictionary(OptionsDictionary):
                      desc='setting to control if segment collocation defects are '
                           'solved with a newton solver')
 
+        self.declare('time_direction', default='forward', values=('forward', 'backward'),
+                     desc='Whether the numerical propagation occurs forward or backward '
+                          'in time for this state.  This poses restrictions on whether '
+                          'states can have fixed or connected initial and final values.')
+
 
 class TimeOptionsDictionary(OptionsDictionary):
     """

--- a/dymos/phases/phase_base.py
+++ b/dymos/phases/phase_base.py
@@ -100,7 +100,7 @@ class PhaseBase(Group):
                           fix_initial=False, fix_final=False, initial_bounds=None,
                           final_bounds=None, lower=None, upper=None, scaler=None, adder=None,
                           ref=None, ref0=None, defect_scaler=1.0, defect_ref=None,
-                          solve_segments=False):
+                          solve_segments=False, time_direction='forward'):
         """
         Set options that apply the EOM state variable of the given name.
 
@@ -143,6 +143,9 @@ class PhaseBase(Group):
             If True, a solver will be used to converge the collocation defects within a segment.
             Note that the state continuity defects between segements will still be
             handled by the optimizer.
+        time_direction : str
+            The direction of time propagation for this state when solve_segments is True.  Must be
+            one of 'forward' or 'backward'.
 
         """
         if units is not _unspecified:
@@ -161,6 +164,7 @@ class PhaseBase(Group):
         self.state_options[name]['defect_scaler'] = defect_scaler
         self.state_options[name]['defect_ref'] = defect_ref
         self.state_options[name]['solve_segments'] = solve_segments
+        self.state_options[name]['time_direction'] = time_direction
 
     def add_control(self, name, val=0.0, units=0, opt=True, lower=None, upper=None,
                     fix_initial=False, fix_final=False,

--- a/dymos/phases/runge_kutta/components/runge_kutta_state_continuity_comp.py
+++ b/dymos/phases/runge_kutta/components/runge_kutta_state_continuity_comp.py
@@ -27,22 +27,17 @@ class RungeKuttaStateContinuityComp(ImplicitComponent):
         self.options.declare('num_segments', types=int,
                              desc='The number of segments (timesteps) in the phase.')
 
-        self.options.declare('direction', default='forward', values=('forward', 'backward'),
-                             desc='Whether the numerical propagation occurs forwards or backwards '
-                                  'in time.  This poses restrictions on whether states can have '
-                                  'fixed initial/final values.')
-
     def setup(self):
         """
         Define the independent variables, output variables, and partials.
         """
         num_seg = self.options['num_segments']
         state_options = self.options['state_options']
-        direction = self.options['direction']
 
         self._var_names = {}
 
         for state_name, options in iteritems(state_options):
+            direction = options['time_direction']
 
             self._var_names[state_name] = {
                 'states': 'states:{0}'.format(state_name),
@@ -106,10 +101,10 @@ class RungeKuttaStateContinuityComp(ImplicitComponent):
             unscaled, dimensional residuals written to via residuals[key]
         """
         state_options = self.options['state_options']
-        direction = self.options['direction']
 
         for state_name, options in iteritems(state_options):
-            names = self._var_names[state_name]\
+            names = self._var_names[state_name]
+            direction = options['time_direction']
 
             x_i = outputs[names['states']][:-1, ...]
             x_f = outputs[names['states']][1:, ...]

--- a/dymos/phases/runge_kutta/components/runge_kutta_state_continuity_iter_group.py
+++ b/dymos/phases/runge_kutta/components/runge_kutta_state_continuity_iter_group.py
@@ -34,11 +34,6 @@ class RungeKuttaStateContinuityIterGroup(Group):
         self.options.declare('time_units', default=None, allow_none=True, types=string_types,
                              desc='Units of the integration variable')
 
-        self.options.declare('direction', default='forward', values=('forward', 'backward'),
-                             desc='Whether the numerical propagation occurs forward or backward '
-                                  'in time.  This poses restrictions on whether states can have '
-                                  'fixed initial/final values.')
-
         self.options.declare('ode_class',
                              desc='System defining the ODE')
 
@@ -89,8 +84,7 @@ class RungeKuttaStateContinuityIterGroup(Group):
         self.add_subsystem('continuity_comp',
                            RungeKuttaStateContinuityComp(
                                num_segments=self.options['num_segments'],
-                               state_options=self.options['state_options'],
-                               direction=self.options['direction']),
+                               state_options=self.options['state_options']),
                            promotes_inputs=['state_integrals:*'],
                            promotes_outputs=['states:*'])
 

--- a/dymos/phases/runge_kutta/components/test/test_rk_continuity_comp.py
+++ b/dymos/phases/runge_kutta/components/test/test_rk_continuity_comp.py
@@ -3,7 +3,6 @@ from __future__ import print_function, division, absolute_import
 import unittest
 
 import numpy as np
-from numpy.testing import assert_almost_equal
 
 from openmdao.api import Problem, Group, NonlinearRunOnce, NonlinearBlockGS, \
     NewtonSolver, DirectSolver
@@ -17,7 +16,8 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
 
     def test_continuity_comp_no_iteration_fwd(self):
         num_seg = 4
-        state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y']}}
+        state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'],
+                               'time_direction': 'forward'}}
 
         p = Problem(model=Group())
 
@@ -81,7 +81,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_nonlinearblockgs_fwd(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False}}
+                               'fix_final': False, 'time_direction': 'forward'}}
 
         p = Problem(model=Group())
 
@@ -145,7 +145,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_newton_fwd(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False}}
+                               'fix_final': False, 'time_direction': 'forward'}}
 
         p = Problem(model=Group())
 
@@ -198,16 +198,16 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
-    def test_continuity_comp_no_iteration_backwards(self):
+    def test_continuity_comp_no_iteration_backward(self):
         num_seg = 4
-        state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y']}}
+        state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'],
+                               'time_direction': 'backward'}}
 
         p = Problem(model=Group())
 
         p.model.add_subsystem('continuity_comp',
                               RungeKuttaStateContinuityComp(num_segments=num_seg,
-                                                            state_options=state_options,
-                                                            direction='backward'),
+                                                            state_options=state_options),
                               promotes_inputs=['*'],
                               promotes_outputs=['*'])
 
@@ -262,17 +262,16 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
-    def test_continuity_comp_nonlinearblockgs_backwards(self):
+    def test_continuity_comp_nonlinearblockgs_backward(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False}}
+                               'fix_final': False, 'time_direction': 'backward'}}
 
         p = Problem(model=Group())
 
         p.model.add_subsystem('continuity_comp',
                               RungeKuttaStateContinuityComp(num_segments=num_seg,
-                                                            state_options=state_options,
-                                                            direction='backward'),
+                                                            state_options=state_options),
                               promotes_inputs=['*'],
                               promotes_outputs=['*'])
 
@@ -330,14 +329,13 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_newton_backwards(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False}}
+                               'fix_final': False, 'time_direction': 'backward'}}
 
         p = Problem(model=Group())
 
         p.model.add_subsystem('continuity_comp',
                               RungeKuttaStateContinuityComp(num_segments=num_seg,
-                                                            state_options=state_options,
-                                                            direction='backward'),
+                                                            state_options=state_options),
                               promotes_inputs=['*'],
                               promotes_outputs=['*'])
 

--- a/dymos/phases/runge_kutta/components/test/test_rk_continuity_iter_group.py
+++ b/dymos/phases/runge_kutta/components/test/test_rk_continuity_iter_group.py
@@ -19,7 +19,7 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
     def test_continuity_comp_no_iteration(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False}}
+                               'fix_final': False, 'time_direction': 'forward'}}
 
         p = Problem(model=Group())
 
@@ -115,7 +115,7 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
     def test_continuity_comp_newtonsolver(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False}}
+                               'fix_final': False, 'time_direction': 'forward'}}
 
         p = Problem(model=Group())
 

--- a/dymos/phases/runge_kutta/runge_kutta_phase.py
+++ b/dymos/phases/runge_kutta/runge_kutta_phase.py
@@ -249,7 +249,7 @@ class RungeKuttaPhase(PhaseBase):
                 if options['fix_initial']:
                     if options['time_direction'] == 'backward':
                         raise ValueError('Cannot specify \'fix_initial=True\' and specify '
-                                         'direction=\'backward\' for state {0} in '
+                                         'time_direction=\'backward\' for state {0} in '
                                          'RungeKuttaPhase'.format(state_name))
                     if options['initial_bounds'] is not None:
                         raise ValueError('Cannot specify \'fix_initial=True\' and specify '
@@ -264,7 +264,7 @@ class RungeKuttaPhase(PhaseBase):
                 if options['fix_final']:
                     if options['time_direction'] == 'forward':
                         raise ValueError('Cannot specify \'fix_final=True\' and specify '
-                                         'direction=\'forrward\' for state {0} in '
+                                         'time_direction=\'forward\' for state {0} in '
                                          'RungeKuttaPhase'.format(state_name))
                     if options['final_bounds'] is not None:
                         raise ValueError('Cannot specify \'fix_final=True\' and specify '
@@ -768,7 +768,8 @@ class RungeKuttaPhase(PhaseBase):
     def set_state_options(self, name, units=_unspecified, val=1.0,
                           fix_initial=False, fix_final=False, initial_bounds=None,
                           final_bounds=None, lower=None, upper=None, scaler=None, adder=None,
-                          ref=None, ref0=None, defect_scaler=1.0, defect_ref=None):
+                          ref=None, ref0=None, defect_scaler=1.0, defect_ref=None,
+                          time_direction='forward'):
         """
         Set options that apply the EOM state variable of the given name.
 
@@ -790,6 +791,8 @@ class RungeKuttaPhase(PhaseBase):
         fix_final : bool(False)
             If True, omit the final value of the state from the design variables (prevent the
             optimizer from changing it).
+        time_direction : str('forward')
+            The direction of propagation for this state variable, either 'forward' or 'backward'.
         lower : float or ndarray or None (None)
             The lower bound of the state at the nodes of the phase.
         upper : float or ndarray or None (None)
@@ -823,7 +826,8 @@ class RungeKuttaPhase(PhaseBase):
                                                        ref=ref,
                                                        ref0=ref0,
                                                        defect_scaler=defect_scaler,
-                                                       defect_ref=defect_ref)
+                                                       defect_ref=defect_ref,
+                                                       time_direction=time_direction)
 
     def add_objective(self, name, loc='final', index=None, shape=(1,), ref=None, ref0=None,
                       adder=None, scaler=None, parallel_deriv_color=None,

--- a/dymos/phases/runge_kutta/test/test_rk4_simple_integration.py
+++ b/dymos/phases/runge_kutta/test/test_rk4_simple_integration.py
@@ -4,12 +4,11 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, ExplicitComponent, NonlinearBlockGS, NonlinearRunOnce
+from openmdao.api import Problem, Group
 from openmdao.utils.assert_utils import assert_rel_error
 
-from dymos import RungeKuttaPhase, declare_time, declare_state
+from dymos import RungeKuttaPhase
 from dymos.phases.runge_kutta.test.rk_test_ode import TestODE, _test_ode_solution
-from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
 
 class TestRK4SimpleIntegration(unittest.TestCase):
@@ -52,11 +51,11 @@ class TestRK4SimpleIntegration(unittest.TestCase):
             RungeKuttaPhase(num_segments=4,
                             method='rk4',
                             ode_class=TestODE,
-                            direction='backward',
                             k_solver_options={'iprint': 2},
                             continuity_solver_options={'iprint': 2, 'solve_subsystems': True}))
 
         phase.set_time_options(fix_initial=True, fix_duration=True)
+        phase.set_state_options('y', fix_initial=False, time_direction='backward')
 
         phase.add_timeseries_output('ydot', output_name='state_rate:y', units='m/s')
 


### PR DESCRIPTION
- Adds state option `time_direction = 'forward'|'backward'` for use in RungeKuttaPhase and solved pseudospectral phases.
- Started adding tests for phase connectivity in trajectories.
- continuity_solver_options now has `{'solve_subsystems': True}` to improve performance on nonlinear systems.

Resolves #135 