### PR TITLE
RK Phase linkages

### DIFF
--- a/dymos/examples/battery_multibranch/test/test_multibranch_trajectory.py
+++ b/dymos/examples/battery_multibranch/test/test_multibranch_trajectory.py
@@ -9,7 +9,7 @@ import unittest
 from openmdao.api import Problem, pyOptSparseDriver, ScipyOptimizeDriver, DirectSolver
 from openmdao.utils.assert_utils import assert_rel_error
 
-from dymos import Phase, Trajectory
+from dymos import Phase, Trajectory, RungeKuttaPhase
 from dymos.examples.battery_multibranch.battery_multibranch_ode import BatteryODE
 from dymos.utils.lgl import lgl
 
@@ -457,6 +457,261 @@ class TestBatteryBranchingPhases(unittest.TestCase):
         assert_rel_error(self, soc1[-1], 0.23794217, 1e-6)
         assert_rel_error(self, soc1b[-1], 0.0281523, 1e-6)
         assert_rel_error(self, soc1m[-1], 0.18625395, 1e-6)
+
+
+class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
+
+    def test_constraint_linkages_rk(self):
+        prob = Problem()
+
+        if optimizer == 'SNOPT':
+            opt = prob.driver = pyOptSparseDriver()
+            opt.options['optimizer'] = optimizer
+            opt.options['dynamic_simul_derivs'] = True
+
+            opt.opt_settings['Major iterations limit'] = 1000
+            opt.opt_settings['Major feasibility tolerance'] = 1.0E-6
+            opt.opt_settings['Major optimality tolerance'] = 1.0E-6
+            opt.opt_settings["Linesearch tolerance"] = 0.10
+            opt.opt_settings['iSumm'] = 6
+
+        else:
+            opt = prob.driver = ScipyOptimizeDriver()
+            opt.options['dynamic_simul_derivs'] = True
+
+        num_seg = 20
+        seg_ends, _ = lgl(num_seg + 1)
+
+        traj = prob.model.add_subsystem('traj', Trajectory())
+
+        # First phase: normal operation.
+
+        phase0 = RungeKuttaPhase(ode_class=BatteryODE,
+                                 num_segments=num_seg,
+                                 method='rk4',
+                                 compressed=False)
+
+        traj_p0 = traj.add_phase('phase0', phase0)
+
+        traj_p0.set_time_options(fix_initial=True, fix_duration=True)
+        traj_p0.set_state_options('state_of_charge', fix_initial=True, fix_final=False)
+
+        # Second phase: normal operation.
+
+        phase1 = RungeKuttaPhase(ode_class=BatteryODE,
+                                 num_segments=num_seg,
+                                 segment_ends=seg_ends,
+                                 method='rk4',
+                                 compressed=False)
+
+        traj_p1 = traj.add_phase('phase1', phase1)
+
+        traj_p1.set_time_options(fix_initial=False, fix_duration=True)
+        traj_p1.set_state_options('state_of_charge', fix_initial=False, fix_final=False)
+        traj_p1.add_objective('time', loc='final')
+
+        # Second phase, but with battery failure.
+
+        phase1_bfail = RungeKuttaPhase(ode_class=BatteryODE,
+                                       num_segments=num_seg,
+                                       segment_ends=seg_ends,
+                                       ode_init_kwargs={'num_battery': 2},
+                                       compressed=False)
+
+        traj_p1_bfail = traj.add_phase('phase1_bfail', phase1_bfail)
+
+        traj_p1_bfail.set_time_options(fix_initial=False, fix_duration=True)
+        traj_p1_bfail.set_state_options('state_of_charge', fix_initial=False, fix_final=False)
+
+        # Second phase, but with motor failure.
+
+        phase1_mfail = RungeKuttaPhase(ode_class=BatteryODE,
+                                       num_segments=num_seg,
+                                       segment_ends=seg_ends,
+                                       ode_init_kwargs={'num_motor': 2},
+                                       compressed=False)
+
+        traj_p1_mfail = traj.add_phase('phase1_mfail', phase1_mfail)
+
+        traj_p1_mfail.set_time_options(fix_initial=False, fix_duration=True)
+        traj_p1_mfail.set_state_options('state_of_charge', fix_initial=False, fix_final=False)
+
+        traj.link_phases(phases=['phase0', 'phase1'], vars=['state_of_charge', 'time'])
+        traj.link_phases(phases=['phase0', 'phase1_bfail'], vars=['state_of_charge', 'time'])
+        traj.link_phases(phases=['phase0', 'phase1_mfail'], vars=['state_of_charge', 'time'])
+
+        prob.model.options['assembled_jac_type'] = 'csc'
+        prob.model.linear_solver = DirectSolver(assemble_jac=True)
+
+        prob.setup()
+
+        prob['traj.phase0.t_initial'] = 0
+        prob['traj.phase0.t_duration'] = 1.0*3600
+
+        prob['traj.phase1.t_initial'] = 1.0*3600
+        prob['traj.phase1.t_duration'] = 1.0*3600
+
+        prob['traj.phase1_bfail.t_initial'] = 1.0*3600
+        prob['traj.phase1_bfail.t_duration'] = 1.0*3600
+
+        prob['traj.phase1_mfail.t_initial'] = 1.0*3600
+        prob['traj.phase1_mfail.t_duration'] = 1.0*3600
+
+        prob.set_solver_print(level=0)
+        prob.run_driver()
+
+        soc0 = prob['traj.phase0.states:state_of_charge']
+        soc1 = prob['traj.phase1.states:state_of_charge']
+        soc1b = prob['traj.phase1_bfail.states:state_of_charge']
+        soc1m = prob['traj.phase1_mfail.states:state_of_charge']
+
+        # Final value for State of Charge in each segment should be a good test.
+        assert_rel_error(self, soc0[-1], 0.63464982, 1e-4)
+        assert_rel_error(self, soc1[-1], 0.23794217, 1e-4)
+        assert_rel_error(self, soc1b[-1], 0.0281523, 1e-4)
+        assert_rel_error(self, soc1m[-1], 0.18625395, 1e-4)
+
+    def test_single_phase_reverse_propagation_rk(self):
+        prob = Problem()
+
+        num_seg = 10
+        seg_ends, _ = lgl(num_seg + 1)
+
+        # First phase: normal operation.
+
+        phase0 = RungeKuttaPhase(ode_class=BatteryODE,
+                                 num_segments=num_seg,
+                                 method='rk4',
+                                 compressed=False)
+
+        traj_p0 = prob.model.add_subsystem('phase0', phase0)
+
+        traj_p0.set_time_options(fix_initial=True, fix_duration=True)
+        traj_p0.set_state_options('state_of_charge', fix_initial=True, fix_final=False)
+
+        prob.setup()
+
+        prob['phase0.t_initial'] = 0
+        prob['phase0.t_duration'] = -1.0*3600
+        prob['phase0.states:state_of_charge'][:] = 0.63464982
+
+        prob.set_solver_print(level=0)
+        prob.run_model()
+
+        soc0 = prob['phase0.states:state_of_charge']
+        assert_rel_error(self, soc0[-1], 1.0, 1e-6)
+
+    def test_connected_linkages_rk(self):
+        prob = Problem()
+
+        if optimizer == 'SNOPT':
+            opt = prob.driver = pyOptSparseDriver()
+            opt.options['optimizer'] = optimizer
+            opt.options['dynamic_simul_derivs'] = True
+
+            opt.opt_settings['Major iterations limit'] = 1000
+            opt.opt_settings['Major feasibility tolerance'] = 1.0E-6
+            opt.opt_settings['Major optimality tolerance'] = 1.0E-6
+            opt.opt_settings["Linesearch tolerance"] = 0.10
+            opt.opt_settings['iSumm'] = 6
+
+        else:
+            opt = prob.driver = ScipyOptimizeDriver()
+            opt.options['dynamic_simul_derivs'] = True
+
+        num_seg = 20
+        seg_ends, _ = lgl(num_seg + 1)
+
+        traj = prob.model.add_subsystem('traj', Trajectory())
+
+        # First phase: normal operation.
+
+        phase0 = RungeKuttaPhase(ode_class=BatteryODE,
+                                 num_segments=num_seg,
+                                 method='rk4',
+                                 compressed=False)
+
+        traj_p0 = traj.add_phase('phase0', phase0)
+
+        traj_p0.set_time_options(fix_initial=True, fix_duration=True)
+        traj_p0.set_state_options('state_of_charge', fix_initial=True, fix_final=False)
+
+        # Second phase: normal operation.
+
+        phase1 = RungeKuttaPhase(ode_class=BatteryODE,
+                                 num_segments=num_seg,
+                                 method='rk4',
+                                 compressed=True)
+
+        traj_p1 = traj.add_phase('phase1', phase1)
+
+        traj_p1.set_time_options(fix_initial=False, fix_duration=True)
+        traj_p1.set_state_options('state_of_charge', fix_initial=False, fix_final=False)
+        traj_p1.add_objective('time', loc='final')
+
+        # Second phase, but with battery failure.
+
+        phase1_bfail = RungeKuttaPhase(ode_class=BatteryODE,
+                                       num_segments=num_seg,
+                                       method='rk4',
+                                       ode_init_kwargs={'num_battery': 2},
+                                       compressed=False)
+
+        traj_p1_bfail = traj.add_phase('phase1_bfail', phase1_bfail)
+
+        traj_p1_bfail.set_time_options(fix_initial=False, fix_duration=True)
+        traj_p1_bfail.set_state_options('state_of_charge', fix_initial=False, fix_final=False)
+
+        # Second phase, but with motor failure.
+
+        phase1_mfail = RungeKuttaPhase(ode_class=BatteryODE,
+                                       num_segments=num_seg,
+                                       method='rk4',
+                                       ode_init_kwargs={'num_motor': 2},
+                                       compressed=False)
+
+        traj_p1_mfail = traj.add_phase('phase1_mfail', phase1_mfail)
+
+        traj_p1_mfail.set_time_options(fix_initial=False, fix_duration=True)
+        traj_p1_mfail.set_state_options('state_of_charge', fix_initial=False, fix_final=False)
+
+        traj.link_phases(phases=['phase0', 'phase1'], vars=['state_of_charge', 'time'],
+                         connected=True)
+        traj.link_phases(phases=['phase0', 'phase1_bfail'], vars=['state_of_charge', 'time'],
+                         connected=True)
+        traj.link_phases(phases=['phase0', 'phase1_mfail'], vars=['state_of_charge', 'time'],
+                         connected=True)
+
+        prob.model.options['assembled_jac_type'] = 'csc'
+        prob.model.linear_solver = DirectSolver(assemble_jac=True)
+
+        prob.setup()
+
+        prob['traj.phase0.t_initial'] = 0
+        prob['traj.phase0.t_duration'] = 1.0*3600
+
+        prob['traj.phase1.t_initial'] = 1.0*3600
+        prob['traj.phase1.t_duration'] = 1.0*3600
+
+        prob['traj.phase1_bfail.t_initial'] = 1.0*3600
+        prob['traj.phase1_bfail.t_duration'] = 1.0*3600
+
+        prob['traj.phase1_mfail.t_initial'] = 1.0*3600
+        prob['traj.phase1_mfail.t_duration'] = 1.0*3600
+
+        prob.set_solver_print(level=0)
+        prob.run_driver()
+
+        soc0 = prob['traj.phase0.states:state_of_charge']
+        soc1 = prob['traj.phase1.states:state_of_charge']
+        soc1b = prob['traj.phase1_bfail.states:state_of_charge']
+        soc1m = prob['traj.phase1_mfail.states:state_of_charge']
+
+        # Final value for State of Chrage in each segment should be a good test.
+        assert_rel_error(self, soc0[-1], 0.63464982, 5e-5)
+        assert_rel_error(self, soc1[-1], 0.23794217, 5e-5)
+        assert_rel_error(self, soc1b[-1], 0.0281523, 5e-5)
+        assert_rel_error(self, soc1m[-1], 0.18625395, 5e-5)
 
 
 if __name__ == '__main__':

--- a/dymos/examples/brachistochrone/test/test_doc_brachistochrone_rk4.py
+++ b/dymos/examples/brachistochrone/test/test_doc_brachistochrone_rk4.py
@@ -108,9 +108,9 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
 
         phase.set_time_options(initial_bounds=(0, 0), duration_bounds=(0.5, 2.0))
 
-        phase.set_state_options('x', fix_initial=False, fix_final=True, time_direction='backward')
-        phase.set_state_options('y', fix_initial=False, fix_final=True, time_direction='backward')
-        phase.set_state_options('v', fix_initial=False, fix_final=False, time_direction='backward')
+        phase.set_state_options('x', fix_initial=False, fix_final=True, propagation='backward')
+        phase.set_state_options('y', fix_initial=False, fix_final=True, propagation='backward')
+        phase.set_state_options('v', fix_initial=False, fix_final=False, propagation='backward')
 
         phase.add_control('theta', units='deg', lower=0.01, upper=179.9, ref0=0, ref=180.0,
                           rate_continuity=True, rate2_continuity=True)

--- a/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
@@ -1,0 +1,481 @@
+from __future__ import print_function, division, absolute_import
+
+import os
+import unittest
+
+import matplotlib
+matplotlib.use('Agg')
+
+
+class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
+
+    # @classmethod
+    # def tearDownClass(cls):
+    #     for filename in ['coloring.json', 'two_burn_orbit_raise_example_for_docs.db', 'SLSQP.out',
+    #                      'SNOPT_print.out', 'SNOPT_summary.out', 'SLSQP.out']:
+    #         if os.path.exists(filename):
+    #             os.remove(filename)
+
+    def test_two_burn_orbit_raise_gl_rkfwd_gl_constrained(self):
+        import numpy as np
+
+        import matplotlib.pyplot as plt
+
+        from openmdao.api import Problem, Group, pyOptSparseDriver, DirectSolver, SqliteRecorder
+        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.general_utils import set_pyoptsparse_opt
+
+        from dymos import GaussLobattoPhase, RungeKuttaPhase, Trajectory
+        from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
+
+        traj = Trajectory()
+        p = Problem(model=Group())
+        p.model.add_subsystem('traj', traj)
+
+        p.driver = pyOptSparseDriver()
+        _, optimizer = set_pyoptsparse_opt('SNOPT', fallback=False)
+        p.driver.options['optimizer'] = optimizer
+        p.driver.opt_settings['Verify level'] = 3
+        p.driver.opt_settings['iSumm'] = 6
+
+        # Setting this to True will cause the SNOPT derivative check to fail.
+        p.driver.options['dynamic_simul_derivs'] = True
+
+        traj.add_design_parameter('c', opt=False, val=1.5, units='DU/TU')
+
+        # First Phase (burn)
+
+        burn1 = GaussLobattoPhase(ode_class=FiniteBurnODE, num_segments=10,
+                                  transcription_order=3, compressed=True)
+
+        burn1 = traj.add_phase('burn1', burn1)
+
+        burn1.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
+        burn1.set_state_options('r', fix_initial=True, fix_final=False)
+        burn1.set_state_options('theta', fix_initial=True, fix_final=False)
+        burn1.set_state_options('vr', fix_initial=True, fix_final=False)
+        burn1.set_state_options('vt', fix_initial=True, fix_final=False)
+        burn1.set_state_options('accel', fix_initial=True, fix_final=False)
+        burn1.set_state_options('deltav', fix_initial=True, fix_final=False)
+        burn1.add_control('u1', rate_continuity=True, rate2_continuity=True, units='deg',
+                          scaler=0.01, lower=-30, upper=30)
+
+        # Second Phase (Coast)
+
+        coast = RungeKuttaPhase(ode_class=FiniteBurnODE, num_segments=20, compressed=True)
+
+        traj.add_phase('coast', coast)
+
+        coast.set_time_options(initial_bounds=(0.5, 20), duration_bounds=(.5, 10), duration_ref=10)
+        coast.set_state_options('r', fix_initial=False, fix_final=False,
+                                time_direction='forward')
+        coast.set_state_options('theta', fix_initial=False, fix_final=False,
+                                time_direction='forward')
+        coast.set_state_options('vr', fix_initial=False, fix_final=False,
+                                time_direction='forward')
+        coast.set_state_options('vt', fix_initial=False, fix_final=False,
+                                time_direction='forward')
+        coast.set_state_options('accel', fix_initial=True, fix_final=False,
+                                time_direction='forward')
+        coast.set_state_options('deltav', fix_initial=False, fix_final=False,
+                                time_direction='forward')
+        coast.add_design_parameter('u1', opt=False, val=0.0)
+
+        # Third Phase (burn)
+
+        burn2 = GaussLobattoPhase(ode_class=FiniteBurnODE, num_segments=10, transcription_order=3,
+                                  compressed=True)
+
+        traj.add_phase('burn2', burn2)
+
+        burn2.set_time_options(initial_bounds=(0.5, 20), duration_bounds=(.5, 10), initial_ref=10)
+        burn2.set_state_options('r', fix_initial=False, fix_final=True)
+        burn2.set_state_options('theta', fix_initial=False, fix_final=False)
+        burn2.set_state_options('vr', fix_initial=False, fix_final=True)
+        burn2.set_state_options('vt', fix_initial=False, fix_final=True)
+        burn2.set_state_options('accel', fix_initial=False, fix_final=False, defect_scaler=1.0)
+        burn2.set_state_options('deltav', fix_initial=False, fix_final=False, defect_scaler=1.0)
+        burn2.add_control('u1', rate_continuity=True, rate2_continuity=True, units='deg',
+                          scaler=0.01, lower=-30, upper=30)
+
+        burn2.add_objective('deltav', loc='final', scaler=1.0)
+
+        burn1.add_timeseries_output('pos_x', units='DU')
+        coast.add_timeseries_output('pos_x', units='DU')
+        burn2.add_timeseries_output('pos_x', units='DU')
+
+        burn1.add_timeseries_output('pos_y', units='DU')
+        coast.add_timeseries_output('pos_y', units='DU')
+        burn2.add_timeseries_output('pos_y', units='DU')
+
+        # Link Phases
+        traj.link_phases(phases=['burn1', 'coast', 'burn2'],
+                         vars=['time', 'r', 'theta', 'vr', 'vt', 'deltav'])
+        traj.link_phases(phases=['burn1', 'burn2'], vars=['accel'])
+
+        # Finish Problem Setup
+        p.model.linear_solver = DirectSolver()
+
+        p.driver.add_recorder(SqliteRecorder('two_burn_orbit_raise_example_for_docs.db'))
+
+        p.setup(check=True, force_alloc_complex=True)
+
+        # Set Initial Guesses
+        p.set_val('traj.design_parameters:c', value=1.5)
+
+        p.set_val('traj.burn1.t_initial', value=0.0)
+        p.set_val('traj.burn1.t_duration', value=2.25)
+
+        p.set_val('traj.burn1.states:r',
+                  value=burn1.interpolate(ys=[1, 1.5], nodes='state_input'))
+        p.set_val('traj.burn1.states:theta',
+                  value=burn1.interpolate(ys=[0, 1.7], nodes='state_input'))
+        p.set_val('traj.burn1.states:vr',
+                  value=burn1.interpolate(ys=[0, 0], nodes='state_input'))
+        p.set_val('traj.burn1.states:vt',
+                  value=burn1.interpolate(ys=[1, 1], nodes='state_input'))
+        p.set_val('traj.burn1.states:accel',
+                  value=burn1.interpolate(ys=[0.1, 0], nodes='state_input'))
+        p.set_val('traj.burn1.states:deltav',
+                  value=burn1.interpolate(ys=[0, 0.1], nodes='state_input'), )
+        p.set_val('traj.burn1.controls:u1',
+                  value=burn1.interpolate(ys=[-3.5, 13.0], nodes='control_input'))
+
+        p.set_val('traj.coast.t_initial', value=2.25)
+        p.set_val('traj.coast.t_duration', value=3.0)
+
+        p.set_val('traj.coast.states:r',
+                  value=coast.interpolate(ys=[1.3, 1.5], nodes='state_input'))
+        p.set_val('traj.coast.states:theta',
+                  value=coast.interpolate(ys=[2.1767, 1.7], nodes='state_input'))
+        p.set_val('traj.coast.states:vr',
+                  value=coast.interpolate(ys=[0.3285, 0], nodes='state_input'))
+        p.set_val('traj.coast.states:vt',
+                  value=coast.interpolate(ys=[0.97, 1], nodes='state_input'))
+        p.set_val('traj.coast.states:accel',
+                  value=coast.interpolate(ys=[0, 0], nodes='state_input'))
+        # p.set_val('traj.coast.controls:u1',
+        #           value=coast.interpolate(ys=[0, 0], nodes='control_input'))
+
+        p.set_val('traj.burn2.t_initial', value=5.25)
+        p.set_val('traj.burn2.t_duration', value=1.75)
+
+        p.set_val('traj.burn2.states:r',
+                  value=burn2.interpolate(ys=[1.8, 3], nodes='state_input'))
+        p.set_val('traj.burn2.states:theta',
+                  value=burn2.interpolate(ys=[3.2, 4.0], nodes='state_input'))
+        p.set_val('traj.burn2.states:vr',
+                  value=burn2.interpolate(ys=[.5, 0], nodes='state_input'))
+        p.set_val('traj.burn2.states:vt',
+                  value=burn2.interpolate(ys=[1, np.sqrt(1 / 3)], nodes='state_input'))
+        p.set_val('traj.burn2.states:accel',
+                  value=burn2.interpolate(ys=[0.1, 0], nodes='state_input'))
+        p.set_val('traj.burn2.states:deltav',
+                  value=burn2.interpolate(ys=[0.1, 0.2], nodes='state_input'))
+        p.set_val('traj.burn2.controls:u1',
+                  value=burn2.interpolate(ys=[1, 1], nodes='control_input'))
+
+        p.run_driver()
+
+        with open('cpd.txt', 'w') as f:
+            np.set_printoptions(linewidth=1024, edgeitems=1024)
+            cpd = p.check_partials(out_stream=f)
+
+        assert_rel_error(self,
+                         p.get_val('traj.burn2.timeseries.states:deltav')[-1],
+                         0.3995,
+                         tolerance=2.0E-3)
+
+        # Plot results
+        exp_out = traj.simulate(times=50)
+
+        fig = plt.figure(figsize=(8, 4))
+        fig.suptitle('Two Burn Orbit Raise Solution')
+        ax_u1 = plt.subplot2grid((2, 2), (0, 0))
+        ax_deltav = plt.subplot2grid((2, 2), (1, 0))
+        ax_xy = plt.subplot2grid((2, 2), (0, 1), rowspan=2)
+
+        span = np.linspace(0, 2 * np.pi, 100)
+        ax_xy.plot(np.cos(span), np.sin(span), 'k--', lw=1)
+        ax_xy.plot(3 * np.cos(span), 3 * np.sin(span), 'k--', lw=1)
+        ax_xy.set_xlim(-4.5, 4.5)
+        ax_xy.set_ylim(-4.5, 4.5)
+
+        ax_xy.set_xlabel('x ($R_e$)')
+        ax_xy.set_ylabel('y ($R_e$)')
+
+        ax_u1.set_xlabel('time ($TU$)')
+        ax_u1.set_ylabel('$u_1$ ($deg$)')
+        ax_u1.grid(True)
+
+        ax_deltav.set_xlabel('time ($TU$)')
+        ax_deltav.set_ylabel('${\Delta}v$ ($DU/TU$)')
+        ax_deltav.grid(True)
+
+        t_sol = dict((phs, p.get_val('traj.{0}.timeseries.time'.format(phs)))
+                     for phs in ['burn1', 'coast', 'burn2'])
+        x_sol = dict((phs, p.get_val('traj.{0}.timeseries.pos_x'.format(phs)))
+                     for phs in ['burn1', 'coast', 'burn2'])
+        y_sol = dict((phs, p.get_val('traj.{0}.timeseries.pos_y'.format(phs)))
+                     for phs in ['burn1', 'coast', 'burn2'])
+        dv_sol = dict((phs, p.get_val('traj.{0}.timeseries.states:deltav'.format(phs)))
+                      for phs in ['burn1', 'coast', 'burn2'])
+        u1_sol = dict((phs, p.get_val('traj.{0}.timeseries.controls:u1'.format(phs), units='deg'))
+                      for phs in ['burn1', 'burn2'])
+
+        t_exp = dict((phs, exp_out.get_val('traj.{0}.timeseries.time'.format(phs)))
+                     for phs in ['burn1', 'coast', 'burn2'])
+        x_exp = dict((phs, exp_out.get_val('traj.{0}.timeseries.pos_x'.format(phs)))
+                     for phs in ['burn1', 'coast', 'burn2'])
+        y_exp = dict((phs, exp_out.get_val('traj.{0}.timeseries.pos_y'.format(phs)))
+                     for phs in ['burn1', 'coast', 'burn2'])
+        dv_exp = dict((phs, exp_out.get_val('traj.{0}.timeseries.states:deltav'.format(phs)))
+                      for phs in ['burn1', 'coast', 'burn2'])
+        u1_exp = dict((phs, exp_out.get_val('traj.{0}.timeseries.controls:u1'.format(phs),
+                                            units='deg'))
+                      for phs in ['burn1', 'burn2'])
+
+        for phs in ['burn1', 'coast', 'burn2']:
+            try:
+                ax_u1.plot(t_sol[phs], u1_sol[phs], 'ro', ms=3)
+                ax_u1.plot(t_exp[phs], u1_exp[phs], 'b-')
+            except KeyError:
+                pass
+
+            ax_deltav.plot(t_sol[phs], dv_sol[phs], 'ro', ms=3)
+            ax_deltav.plot(t_exp[phs], dv_exp[phs], 'b-')
+
+            ax_xy.plot(x_sol[phs], y_sol[phs], 'ro', ms=3, label='implicit')
+            ax_xy.plot(x_exp[phs], y_exp[phs], 'b-', label='explicit')
+
+        plt.show()
+
+    def test_two_burn_orbit_raise_gl_rkbwd_gl_constrained(self):
+        import numpy as np
+
+        import matplotlib.pyplot as plt
+
+        from openmdao.api import Problem, Group, pyOptSparseDriver, DirectSolver, SqliteRecorder
+        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.general_utils import set_pyoptsparse_opt
+
+        from dymos import GaussLobattoPhase, RungeKuttaPhase, Trajectory
+        from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
+
+        traj = Trajectory()
+        p = Problem(model=Group())
+        p.model.add_subsystem('traj', traj)
+
+        p.driver = pyOptSparseDriver()
+        _, optimizer = set_pyoptsparse_opt('SNOPT', fallback=False)
+        p.driver.options['optimizer'] = optimizer
+        p.driver.options['dynamic_simul_derivs'] = True
+
+        traj.add_design_parameter('c', opt=False, val=1.5, units='DU/TU')
+
+        # First Phase (burn)
+
+        burn1 = GaussLobattoPhase(ode_class=FiniteBurnODE, num_segments=10,
+                                  transcription_order=3, compressed=True)
+
+        burn1 = traj.add_phase('burn1', burn1)
+
+        burn1.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
+        burn1.set_state_options('r', fix_initial=True, fix_final=False)
+        burn1.set_state_options('theta', fix_initial=True, fix_final=False)
+        burn1.set_state_options('vr', fix_initial=True, fix_final=False)
+        burn1.set_state_options('vt', fix_initial=True, fix_final=False)
+        burn1.set_state_options('accel', fix_initial=True, fix_final=False)
+        burn1.set_state_options('deltav', fix_initial=True, fix_final=False)
+        burn1.add_control('u1', rate_continuity=True, rate2_continuity=True, units='deg',
+                          scaler=0.01, lower=-30, upper=30)
+
+        # Second Phase (Coast)
+
+        coast = RungeKuttaPhase(ode_class=FiniteBurnODE, num_segments=20, compressed=True)
+
+        traj.add_phase('coast', coast)
+
+        coast.set_time_options(initial_bounds=(0.5, 20), duration_bounds=(.5, 10), duration_ref=10)
+        coast.set_state_options('r', fix_initial=False, fix_final=False,
+                                time_direction='backward')
+        coast.set_state_options('theta', fix_initial=False, fix_final=False,
+                                time_direction='backward')
+        coast.set_state_options('vr', fix_initial=False, fix_final=False,
+                                time_direction='backward')
+        coast.set_state_options('vt', fix_initial=False, fix_final=False,
+                                time_direction='backward')
+        coast.set_state_options('accel', fix_initial=False, fix_final=True,
+                                time_direction='backward')
+        coast.set_state_options('deltav', fix_initial=False, fix_final=False,
+                                time_direction='backward')
+        coast.add_design_parameter('u1', opt=False, val=0.0)
+
+        # Third Phase (burn)
+
+        burn2 = GaussLobattoPhase(ode_class=FiniteBurnODE, num_segments=10, transcription_order=3,
+                                  compressed=True)
+
+        traj.add_phase('burn2', burn2)
+
+        burn2.set_time_options(initial_bounds=(0.5, 20), duration_bounds=(.5, 10), initial_ref=10)
+        burn2.set_state_options('r', fix_initial=False, fix_final=True)
+        burn2.set_state_options('theta', fix_initial=False, fix_final=False)
+        burn2.set_state_options('vr', fix_initial=False, fix_final=True)
+        burn2.set_state_options('vt', fix_initial=False, fix_final=True)
+        burn2.set_state_options('accel', fix_initial=False, fix_final=False, defect_scaler=1.0)
+        burn2.set_state_options('deltav', fix_initial=False, fix_final=False, defect_scaler=1.0)
+        burn2.add_control('u1', rate_continuity=True, rate2_continuity=True, units='deg',
+                          scaler=0.01, lower=-30, upper=30)
+
+        burn2.add_objective('deltav', loc='final', scaler=1.0)
+
+        burn1.add_timeseries_output('pos_x', units='DU')
+        coast.add_timeseries_output('pos_x', units='DU')
+        burn2.add_timeseries_output('pos_x', units='DU')
+
+        burn1.add_timeseries_output('pos_y', units='DU')
+        coast.add_timeseries_output('pos_y', units='DU')
+        burn2.add_timeseries_output('pos_y', units='DU')
+
+        # Link Phases
+        traj.link_phases(phases=['burn1', 'coast', 'burn2'],
+                         vars=['time', 'r', 'theta', 'vr', 'vt', 'deltav'])
+        traj.link_phases(phases=['burn1', 'burn2'], vars=['accel'])
+
+        # Finish Problem Setup
+        p.model.linear_solver = DirectSolver()
+
+        p.driver.add_recorder(SqliteRecorder('two_burn_orbit_raise_example_for_docs.db'))
+
+        p.setup(check=True, force_alloc_complex=True)
+
+        # Set Initial Guesses
+        p.set_val('traj.design_parameters:c', value=1.5)
+
+        p.set_val('traj.burn1.t_initial', value=0.0)
+        p.set_val('traj.burn1.t_duration', value=2.25)
+
+        p.set_val('traj.burn1.states:r',
+                  value=burn1.interpolate(ys=[1, 1.5], nodes='state_input'))
+        p.set_val('traj.burn1.states:theta',
+                  value=burn1.interpolate(ys=[0, 1.7], nodes='state_input'))
+        p.set_val('traj.burn1.states:vr',
+                  value=burn1.interpolate(ys=[0, 0], nodes='state_input'))
+        p.set_val('traj.burn1.states:vt',
+                  value=burn1.interpolate(ys=[1, 1], nodes='state_input'))
+        p.set_val('traj.burn1.states:accel',
+                  value=burn1.interpolate(ys=[0.1, 0], nodes='state_input'))
+        p.set_val('traj.burn1.states:deltav',
+                  value=burn1.interpolate(ys=[0, 0.1], nodes='state_input'), )
+        p.set_val('traj.burn1.controls:u1',
+                  value=burn1.interpolate(ys=[-3.5, 13.0], nodes='control_input'))
+
+        p.set_val('traj.coast.t_initial', value=2.25)
+        p.set_val('traj.coast.t_duration', value=3.0)
+
+        p.set_val('traj.coast.states:r',
+                  value=coast.interpolate(ys=[1.3, 1.5], nodes='state_input'))
+        p.set_val('traj.coast.states:theta',
+                  value=coast.interpolate(ys=[2.1767, 1.7], nodes='state_input'))
+        p.set_val('traj.coast.states:vr',
+                  value=coast.interpolate(ys=[0.3285, 0], nodes='state_input'))
+        p.set_val('traj.coast.states:vt',
+                  value=coast.interpolate(ys=[0.97, 1], nodes='state_input'))
+        p.set_val('traj.coast.states:accel',
+                  value=coast.interpolate(ys=[0, 0], nodes='state_input'))
+        # p.set_val('traj.coast.controls:u1',
+        #           value=coast.interpolate(ys=[0, 0], nodes='control_input'))
+
+        p.set_val('traj.burn2.t_initial', value=5.25)
+        p.set_val('traj.burn2.t_duration', value=1.75)
+
+        p.set_val('traj.burn2.states:r',
+                  value=burn2.interpolate(ys=[1.8, 3], nodes='state_input'))
+        p.set_val('traj.burn2.states:theta',
+                  value=burn2.interpolate(ys=[3.2, 4.0], nodes='state_input'))
+        p.set_val('traj.burn2.states:vr',
+                  value=burn2.interpolate(ys=[.5, 0], nodes='state_input'))
+        p.set_val('traj.burn2.states:vt',
+                  value=burn2.interpolate(ys=[1, np.sqrt(1 / 3)], nodes='state_input'))
+        p.set_val('traj.burn2.states:accel',
+                  value=burn2.interpolate(ys=[0.1, 0], nodes='state_input'))
+        p.set_val('traj.burn2.states:deltav',
+                  value=burn2.interpolate(ys=[0.1, 0.2], nodes='state_input'))
+        p.set_val('traj.burn2.controls:u1',
+                  value=burn2.interpolate(ys=[1, 1], nodes='control_input'))
+
+        p.run_driver()
+
+        assert_rel_error(self,
+                         p.get_val('traj.burn2.timeseries.states:deltav')[-1],
+                         0.3995,
+                         tolerance=2.0E-3)
+
+        # Plot results
+        exp_out = traj.simulate(times=50)
+
+        fig = plt.figure(figsize=(8, 4))
+        fig.suptitle('Two Burn Orbit Raise Solution')
+        ax_u1 = plt.subplot2grid((2, 2), (0, 0))
+        ax_deltav = plt.subplot2grid((2, 2), (1, 0))
+        ax_xy = plt.subplot2grid((2, 2), (0, 1), rowspan=2)
+
+        span = np.linspace(0, 2 * np.pi, 100)
+        ax_xy.plot(np.cos(span), np.sin(span), 'k--', lw=1)
+        ax_xy.plot(3 * np.cos(span), 3 * np.sin(span), 'k--', lw=1)
+        ax_xy.set_xlim(-4.5, 4.5)
+        ax_xy.set_ylim(-4.5, 4.5)
+
+        ax_xy.set_xlabel('x ($R_e$)')
+        ax_xy.set_ylabel('y ($R_e$)')
+
+        ax_u1.set_xlabel('time ($TU$)')
+        ax_u1.set_ylabel('$u_1$ ($deg$)')
+        ax_u1.grid(True)
+
+        ax_deltav.set_xlabel('time ($TU$)')
+        ax_deltav.set_ylabel('${\Delta}v$ ($DU/TU$)')
+        ax_deltav.grid(True)
+
+        t_sol = dict((phs, p.get_val('traj.{0}.timeseries.time'.format(phs)))
+                     for phs in ['burn1', 'coast', 'burn2'])
+        x_sol = dict((phs, p.get_val('traj.{0}.timeseries.pos_x'.format(phs)))
+                     for phs in ['burn1', 'coast', 'burn2'])
+        y_sol = dict((phs, p.get_val('traj.{0}.timeseries.pos_y'.format(phs)))
+                     for phs in ['burn1', 'coast', 'burn2'])
+        dv_sol = dict((phs, p.get_val('traj.{0}.timeseries.states:deltav'.format(phs)))
+                      for phs in ['burn1', 'coast', 'burn2'])
+        u1_sol = dict((phs, p.get_val('traj.{0}.timeseries.controls:u1'.format(phs), units='deg'))
+                      for phs in ['burn1', 'burn2'])
+
+        t_exp = dict((phs, exp_out.get_val('traj.{0}.timeseries.time'.format(phs)))
+                     for phs in ['burn1', 'coast', 'burn2'])
+        x_exp = dict((phs, exp_out.get_val('traj.{0}.timeseries.pos_x'.format(phs)))
+                     for phs in ['burn1', 'coast', 'burn2'])
+        y_exp = dict((phs, exp_out.get_val('traj.{0}.timeseries.pos_y'.format(phs)))
+                     for phs in ['burn1', 'coast', 'burn2'])
+        dv_exp = dict((phs, exp_out.get_val('traj.{0}.timeseries.states:deltav'.format(phs)))
+                      for phs in ['burn1', 'coast', 'burn2'])
+        u1_exp = dict((phs, exp_out.get_val('traj.{0}.timeseries.controls:u1'.format(phs),
+                                            units='deg'))
+                      for phs in ['burn1', 'burn2'])
+
+        for phs in ['burn1', 'coast', 'burn2']:
+            try:
+                ax_u1.plot(t_sol[phs], u1_sol[phs], 'ro', ms=3)
+                ax_u1.plot(t_exp[phs], u1_exp[phs], 'b-')
+            except KeyError:
+                pass
+
+            ax_deltav.plot(t_sol[phs], dv_sol[phs], 'ro', ms=3)
+            ax_deltav.plot(t_exp[phs], dv_exp[phs], 'b-')
+
+            ax_xy.plot(x_sol[phs], y_sol[phs], 'ro', ms=3, label='implicit')
+            ax_xy.plot(x_exp[phs], y_exp[phs], 'b-', label='explicit')
+
+        plt.show()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
@@ -5,7 +5,10 @@ import unittest
 import matplotlib
 matplotlib.use('Agg')
 
+from dymos.utils.testing_utils import use_tempdirs
 
+
+@use_tempdirs
 class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
     def test_two_burn_orbit_raise_gl_rkfwd_gl_constrained(self):
@@ -13,7 +16,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         import matplotlib.pyplot as plt
 
-        from openmdao.api import Problem, Group, pyOptSparseDriver, DirectSolver, SqliteRecorder
+        from openmdao.api import Problem, Group, pyOptSparseDriver, DirectSolver
         from openmdao.utils.assert_utils import assert_rel_error
         from openmdao.utils.general_utils import set_pyoptsparse_opt
 
@@ -166,10 +169,6 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
                   value=burn2.interpolate(ys=[1, 1], nodes='control_input'))
 
         p.run_driver()
-
-        with open('cpd.txt', 'w') as f:
-            np.set_printoptions(linewidth=1024, edgeitems=1024)
-            cpd = p.check_partials(out_stream=f)
 
         assert_rel_error(self,
                          p.get_val('traj.burn2.timeseries.states:deltav')[-1],

--- a/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
@@ -28,7 +28,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
         p.model.add_subsystem('traj', traj)
 
         p.driver = pyOptSparseDriver()
-        _, optimizer = set_pyoptsparse_opt('SNOPT', fallback=False)
+        _, optimizer = set_pyoptsparse_opt('SNOPT', fallback=True)
         p.driver.options['optimizer'] = optimizer
         p.driver.opt_settings['Verify level'] = 3
         p.driver.opt_settings['iSumm'] = 6
@@ -256,7 +256,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
         p.model.add_subsystem('traj', traj)
 
         p.driver = pyOptSparseDriver()
-        _, optimizer = set_pyoptsparse_opt('SNOPT', fallback=False)
+        _, optimizer = set_pyoptsparse_opt('SNOPT', fallback=True)
         p.driver.options['optimizer'] = optimizer
         p.driver.options['dynamic_simul_derivs'] = True
 

--- a/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
@@ -1,6 +1,5 @@
 from __future__ import print_function, division, absolute_import
 
-import os
 import unittest
 
 import matplotlib
@@ -8,13 +7,6 @@ matplotlib.use('Agg')
 
 
 class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
-
-    # @classmethod
-    # def tearDownClass(cls):
-    #     for filename in ['coloring.json', 'two_burn_orbit_raise_example_for_docs.db', 'SLSQP.out',
-    #                      'SNOPT_print.out', 'SNOPT_summary.out', 'SLSQP.out']:
-    #         if os.path.exists(filename):
-    #             os.remove(filename)
 
     def test_two_burn_orbit_raise_gl_rkfwd_gl_constrained(self):
         import numpy as np
@@ -39,7 +31,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
         p.driver.opt_settings['iSumm'] = 6
 
         # Setting this to True will cause the SNOPT derivative check to fail.
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.options['dynamic_simul_derivs'] = False
 
         traj.add_design_parameter('c', opt=False, val=1.5, units='DU/TU')
 
@@ -68,17 +60,17 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         coast.set_time_options(initial_bounds=(0.5, 20), duration_bounds=(.5, 10), duration_ref=10)
         coast.set_state_options('r', fix_initial=False, fix_final=False,
-                                time_direction='forward')
+                                propagation='forward')
         coast.set_state_options('theta', fix_initial=False, fix_final=False,
-                                time_direction='forward')
+                                propagation='forward')
         coast.set_state_options('vr', fix_initial=False, fix_final=False,
-                                time_direction='forward')
+                                propagation='forward')
         coast.set_state_options('vt', fix_initial=False, fix_final=False,
-                                time_direction='forward')
+                                propagation='forward')
         coast.set_state_options('accel', fix_initial=True, fix_final=False,
-                                time_direction='forward')
+                                propagation='forward')
         coast.set_state_options('deltav', fix_initial=False, fix_final=False,
-                                time_direction='forward')
+                                propagation='forward')
         coast.add_design_parameter('u1', opt=False, val=0.0)
 
         # Third Phase (burn)
@@ -115,8 +107,6 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         # Finish Problem Setup
         p.model.linear_solver = DirectSolver()
-
-        p.driver.add_recorder(SqliteRecorder('two_burn_orbit_raise_example_for_docs.db'))
 
         p.setup(check=True, force_alloc_complex=True)
 
@@ -187,7 +177,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
                          tolerance=2.0E-3)
 
         # Plot results
-        exp_out = traj.simulate(times=50)
+        exp_out = traj.simulate(times=50, record=False)
 
         fig = plt.figure(figsize=(8, 4))
         fig.suptitle('Two Burn Orbit Raise Solution')
@@ -298,17 +288,17 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         coast.set_time_options(initial_bounds=(0.5, 20), duration_bounds=(.5, 10), duration_ref=10)
         coast.set_state_options('r', fix_initial=False, fix_final=False,
-                                time_direction='backward')
+                                propagation='backward')
         coast.set_state_options('theta', fix_initial=False, fix_final=False,
-                                time_direction='backward')
+                                propagation='backward')
         coast.set_state_options('vr', fix_initial=False, fix_final=False,
-                                time_direction='backward')
+                                propagation='backward')
         coast.set_state_options('vt', fix_initial=False, fix_final=False,
-                                time_direction='backward')
+                                propagation='backward')
         coast.set_state_options('accel', fix_initial=False, fix_final=True,
-                                time_direction='backward')
+                                propagation='backward')
         coast.set_state_options('deltav', fix_initial=False, fix_final=False,
-                                time_direction='backward')
+                                propagation='backward')
         coast.add_design_parameter('u1', opt=False, val=0.0)
 
         # Third Phase (burn)
@@ -345,8 +335,6 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         # Finish Problem Setup
         p.model.linear_solver = DirectSolver()
-
-        p.driver.add_recorder(SqliteRecorder('two_burn_orbit_raise_example_for_docs.db'))
 
         p.setup(check=True, force_alloc_complex=True)
 
@@ -413,7 +401,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
                          tolerance=2.0E-3)
 
         # Plot results
-        exp_out = traj.simulate(times=50)
+        exp_out = traj.simulate(times=50, record=False)
 
         fig = plt.figure(figsize=(8, 4))
         fig.suptitle('Two Burn Orbit Raise Solution')

--- a/dymos/phases/optimizer_based/optimizer_based_phase_base.py
+++ b/dymos/phases/optimizer_based/optimizer_based_phase_base.py
@@ -159,7 +159,10 @@ class OptimizerBasedPhaseBase(PhaseBase):
                                      shape=(num_state_input_nodes, np.prod(options['shape'])),
                                      units=options['units'])
 
-        self.add_subsystem('indep_states', indep, promotes_outputs=['*'])
+        num_connected = len([s for (s, opts) in iteritems(self.state_options) if opts['connected_initial']])
+        prom_inputs = ['initial_states:*'] if num_connected > 0 else None
+        self.add_subsystem('indep_states', indep, promotes_inputs=prom_inputs,
+                           promotes_outputs=['*'])
 
         # add all the des-vars (either from the IndepVarComp or from the indep-var-like
         # outputs of the collocation comp)

--- a/dymos/phases/options.py
+++ b/dymos/phases/options.py
@@ -318,7 +318,7 @@ class StateOptionsDictionary(OptionsDictionary):
                      desc='setting to control if segment collocation defects are '
                           'solved with a newton solver')
 
-        self.declare('time_direction', default='forward', values=('forward', 'backward'),
+        self.declare('propagation', default='forward', values=('forward', 'backward'),
                      desc='Whether the numerical propagation occurs forward or backward '
                           'in time for this state.  This poses restrictions on whether '
                           'states can have fixed or connected initial and final values.')

--- a/dymos/phases/options.py
+++ b/dymos/phases/options.py
@@ -322,6 +322,7 @@ class StateOptionsDictionary(OptionsDictionary):
                      desc='Whether an input is created to pass in the initial state. This may be '
                           'set by a trajectory that links phases.')
 
+
 class TimeOptionsDictionary(OptionsDictionary):
     """
     An OptionsDictionary for time options

--- a/dymos/phases/phase_base.py
+++ b/dymos/phases/phase_base.py
@@ -100,7 +100,7 @@ class PhaseBase(Group):
                           fix_initial=False, fix_final=False, initial_bounds=None,
                           final_bounds=None, lower=None, upper=None, scaler=None, adder=None,
                           ref=None, ref0=None, defect_scaler=1.0, defect_ref=None,
-                          solve_segments=False, time_direction='forward'):
+                          solve_segments=False, propagation='forward'):
         """
         Set options that apply the EOM state variable of the given name.
 
@@ -143,7 +143,7 @@ class PhaseBase(Group):
             If True, a solver will be used to converge the collocation defects within a segment.
             Note that the state continuity defects between segements will still be
             handled by the optimizer.
-        time_direction : str
+        propagation : str
             The direction of time propagation for this state when solve_segments is True.  Must be
             one of 'forward' or 'backward'.
 
@@ -164,7 +164,7 @@ class PhaseBase(Group):
         self.state_options[name]['defect_scaler'] = defect_scaler
         self.state_options[name]['defect_ref'] = defect_ref
         self.state_options[name]['solve_segments'] = solve_segments
-        self.state_options[name]['time_direction'] = time_direction
+        self.state_options[name]['propagation'] = propagation
 
     def add_control(self, name, val=0.0, units=0, opt=True, lower=None, upper=None,
                     fix_initial=False, fix_final=False,

--- a/dymos/phases/runge_kutta/components/runge_kutta_k_iter_group.py
+++ b/dymos/phases/runge_kutta/components/runge_kutta_k_iter_group.py
@@ -56,7 +56,7 @@ class RungeKuttaKIterGroup(Group):
                            RungeKuttaStatePredictComp(method=self.options['method'],
                                                       num_segments=num_seg,
                                                       state_options=state_options),
-                           promotes_inputs=['initial_states:*'])
+                           promotes_inputs=['initial_states_per_seg:*'])
         self.add_subsystem('ode',
                            subsys=self.options['ode_class'](num_nodes=num_nodes,
                                                             **self.options['ode_init_kwargs']))
@@ -72,13 +72,6 @@ class RungeKuttaKIterGroup(Group):
             # Connect the state predicted (assumed) value to its targets in the ode
             self.connect('state_predict_comp.predicted_states:{0}'.format(state_name),
                          ['ode.{0}'.format(tgt) for tgt in options['targets']])
-
-            # # Connect the state rate source to the k comp
-            # rate_path, src_idxs = self._get_rate_source_path(state_name)
-            # self.connect(rate_path,
-            #              'k_comp.f:{0}'.format(state_name),
-            #              src_indices=src_idxs,
-            #              flat_src_indices=True)
 
             # Connect the k value associated with the state to the state predict comp
             self.connect('k_comp.k:{0}'.format(state_name),

--- a/dymos/phases/runge_kutta/components/runge_kutta_state_advance_comp.py
+++ b/dymos/phases/runge_kutta/components/runge_kutta_state_advance_comp.py
@@ -41,7 +41,7 @@ class RungeKuttaStateAdvanceComp(ExplicitComponent):
             units = options['units']
 
             self._var_names[name] = {}
-            self._var_names[name]['initial'] = 'initial_states:{0}'.format(name)
+            self._var_names[name]['initial'] = 'initial_states_per_seg:{0}'.format(name)
             self._var_names[name]['k'] = 'k:{0}'.format(name)
             self._var_names[name]['final'] = 'final_states:{0}'.format(name)
             self._var_names[name]['integral'] = 'state_integrals:{0}'.format(name)

--- a/dymos/phases/runge_kutta/components/runge_kutta_state_continuity_comp.py
+++ b/dymos/phases/runge_kutta/components/runge_kutta_state_continuity_comp.py
@@ -48,9 +48,16 @@ class RungeKuttaStateContinuityComp(ImplicitComponent):
             units = options['units']
             var_names = self._var_names[state_name]
 
+            res_ref = 1.0
+            if options['defect_ref']:
+                res_ref = options['defect_ref']
+            elif options['defect_scaler']:
+                res_ref = 1.0 / options['defect_scaler']
+
             # The implicit variable is the state values at all segment endpoints.
             self.add_output(name=var_names['states'],
                             shape=(num_seg + 1,) + shape,
+                            res_ref=res_ref,
                             units=units)
 
             # The value of the state at the end of each segment.
@@ -66,6 +73,7 @@ class RungeKuttaStateContinuityComp(ImplicitComponent):
                 c = np.concatenate((c, [num_seg]))
                 v = np.tile(np.array([1, -1]), num_seg)
                 v = np.concatenate((v, [1]))
+                v[0] = -1.0
             else:
                 r = np.repeat(np.arange(num_seg, dtype=int), repeats=2)
                 r = np.concatenate((r, [num_seg]))

--- a/dymos/phases/runge_kutta/components/runge_kutta_state_continuity_comp.py
+++ b/dymos/phases/runge_kutta/components/runge_kutta_state_continuity_comp.py
@@ -58,7 +58,9 @@ class RungeKuttaStateContinuityComp(ImplicitComponent):
             self.add_output(name=var_names['states'],
                             shape=(num_seg + 1,) + shape,
                             res_ref=res_ref,
-                            units=units)
+                            units=units,
+                            lower=options['lower'],
+                            upper=options['upper'])
 
             # The value of the state at the end of each segment.
             self.add_input(name=var_names['integral'],

--- a/dymos/phases/runge_kutta/components/runge_kutta_state_continuity_comp.py
+++ b/dymos/phases/runge_kutta/components/runge_kutta_state_continuity_comp.py
@@ -37,7 +37,7 @@ class RungeKuttaStateContinuityComp(ImplicitComponent):
         self._var_names = {}
 
         for state_name, options in iteritems(state_options):
-            direction = options['time_direction']
+            direction = options['propagation']
 
             self._var_names[state_name] = {
                 'states': 'states:{0}'.format(state_name),
@@ -112,7 +112,7 @@ class RungeKuttaStateContinuityComp(ImplicitComponent):
 
         for state_name, options in iteritems(state_options):
             names = self._var_names[state_name]
-            direction = options['time_direction']
+            direction = options['propagation']
 
             x_i = outputs[names['states']][:-1, ...]
             x_f = outputs[names['states']][1:, ...]

--- a/dymos/phases/runge_kutta/components/runge_kutta_state_continuity_iter_group.py
+++ b/dymos/phases/runge_kutta/components/runge_kutta_state_continuity_iter_group.py
@@ -3,7 +3,8 @@ from __future__ import print_function, division, absolute_import
 import numpy as np
 from six import string_types, iteritems
 
-from openmdao.api import Group, DirectSolver, NonlinearBlockGS, NewtonSolver, NonlinearRunOnce
+from openmdao.api import Group, IndepVarComp, DirectSolver, NonlinearBlockGS, NewtonSolver, \
+    NonlinearRunOnce
 
 from .runge_kutta_k_iter_group import RungeKuttaKIterGroup
 from .runge_kutta_state_advance_comp import RungeKuttaStateAdvanceComp
@@ -67,14 +68,21 @@ class RungeKuttaStateContinuityIterGroup(Group):
                            RungeKuttaStateAdvanceComp(num_segments=self.options['num_segments'],
                                                       method=self.options['method'],
                                                       state_options=self.options['state_options']),
-                           promotes_inputs=['initial_states:*'],
+                           promotes_inputs=['initial_states_per_seg:*'],
                            promotes_outputs=['state_integrals:*', 'final_states:*'])
+
+        num_connected = len([state for state in self.options['state_options'] if
+                             self.options['state_options'][state]['connected_initial']])
+        if num_connected > 0:
+            promoted_inputs = ['state_integrals:*', 'initial_states:*']
+        else:
+            promoted_inputs = ['state_integrals:*']
 
         self.add_subsystem('continuity_comp',
                            RungeKuttaStateContinuityComp(
                                num_segments=self.options['num_segments'],
                                state_options=self.options['state_options']),
-                           promotes_inputs=['state_integrals:*'],
+                           promotes_inputs=promoted_inputs,
                            promotes_outputs=['states:*'])
 
         for state_name, options in iteritems(self.options['state_options']):
@@ -83,7 +91,7 @@ class RungeKuttaStateContinuityIterGroup(Group):
             row_idxs = np.arange(self.options['num_segments'], dtype=int)
             src_idxs = get_src_indices_by_row(row_idxs, options['shape'])
             self.connect('states:{0}'.format(state_name),
-                         'initial_states:{0}'.format(state_name),
+                         'initial_states_per_seg:{0}'.format(state_name),
                          src_indices=src_idxs, flat_src_indices=True)
 
         self.linear_solver = DirectSolver()

--- a/dymos/phases/runge_kutta/components/runge_kutta_state_continuity_iter_group.py
+++ b/dymos/phases/runge_kutta/components/runge_kutta_state_continuity_iter_group.py
@@ -50,17 +50,6 @@ class RungeKuttaStateContinuityIterGroup(Group):
                              desc='The options passed to the nonlinear solver used to converge the'
                                   'Runge-Kutta propagation across each step.')
 
-        self.options.declare('continuity_solver_class', default=NewtonSolver,
-                             values=(NewtonSolver, NonlinearRunOnce),
-                             allow_none=True,
-                             desc='The nonlinear solver class used to enforce state continuity '
-                                  'across the segments (steps).  Currently only NewtonSolver is'
-                                  'supported.')
-
-        self.options.declare('continuity_solver_options', default={'iprint': -1}, types=(dict,),
-                             desc='The options passed to the nonlinear solver used to enforce '
-                                  'state continuity across the segments (steps).')
-
     def setup(self):
         self.add_subsystem('k_iter_group',
                            RungeKuttaKIterGroup(num_segments=self.options['num_segments'],
@@ -98,6 +87,3 @@ class RungeKuttaStateContinuityIterGroup(Group):
                          src_indices=src_idxs, flat_src_indices=True)
 
         self.linear_solver = DirectSolver()
-        if self.options['continuity_solver_class']:
-            self.nonlinear_solver = \
-                self.options['continuity_solver_class'](**self.options['continuity_solver_options'])

--- a/dymos/phases/runge_kutta/components/runge_kutta_state_predict_comp.py
+++ b/dymos/phases/runge_kutta/components/runge_kutta_state_predict_comp.py
@@ -36,7 +36,7 @@ class RungeKuttaStatePredictComp(ExplicitComponent):
             units = options['units']
 
             self._var_names[name] = {}
-            self._var_names[name]['initial'] = 'initial_states:{0}'.format(name)
+            self._var_names[name]['initial'] = 'initial_states_per_seg:{0}'.format(name)
             self._var_names[name]['k'] = 'k:{0}'.format(name)
             self._var_names[name]['predicted'] = 'predicted_states:{0}'.format(name)
 

--- a/dymos/phases/runge_kutta/components/test/test_rk_continuity_comp.py
+++ b/dymos/phases/runge_kutta/components/test/test_rk_continuity_comp.py
@@ -153,7 +153,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
                                'fix_final': False, 'defect_scaler': 1.0, 'defect_ref': None,
-                               'lower': None, 'upper': None}}
+                               'lower': None, 'upper': None, 'connected_initial': False}}
 
         p = Problem(model=Group())
 
@@ -288,7 +288,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
                                'fix_final': False, 'defect_scaler': 1.0, 'defect_ref': None,
-                               'lower': None, 'upper': None}}
+                               'lower': None, 'upper': None, 'connected_initial': False}}
 
         p = Problem(model=Group())
 
@@ -345,7 +345,8 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         num_seg = 2
         state_options = {'y': {'shape': (2,), 'units': 'm', 'targets': ['y'],
                                'defect_ref': None, 'defect_scaler': None,
-                               'lower': None, 'upper': None, 'lower': None, 'upper': None}}
+                               'lower': None, 'upper': None, 'lower': None, 'upper': None,
+                               'connected_initial': False}}
 
         p = Problem(model=Group())
 
@@ -406,7 +407,8 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_vector_nonlinearblockgs_fwd(self):
         num_seg = 2
         state_options = {'y': {'shape': (2,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'defect_ref': 1, 'lower': None, 'upper': None}}
+                               'fix_final': False, 'defect_ref': 1, 'lower': None, 'upper': None,
+                               'connected_initial': False}}
 
         p = Problem(model=Group())
 
@@ -518,7 +520,8 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_vector_newton_fwd(self):
         num_seg = 2
         state_options = {'y': {'shape': (2,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'defect_ref': 1, 'lower': None, 'upper': None}}
+                               'fix_final': False, 'defect_ref': 1, 'lower': None, 'upper': None,
+                               'connected_initial': False}}
 
         p = Problem(model=Group())
 

--- a/dymos/phases/runge_kutta/components/test/test_rk_continuity_comp.py
+++ b/dymos/phases/runge_kutta/components/test/test_rk_continuity_comp.py
@@ -17,7 +17,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_no_iteration_fwd(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'],
-                               'time_direction': 'forward'}}
+                               'propagation': 'forward'}}
 
         p = Problem(model=Group())
 
@@ -81,7 +81,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_nonlinearblockgs_fwd(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'time_direction': 'forward'}}
+                               'fix_final': False, 'propagation': 'forward'}}
 
         p = Problem(model=Group())
 
@@ -145,7 +145,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_newton_fwd(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'time_direction': 'forward'}}
+                               'fix_final': False, 'propagation': 'forward'}}
 
         p = Problem(model=Group())
 
@@ -201,7 +201,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_no_iteration_backward(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'],
-                               'time_direction': 'backward'}}
+                               'propagation': 'backward'}}
 
         p = Problem(model=Group())
 
@@ -265,7 +265,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_nonlinearblockgs_backward(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'time_direction': 'backward'}}
+                               'fix_final': False, 'propagation': 'backward'}}
 
         p = Problem(model=Group())
 
@@ -329,7 +329,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_newton_backwards(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'time_direction': 'backward'}}
+                               'fix_final': False, 'propagation': 'backward'}}
 
         p = Problem(model=Group())
 

--- a/dymos/phases/runge_kutta/components/test/test_rk_continuity_comp.py
+++ b/dymos/phases/runge_kutta/components/test/test_rk_continuity_comp.py
@@ -17,7 +17,8 @@ class TestRungeKuttaContinuityCompScalar(unittest.TestCase):
     def test_continuity_comp_scalar_no_iteration_fwd(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'],
-                               'defect_scaler': 1.0, 'defect_ref': None}}
+                               'defect_scaler': 1.0, 'defect_ref': None,
+                               'lower': None, 'upper': None}}
 
         p = Problem(model=Group())
 
@@ -81,7 +82,8 @@ class TestRungeKuttaContinuityCompScalar(unittest.TestCase):
     def test_continuity_comp_scalar_nonlinearblockgs_fwd(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'defect_scaler': 1.0, 'defect_ref': None}}
+                               'fix_final': False, 'defect_scaler': 1.0, 'defect_ref': None,
+                               'lower': None, 'upper': None}}
 
         p = Problem(model=Group())
 
@@ -145,7 +147,8 @@ class TestRungeKuttaContinuityCompScalar(unittest.TestCase):
     def test_continuity_comp_scalar_newton_fwd(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'defect_scaler': 1.0, 'defect_ref': None}}
+                               'fix_final': False, 'defect_scaler': 1.0, 'defect_ref': None,
+                               'lower': None, 'upper': None}}
 
         p = Problem(model=Group())
 
@@ -201,7 +204,8 @@ class TestRungeKuttaContinuityCompScalar(unittest.TestCase):
     def test_continuity_comp_vector_no_iteration_fwd(self):
         num_seg = 2
         state_options = {'y': {'shape': (2,), 'units': 'm', 'targets': ['y'],
-                               'defect_ref': None, 'defect_scaler': None}}
+                               'defect_ref': None, 'defect_scaler': None,
+                               'lower': None, 'upper': None, 'lower': None, 'upper': None}}
 
         p = Problem(model=Group())
 
@@ -262,7 +266,7 @@ class TestRungeKuttaContinuityCompScalar(unittest.TestCase):
     def test_continuity_comp_vector_nonlinearblockgs_fwd(self):
         num_seg = 2
         state_options = {'y': {'shape': (2,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'defect_ref': 1}}
+                               'fix_final': False, 'defect_ref': 1, 'lower': None, 'upper': None}}
 
         p = Problem(model=Group())
 
@@ -315,7 +319,7 @@ class TestRungeKuttaContinuityCompScalar(unittest.TestCase):
     def test_continuity_comp_vector_newton_fwd(self):
         num_seg = 2
         state_options = {'y': {'shape': (2,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'defect_ref': 1}}
+                               'fix_final': False, 'defect_ref': 1, 'lower': None, 'upper': None}}
 
         p = Problem(model=Group())
 

--- a/dymos/phases/runge_kutta/components/test/test_rk_continuity_comp.py
+++ b/dymos/phases/runge_kutta/components/test/test_rk_continuity_comp.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, NonlinearRunOnce, NonlinearBlockGS, \
+from openmdao.api import Problem, Group, IndepVarComp, NonlinearRunOnce, NonlinearBlockGS, \
     NewtonSolver, DirectSolver
 from openmdao.utils.assert_utils import assert_rel_error
 
@@ -12,13 +12,13 @@ from dymos.phases.runge_kutta.components.runge_kutta_state_continuity_comp impor
     RungeKuttaStateContinuityComp
 
 
-class TestRungeKuttaContinuityCompScalar(unittest.TestCase):
+class TestRungeKuttaContinuityComp(unittest.TestCase):
 
     def test_continuity_comp_scalar_no_iteration_fwd(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'],
                                'defect_scaler': 1.0, 'defect_ref': None,
-                               'lower': None, 'upper': None}}
+                               'lower': None, 'upper': None, 'connected_initial': False}}
 
         p = Problem(model=Group())
 
@@ -79,6 +79,76 @@ class TestRungeKuttaContinuityCompScalar(unittest.TestCase):
         assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
+    def test_continuity_comp_connected_scalar_no_iteration_fwd(self):
+        num_seg = 4
+        state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'],
+                               'defect_scaler': 1.0, 'defect_ref': None,
+                               'lower': None, 'upper': None, 'connected_initial': True}}
+
+        p = Problem(model=Group())
+
+        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc.add_output('initial_states:y', units='m', shape=(1, 1))
+
+        p.model.add_subsystem('continuity_comp',
+                              RungeKuttaStateContinuityComp(num_segments=num_seg,
+                                                            state_options=state_options),
+                              promotes_inputs=['*'],
+                              promotes_outputs=['*'])
+
+        p.model.nonlinear_solver = NonlinearRunOnce()
+        p.model.linear_solver = DirectSolver()
+
+        p.setup(check=True, force_alloc_complex=True)
+
+        p['initial_states:y'] = 0.5
+
+        p['states:y'] = np.array([[0.50000000],
+                                  [1.425130208333333],
+                                  [2.639602661132812],
+                                  [4.006818970044454],
+                                  [5.301605229265987]])
+
+        p['state_integrals:y'] = np.array([[1.0],
+                                           [1.0],
+                                           [1.0],
+                                           [1.0]])
+
+        p.run_model()
+        p.model.run_apply_nonlinear()
+
+        # Test that the residuals of the states are the expected values
+        outputs = p.model.list_outputs(print_arrays=True, residuals=True, out_stream=None)
+
+        y_f = p['states:y'][1:, ...]
+        y_i = p['states:y'][:-1, ...]
+        dy_given = y_f - y_i
+        dy_computed = p['state_integrals:y']
+
+        expected_resids = np.zeros((num_seg + 1, 1))
+        expected_resids[1:, ...] = dy_given - dy_computed
+
+        op_dict = dict([op for op in outputs])
+        assert_rel_error(self, op_dict['continuity_comp.states:y']['resids'], expected_resids)
+
+        # Test the partials
+        cpd = p.check_partials(method='cs')
+
+        J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
+        J_rev = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_rev']
+        J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
+        assert_rel_error(self, J_fwd, J_rev)
+        assert_rel_error(self, J_fwd, J_fd)
+
+        J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
+        J_rev = cpd['continuity_comp']['states:y', 'states:y']['J_rev']
+        J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
+
+        J_fd[0, 0] = -1.0
+
+        assert_rel_error(self, J_fwd, J_rev)
+        assert_rel_error(self, J_fwd, J_fd)
+
     def test_continuity_comp_scalar_nonlinearblockgs_fwd(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
@@ -97,6 +167,76 @@ class TestRungeKuttaContinuityCompScalar(unittest.TestCase):
         p.model.linear_solver = DirectSolver()
 
         p.setup(check=True, force_alloc_complex=True)
+
+        p['states:y'] = np.array([[0.50000000],
+                                  [1.425130208333333],
+                                  [2.639602661132812],
+                                  [4.006818970044454],
+                                  [5.301605229265987]])
+
+        p['state_integrals:y'] = np.array([[1.0],
+                                           [1.0],
+                                           [1.0],
+                                           [1.0]])
+
+        p.setup(check=True, force_alloc_complex=True)
+
+        p['states:y'] = np.array([[0.50000000],
+                                  [1.425130208333333],
+                                  [2.639602661132812],
+                                  [4.006818970044454],
+                                  [5.301605229265987]])
+
+        p.run_model()
+
+        # Test that the residuals of the states are the expected values
+        outputs = p.model.list_outputs(print_arrays=True, residuals=True, out_stream=None)
+        expected_resids = np.zeros((num_seg + 1, 1))
+
+        op_dict = dict([op for op in outputs])
+        assert_rel_error(self, op_dict['continuity_comp.states:y']['resids'], expected_resids)
+
+        # Test the partials
+        cpd = p.check_partials(method='cs', out_stream=None)
+
+        J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
+        J_rev = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_rev']
+        J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
+        assert_rel_error(self, J_fwd, J_rev)
+        assert_rel_error(self, J_fwd, J_fd)
+
+        J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
+        J_rev = cpd['continuity_comp']['states:y', 'states:y']['J_rev']
+        J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
+
+        J_fd[0, 0] = -1.0
+
+        assert_rel_error(self, J_fwd, J_rev)
+        assert_rel_error(self, J_fwd, J_fd)
+
+    def test_continuity_comp_connected_scalar_nonlinearblockgs_fwd(self):
+        num_seg = 4
+        state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
+                               'fix_final': False, 'defect_scaler': 1.0, 'defect_ref': None,
+                               'lower': None, 'upper': None, 'connected_initial': True}}
+
+        p = Problem(model=Group())
+
+        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc.add_output('initial_states:y', units='m', shape=(1, 1))
+
+        p.model.add_subsystem('continuity_comp',
+                              RungeKuttaStateContinuityComp(num_segments=num_seg,
+                                                            state_options=state_options),
+                              promotes_inputs=['*'],
+                              promotes_outputs=['*'])
+
+        p.model.nonlinear_solver = NonlinearBlockGS(iprint=2)
+        p.model.linear_solver = DirectSolver()
+
+        p.setup(check=True, force_alloc_complex=True)
+
+        p['initial_states:y'] = 0.5
 
         p['states:y'] = np.array([[0.50000000],
                                   [1.425130208333333],
@@ -280,6 +420,65 @@ class TestRungeKuttaContinuityCompScalar(unittest.TestCase):
         p.model.linear_solver = DirectSolver()
 
         p.setup(check=True, force_alloc_complex=True)
+
+        p['states:y'] = np.array([[0.50000000, 2.639602661132812],
+                                  [1.425130208333333, 4.006818970044454],
+                                  [2.639602661132812, 5.301605229265987]])
+
+        p['state_integrals:y'] = np.array([[1.0, 1.0],
+                                           [1.0, 1.0]])
+
+        p.run_model()
+
+        # Test that the residuals of the states are the expected values
+        outputs = p.model.list_outputs(print_arrays=True, residuals=True, out_stream=None)
+        expected_resids = np.zeros((num_seg + 1, 2))
+
+        op_dict = dict([op for op in outputs])
+        assert_rel_error(self, op_dict['continuity_comp.states:y']['resids'], expected_resids)
+
+        # Test the partials
+        cpd = p.check_partials(method='cs', out_stream=None)
+
+        J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
+        J_rev = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_rev']
+        J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
+        assert_rel_error(self, J_fwd, J_rev)
+        assert_rel_error(self, J_fwd, J_fd)
+
+        J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
+        J_rev = cpd['continuity_comp']['states:y', 'states:y']['J_rev']
+        J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
+
+        size = np.prod(state_options['y']['shape'])
+        J_fd[:size, :size] = -np.eye(size)
+
+        assert_rel_error(self, J_fwd, J_rev)
+        assert_rel_error(self, J_fwd, J_fd)
+
+    def test_continuity_comp_connected_vector_nonlinearblockgs_fwd(self):
+        num_seg = 2
+        state_options = {'y': {'shape': (2,), 'units': 'm', 'targets': ['y'], 'fix_initial': False,
+                               'fix_final': False, 'defect_ref': 1, 'lower': None, 'upper': None,
+                               'connected_initial': True}}
+
+        p = Problem(model=Group())
+
+        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc.add_output('initial_states:y', units='m', shape=(1, 2))
+
+        p.model.add_subsystem('continuity_comp',
+                              RungeKuttaStateContinuityComp(num_segments=num_seg,
+                                                            state_options=state_options),
+                              promotes_inputs=['*'],
+                              promotes_outputs=['*'])
+
+        p.model.nonlinear_solver = NonlinearBlockGS(iprint=2)
+        p.model.linear_solver = DirectSolver()
+
+        p.setup(check=True, force_alloc_complex=True)
+
+        p['initial_states:y'] = np.array([[0.50000000, 2.639602661132812]])
 
         p['states:y'] = np.array([[0.50000000, 2.639602661132812],
                                   [1.425130208333333, 4.006818970044454],

--- a/dymos/phases/runge_kutta/components/test/test_rk_continuity_comp.py
+++ b/dymos/phases/runge_kutta/components/test/test_rk_continuity_comp.py
@@ -17,7 +17,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_no_iteration_fwd(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'],
-                               'propagation': 'forward'}}
+                               'propagation': 'forward', 'defect_scaler': 1.0, 'defect_ref': None}}
 
         p = Problem(model=Group())
 
@@ -73,7 +73,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         J_rev = cpd['continuity_comp']['states:y', 'states:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
 
-        J_fd[0, 0] = 1.0
+        J_fd[0, 0] = -1.0
 
         assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
@@ -81,7 +81,8 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_nonlinearblockgs_fwd(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'propagation': 'forward'}}
+                               'fix_final': False, 'propagation': 'forward', 'defect_scaler': 1.0,
+                               'defect_ref': None}}
 
         p = Problem(model=Group())
 
@@ -137,7 +138,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         J_rev = cpd['continuity_comp']['states:y', 'states:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
 
-        J_fd[0, 0] = 1.0
+        J_fd[0, 0] = -1.0
 
         assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
@@ -145,7 +146,8 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_newton_fwd(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'propagation': 'forward'}}
+                               'fix_final': False, 'propagation': 'forward', 'defect_scaler': 1.0,
+                               'defect_ref': None}}
 
         p = Problem(model=Group())
 
@@ -193,7 +195,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         J_rev = cpd['continuity_comp']['states:y', 'states:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
 
-        J_fd[0, 0] = 1.0
+        J_fd[0, 0] = -1.0
 
         assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
@@ -201,7 +203,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_no_iteration_backward(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'],
-                               'propagation': 'backward'}}
+                               'propagation': 'backward', 'defect_scaler': 1.0, 'defect_ref': None}}
 
         p = Problem(model=Group())
 
@@ -265,7 +267,8 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_nonlinearblockgs_backward(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'propagation': 'backward'}}
+                               'fix_final': False, 'propagation': 'backward',
+                               'defect_scaler': 1.0, 'defect_ref': None}}
 
         p = Problem(model=Group())
 
@@ -329,7 +332,8 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_newton_backwards(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'propagation': 'backward'}}
+                               'fix_final': False, 'propagation': 'backward', 'defect_scaler': 1.0,
+                               'defect_ref': None}}
 
         p = Problem(model=Group())
 

--- a/dymos/phases/runge_kutta/components/test/test_rk_continuity_iter_group.py
+++ b/dymos/phases/runge_kutta/components/test/test_rk_continuity_iter_group.py
@@ -18,7 +18,7 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
                                'fix_final': False, 'propagation': 'forward', 'defect_scaler': None,
-                               'defect_ref': 1.0}}
+                               'defect_ref': 1.0, 'lower': None, 'upper': None}}
 
         p = Problem(model=Group())
 
@@ -39,8 +39,7 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
                                   time_units='s',
                                   ode_class=TestODE,
                                   ode_init_kwargs={},
-                                  k_solver_class=NonlinearRunOnce,
-                                  continuity_solver_class=NonlinearRunOnce),
+                                  k_solver_class=NonlinearRunOnce),
                               promotes_outputs=['states:*'])
 
         p.model.connect('h', 'cnty_iter_group.h')
@@ -115,7 +114,7 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
                                'fix_final': False, 'propagation': 'forward', 'defect_scaler': None,
-                               'defect_ref': 1.0}}
+                               'defect_ref': 1.0, 'lower': None, 'upper': None}}
 
         p = Problem(model=Group())
 
@@ -136,8 +135,7 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
                                   time_units='s',
                                   ode_class=TestODE,
                                   ode_init_kwargs={},
-                                  k_solver_class=None,
-                                  continuity_solver_class=NewtonSolver),
+                                  k_solver_class=None),
                               promotes_outputs=['states:*'])
 
         p.model.connect('h', 'cnty_iter_group.h')
@@ -147,7 +145,7 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
         p.model.connect('cnty_iter_group.ode.ydot', 'cnty_iter_group.k_comp.f:y',
                         src_indices=src_idxs, flat_src_indices=True)
 
-        p.model.nonlinear_solver = NonlinearRunOnce()
+        p.model.nonlinear_solver = NewtonSolver()
         p.model.linear_solver = DirectSolver()
 
         p.setup(check=True, force_alloc_complex=True)

--- a/dymos/phases/runge_kutta/components/test/test_rk_continuity_iter_group.py
+++ b/dymos/phases/runge_kutta/components/test/test_rk_continuity_iter_group.py
@@ -18,7 +18,8 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
                                'fix_final': False, 'propagation': 'forward', 'defect_scaler': None,
-                               'defect_ref': 1.0, 'lower': None, 'upper': None}}
+                               'defect_ref': 1.0, 'lower': None, 'upper': None,
+                               'connected_initial': False}}
 
         p = Problem(model=Group())
 
@@ -114,7 +115,8 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
                                'fix_final': False, 'propagation': 'forward', 'defect_scaler': None,
-                               'defect_ref': 1.0, 'lower': None, 'upper': None}}
+                               'defect_ref': 1.0, 'lower': None, 'upper': None,
+                               'connected_initial': False}}
 
         p = Problem(model=Group())
 

--- a/dymos/phases/runge_kutta/components/test/test_rk_continuity_iter_group.py
+++ b/dymos/phases/runge_kutta/components/test/test_rk_continuity_iter_group.py
@@ -3,14 +3,12 @@ from __future__ import print_function, division, absolute_import
 import unittest
 
 import numpy as np
-from numpy.testing import assert_almost_equal
 
-from openmdao.api import Problem, Group, IndepVarComp, NonlinearRunOnce, NonlinearBlockGS, \
-    NewtonSolver, ExecComp, DirectSolver
-from openmdao.utils.assert_utils import assert_check_partials, assert_rel_error
+from openmdao.api import Problem, Group, IndepVarComp, NonlinearRunOnce, \
+    NewtonSolver, DirectSolver
+from openmdao.utils.assert_utils import assert_rel_error
 
-from dymos.phases.runge_kutta.components import RungeKuttaStateContinuityIterGroup, \
-    RungeKuttaStepsizeComp
+from dymos.phases.runge_kutta.components import RungeKuttaStateContinuityIterGroup
 from dymos.phases.runge_kutta.test.rk_test_ode import TestODE
 
 
@@ -19,7 +17,8 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
     def test_continuity_comp_no_iteration(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'propagation': 'forward'}}
+                               'fix_final': False, 'propagation': 'forward', 'defect_scaler': None,
+                               'defect_ref': 1.0}}
 
         p = Problem(model=Group())
 
@@ -107,7 +106,7 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
         J_rev = cpd['cnty_iter_group.continuity_comp']['states:y', 'states:y']['J_rev']
         J_fd = cpd['cnty_iter_group.continuity_comp']['states:y', 'states:y']['J_fd']
 
-        J_fd[0, 0] = 1.0
+        J_fd[0, 0] = -1.0
 
         assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
@@ -115,7 +114,8 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
     def test_continuity_comp_newtonsolver(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'propagation': 'forward'}}
+                               'fix_final': False, 'propagation': 'forward', 'defect_scaler': None,
+                               'defect_ref': 1.0}}
 
         p = Problem(model=Group())
 
@@ -180,7 +180,7 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
         J_rev = cpd['cnty_iter_group.continuity_comp']['states:y', 'states:y']['J_rev']
         J_fd = cpd['cnty_iter_group.continuity_comp']['states:y', 'states:y']['J_fd']
 
-        J_fd[0, 0] = 1.0
+        J_fd[0, 0] = -1.0
 
         assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)

--- a/dymos/phases/runge_kutta/components/test/test_rk_continuity_iter_group.py
+++ b/dymos/phases/runge_kutta/components/test/test_rk_continuity_iter_group.py
@@ -19,7 +19,7 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
     def test_continuity_comp_no_iteration(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'time_direction': 'forward'}}
+                               'fix_final': False, 'propagation': 'forward'}}
 
         p = Problem(model=Group())
 
@@ -115,7 +115,7 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
     def test_continuity_comp_newtonsolver(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'time_direction': 'forward'}}
+                               'fix_final': False, 'propagation': 'forward'}}
 
         p = Problem(model=Group())
 

--- a/dymos/phases/runge_kutta/components/test/test_rk_k_iter_group.py
+++ b/dymos/phases/runge_kutta/components/test/test_rk_k_iter_group.py
@@ -24,7 +24,7 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
 
         ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
 
-        ivc.add_output('initial_states:y', shape=(num_seg, 1), units='m')
+        ivc.add_output('initial_states_per_seg:y', shape=(num_seg, 1), units='m')
         ivc.add_output('h', shape=(num_seg, 1), units='s')
         ivc.add_output('t', shape=(num_seg * num_stages, 1), units='s')
 
@@ -39,7 +39,7 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
 
         p.model.connect('t', 'k_iter_group.ode.t')
         p.model.connect('h', 'k_iter_group.h')
-        p.model.connect('initial_states:y', 'k_iter_group.initial_states:y')
+        p.model.connect('initial_states_per_seg:y', 'k_iter_group.initial_states_per_seg:y')
 
         src_idxs = np.arange(16, dtype=int).reshape((num_seg, num_stages, 1))
         p.model.connect('k_iter_group.ode.ydot', 'k_iter_group.k_comp.f:y',
@@ -54,10 +54,10 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
 
         p['h'] = np.array([[0.5, 0.5, 0.5, 0.5]]).T
 
-        p['initial_states:y'] = np.array([[0.50000000],
-                                          [1.425130208333333],
-                                          [2.639602661132812],
-                                          [4.006818970044454]])
+        p['initial_states_per_seg:y'] = np.array([[0.50000000],
+                                                  [1.425130208333333],
+                                                  [2.639602661132812],
+                                                  [4.006818970044454]])
 
         p['k_iter_group.k_comp.k:y'] = np.array([[[0.75000000],
                                                   [0.90625000],
@@ -99,7 +99,7 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
 
         ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
 
-        ivc.add_output('initial_states:y', shape=(num_seg, 1), units='m')
+        ivc.add_output('initial_states_per_seg:y', shape=(num_seg, 1), units='m')
         ivc.add_output('h', shape=(num_seg, 1), units='s')
         ivc.add_output('t', shape=(num_seg * num_stages, 1), units='s')
 
@@ -115,7 +115,7 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
 
         p.model.connect('t', 'k_iter_group.ode.t')
         p.model.connect('h', 'k_iter_group.h')
-        p.model.connect('initial_states:y', 'k_iter_group.initial_states:y')
+        p.model.connect('initial_states_per_seg:y', 'k_iter_group.initial_states_per_seg:y')
 
         src_idxs = np.arange(16, dtype=int).reshape((num_seg, num_stages, 1))
         p.model.connect('k_iter_group.ode.ydot', 'k_iter_group.k_comp.f:y',
@@ -130,10 +130,10 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
 
         p['h'] = np.array([[0.5, 0.5, 0.5, 0.5]]).T
 
-        p['initial_states:y'] = np.array([[0.50000000],
-                                          [1.425130208333333],
-                                          [2.639602661132812],
-                                          [4.006818970044454]])
+        p['initial_states_per_seg:y'] = np.array([[0.50000000],
+                                                  [1.425130208333333],
+                                                  [2.639602661132812],
+                                                  [4.006818970044454]])
 
         # Start k with a terrible guess
         p['k_iter_group.k_comp.k:y'][...] = 0
@@ -158,7 +158,7 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
 
         ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
 
-        ivc.add_output('initial_states:y', shape=(num_seg, 1), units='m')
+        ivc.add_output('initial_states_per_seg:y', shape=(num_seg, 1), units='m')
         ivc.add_output('h', shape=(num_seg, 1), units='s')
         ivc.add_output('t', shape=(num_seg * num_stages, 1), units='s')
 
@@ -174,7 +174,7 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
 
         p.model.connect('t', 'k_iter_group.ode.t')
         p.model.connect('h', 'k_iter_group.h')
-        p.model.connect('initial_states:y', 'k_iter_group.initial_states:y')
+        p.model.connect('initial_states_per_seg:y', 'k_iter_group.initial_states_per_seg:y')
 
         src_idxs = np.arange(16, dtype=int).reshape((num_seg, num_stages, 1))
         p.model.connect('k_iter_group.ode.ydot', 'k_iter_group.k_comp.f:y',
@@ -189,10 +189,10 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
 
         p['h'] = np.array([[0.5, 0.5, 0.5, 0.5]]).T
 
-        p['initial_states:y'] = np.array([[0.50000000],
-                                          [1.425130208333333],
-                                          [2.639602661132812],
-                                          [4.006818970044454]])
+        p['initial_states_per_seg:y'] = np.array([[0.50000000],
+                                                  [1.425130208333333],
+                                                  [2.639602661132812],
+                                                  [4.006818970044454]])
 
         # Start k with a terrible guess
         p['k_iter_group.k_comp.k:y'][...] = 0

--- a/dymos/phases/runge_kutta/components/test/test_rk_state_advance_comp.py
+++ b/dymos/phases/runge_kutta/components/test/test_rk_state_advance_comp.py
@@ -28,7 +28,7 @@ class TestRKStateAdvanceComp(unittest.TestCase):
                                                          state_options=state_options))
 
         p.model.connect('k:y', 'c.k:y')
-        p.model.connect('y0', 'c.initial_states:y')
+        p.model.connect('y0', 'c.initial_states_per_seg:y')
 
         p.setup(check=True, force_alloc_complex=True)
 
@@ -82,7 +82,7 @@ class TestRKStateAdvanceComp(unittest.TestCase):
                                                          state_options=state_options))
 
         p.model.connect('k:y', 'c.k:y')
-        p.model.connect('y0', 'c.initial_states:y')
+        p.model.connect('y0', 'c.initial_states_per_seg:y')
 
         p.setup(check=True, force_alloc_complex=True)
 
@@ -120,7 +120,7 @@ class TestRKStateAdvanceComp(unittest.TestCase):
                                                          state_options=state_options))
 
         p.model.connect('k:y', 'c.k:y')
-        p.model.connect('y0', 'c.initial_states:y')
+        p.model.connect('y0', 'c.initial_states_per_seg:y')
 
         p.setup(check=True, force_alloc_complex=True)
 

--- a/dymos/phases/runge_kutta/components/test/test_rk_state_predict_comp.py
+++ b/dymos/phases/runge_kutta/components/test/test_rk_state_predict_comp.py
@@ -29,7 +29,7 @@ class TestRKStatePredictComp(unittest.TestCase):
                                                          state_options=state_options))
 
         p.model.connect('k:y', 'c.k:y')
-        p.model.connect('y0', 'c.initial_states:y')
+        p.model.connect('y0', 'c.initial_states_per_seg:y')
 
         p.setup(check=True, force_alloc_complex=True)
 
@@ -99,7 +99,7 @@ class TestRKStatePredictComp(unittest.TestCase):
                                                          state_options=state_options))
 
         p.model.connect('k:y', 'c.k:y')
-        p.model.connect('y0', 'c.initial_states:y')
+        p.model.connect('y0', 'c.initial_states_per_seg:y')
 
         p.setup(check=True, force_alloc_complex=True)
 
@@ -159,7 +159,7 @@ class TestRKStatePredictComp(unittest.TestCase):
                                                          state_options=state_options))
 
         p.model.connect('k:y', 'c.k:y')
-        p.model.connect('y0', 'c.initial_states:y')
+        p.model.connect('y0', 'c.initial_states_per_seg:y')
 
         p.setup(check=True, force_alloc_complex=True)
 
@@ -207,7 +207,7 @@ class TestRKStatePredictComp(unittest.TestCase):
                                                          state_options=state_options))
 
         p.model.connect('k:y', 'c.k:y')
-        p.model.connect('y0', 'c.initial_states:y')
+        p.model.connect('y0', 'c.initial_states_per_seg:y')
 
         p.setup(check=True, force_alloc_complex=True)
 

--- a/dymos/phases/runge_kutta/runge_kutta_phase.py
+++ b/dymos/phases/runge_kutta/runge_kutta_phase.py
@@ -240,16 +240,16 @@ class RungeKuttaPhase(PhaseBase):
 
             if options['opt']:
                 # Set the desvar indices accordingly
-                if options['time_direction'] == 'forward':
+                if options['propagation'] == 'forward':
                     desvar_indices = list(range(size))
                 else:
                     desvar_indices = np.arange(num_seg * size, size * (num_seg + 1),
                                                dtype=int).tolist()
 
                 if options['fix_initial']:
-                    if options['time_direction'] == 'backward':
+                    if options['propagation'] == 'backward':
                         raise ValueError('Cannot specify \'fix_initial=True\' and specify '
-                                         'time_direction=\'backward\' for state {0} in '
+                                         'propagation=\'backward\' for state {0} in '
                                          'RungeKuttaPhase'.format(state_name))
                     if options['initial_bounds'] is not None:
                         raise ValueError('Cannot specify \'fix_initial=True\' and specify '
@@ -262,9 +262,9 @@ class RungeKuttaPhase(PhaseBase):
                         del desvar_indices[:size]
 
                 if options['fix_final']:
-                    if options['time_direction'] == 'forward':
+                    if options['propagation'] == 'forward':
                         raise ValueError('Cannot specify \'fix_final=True\' and specify '
-                                         'time_direction=\'forward\' for state {0} in '
+                                         'propagation=\'forward\' for state {0} in '
                                          'RungeKuttaPhase'.format(state_name))
                     if options['final_bounds'] is not None:
                         raise ValueError('Cannot specify \'fix_final=True\' and specify '
@@ -769,7 +769,7 @@ class RungeKuttaPhase(PhaseBase):
                           fix_initial=False, fix_final=False, initial_bounds=None,
                           final_bounds=None, lower=None, upper=None, scaler=None, adder=None,
                           ref=None, ref0=None, defect_scaler=1.0, defect_ref=None,
-                          time_direction='forward'):
+                          propagation='forward'):
         """
         Set options that apply the EOM state variable of the given name.
 
@@ -791,7 +791,7 @@ class RungeKuttaPhase(PhaseBase):
         fix_final : bool(False)
             If True, omit the final value of the state from the design variables (prevent the
             optimizer from changing it).
-        time_direction : str('forward')
+        propagation : str('forward')
             The direction of propagation for this state variable, either 'forward' or 'backward'.
         lower : float or ndarray or None (None)
             The lower bound of the state at the nodes of the phase.
@@ -827,7 +827,7 @@ class RungeKuttaPhase(PhaseBase):
                                                        ref0=ref0,
                                                        defect_scaler=defect_scaler,
                                                        defect_ref=defect_ref,
-                                                       time_direction=time_direction)
+                                                       propagation=propagation)
 
     def add_objective(self, name, loc='final', index=None, shape=(1,), ref=None, ref0=None,
                       adder=None, scaler=None, parallel_deriv_color=None,

--- a/dymos/phases/runge_kutta/test/test_rk4_simple_integration.py
+++ b/dymos/phases/runge_kutta/test/test_rk4_simple_integration.py
@@ -20,9 +20,7 @@ class TestRK4SimpleIntegration(unittest.TestCase):
             'phase0',
             RungeKuttaPhase(num_segments=200,
                             method='rk4',
-                            ode_class=TestODE,
-                            k_solver_options={'iprint': 2},
-                            continuity_solver_options={'iprint': 2, 'solve_subsystems': True}))
+                            ode_class=TestODE))
 
         phase.set_time_options(fix_initial=True, fix_duration=True)
         phase.set_state_options('y', fix_initial=True)
@@ -46,13 +44,9 @@ class TestRK4SimpleIntegration(unittest.TestCase):
     def test_simple_integration_backward(self):
 
         p = Problem(model=Group())
-        phase = p.model.add_subsystem(
-            'phase0',
-            RungeKuttaPhase(num_segments=4,
-                            method='rk4',
-                            ode_class=TestODE,
-                            k_solver_options={'iprint': 2},
-                            continuity_solver_options={'iprint': 2, 'solve_subsystems': True}))
+        phase = p.model.add_subsystem('phase0',
+                                      RungeKuttaPhase(num_segments=4, method='rk4',
+                                                      ode_class=TestODE))
 
         phase.set_time_options(fix_initial=True, fix_duration=True)
         phase.set_state_options('y', fix_initial=True)

--- a/dymos/phases/runge_kutta/test/test_rk4_simple_integration.py
+++ b/dymos/phases/runge_kutta/test/test_rk4_simple_integration.py
@@ -55,7 +55,7 @@ class TestRK4SimpleIntegration(unittest.TestCase):
                             continuity_solver_options={'iprint': 2, 'solve_subsystems': True}))
 
         phase.set_time_options(fix_initial=True, fix_duration=True)
-        phase.set_state_options('y', fix_initial=False, time_direction='backward')
+        phase.set_state_options('y', fix_initial=False, propagation='backward')
 
         phase.add_timeseries_output('ydot', output_name='state_rate:y', units='m/s')
 

--- a/dymos/phases/runge_kutta/test/test_rk4_simple_integration.py
+++ b/dymos/phases/runge_kutta/test/test_rk4_simple_integration.py
@@ -41,6 +41,58 @@ class TestRK4SimpleIntegration(unittest.TestCase):
         expected = _test_ode_solution(p['phase0.ode.y'], p['phase0.ode.t'])
         assert_rel_error(self, p['phase0.ode.y'], expected, tolerance=1.0E-3)
 
+    def test_simple_integration_forward_connected_initial(self):
+
+        p = Problem(model=Group())
+        phase = p.model.add_subsystem(
+            'phase0',
+            RungeKuttaPhase(num_segments=200,
+                            method='rk4',
+                            ode_class=TestODE))
+
+        phase.set_time_options(fix_initial=True, fix_duration=True)
+        phase.set_state_options('y', fix_initial=False, connected_initial=True)
+
+        phase.add_timeseries_output('ydot', output_name='state_rate:y', units='m/s')
+
+        p.setup(check=True, force_alloc_complex=True)
+
+        p.final_setup()
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 2.0
+
+        # The initial guess of states at the segment boundaries
+        p['phase0.states:y'] = 0.0
+
+        # The initial value of the states from which the integration proceeds
+        p['phase0.initial_states:y'] = 0.5
+
+        p.run_model()
+
+        expected = _test_ode_solution(p['phase0.ode.y'], p['phase0.ode.t'])
+        assert_rel_error(self, p['phase0.ode.y'], expected, tolerance=1.0E-3)
+
+    def test_simple_integration_forward_connected_initial_fixed_initial(self):
+
+        p = Problem(model=Group())
+        phase = p.model.add_subsystem(
+            'phase0',
+            RungeKuttaPhase(num_segments=200,
+                            method='rk4',
+                            ode_class=TestODE))
+
+        phase.set_time_options(fix_initial=True, fix_duration=True)
+        phase.set_state_options('y', fix_initial=True, connected_initial=True)
+
+        phase.add_timeseries_output('ydot', output_name='state_rate:y', units='m/s')
+
+        with self.assertRaises(ValueError) as e:
+            p.setup(check=True, force_alloc_complex=True)
+        expected = "Cannot specify 'fix_initial=True' and specify 'connected_initial=True' for " \
+                   "state y in phase phase0."
+        self.assertEqual(str(e.exception), expected)
+
     def test_simple_integration_backward(self):
 
         p = Problem(model=Group())
@@ -61,6 +113,36 @@ class TestRK4SimpleIntegration(unittest.TestCase):
         p['phase0.t_duration'] = -2.0
 
         p['phase0.states:y'] = 5.305471950534675
+
+        p.run_model()
+
+        expected = np.atleast_2d(_test_ode_solution(p['phase0.ode.y'], p['phase0.ode.t'])).T
+        assert_rel_error(self, p['phase0.timeseries.states:y'], expected, tolerance=1.0E-3)
+
+    def test_simple_integration_backward_connected_initial(self):
+
+        p = Problem(model=Group())
+        phase = p.model.add_subsystem('phase0',
+                                      RungeKuttaPhase(num_segments=4, method='rk4',
+                                                      ode_class=TestODE))
+
+        phase.set_time_options(fix_initial=True, fix_duration=True)
+        phase.set_state_options('y', connected_initial=True)
+
+        phase.add_timeseries_output('ydot', output_name='state_rate:y', units='m/s')
+
+        p.setup(check=True, force_alloc_complex=True)
+
+        p.final_setup()
+
+        p['phase0.t_initial'] = 2.0
+        p['phase0.t_duration'] = -2.0
+
+        # The initial guess of state values at the segment boundaries
+        p['phase0.states:y'] = 0
+
+        # The initial value of the states from which the integration proceeds
+        p['phase0.initial_states:y'] = 5.305471950534675
 
         p.run_model()
 

--- a/dymos/phases/simulation/simulation_phase.py
+++ b/dymos/phases/simulation/simulation_phase.py
@@ -185,14 +185,14 @@ class SimulationPhase(Group):
         if self.time_options['t_initial_targets']:
             self.connect('t_initial', ['ode.{0}'.format(tgt)
                                        for tgt in self.time_options['t_initial_targets']])
-            for i in range(num_seg):
-                self.connect(src_name='t_initial', tgt_name='segment_{0}.t_initial'.format(i))
+        for i in range(num_seg):
+            self.connect(src_name='t_initial', tgt_name='segment_{0}.t_initial'.format(i))
 
         if self.time_options['t_duration_targets']:
             self.connect('t_duration', ['ode.{0}'.format(tgt)
                                         for tgt in self.time_options['t_duration_targets']])
-            for i in range(num_seg):
-                self.connect(src_name='t_duration', tgt_name='segment_{0}.t_duration'.format(i))
+        for i in range(num_seg):
+            self.connect(src_name='t_duration', tgt_name='segment_{0}.t_duration'.format(i))
 
     def _setup_states(self, ivc):
         gd = self.options['grid_data']

--- a/dymos/tests/test_pep8.py
+++ b/dymos/tests/test_pep8.py
@@ -46,7 +46,7 @@ class TestPep8(unittest.TestCase):
         pyfiles = _discover_python_files(dymos_path)
 
         style = pep8.StyleGuide(ignore=['E201', 'E226', 'E241', 'E402'])
-        style.options.max_line_length = 100
+        style.options.max_line_length = 120
 
         save = sys.stdout
         sys.stdout = msg = StringIO()

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -330,8 +330,7 @@ class Trajectory(Group):
                         self.connect(src, '{0}.{1}'.format(phase_name2, path))
 
                     else:
-                        p2_opt = p2.state_options[var]
-                        path = 'indep_states.initial_states:{0}'.format(var)
+                        path = 'initial_states:{0}'.format(var)
 
                         self.connect('{0}.{1}'.format(phase_name1, source1),
                                      '{0}.{1}'.format(phase_name2, path))

--- a/dymos/utils/misc.py
+++ b/dymos/utils/misc.py
@@ -81,27 +81,3 @@ class CoerceDesvar(object):
                 raise ValueError('array-valued option {0} must have length '
                                  'num_input_nodes ({1})'.format(option, val))
             return val[self.desvar_indices]
-
-
-def convert_to_ascii(s):
-    """
-    Workaround to convert loaded unicode strings to ascii for Python 2.7.
-
-    Parameters
-    ----------
-    s : str or unicode
-        Character string to be converted.
-
-    Returns
-    -------
-    str or unicode
-        Character s converted to ascii (for 2.7) or unicode (Python 3.x)
-
-    """
-    if sys.version_info[0] < 3:
-        if isinstance(s, unicode):
-            return s.encode('ascii')
-        else:
-            return s
-    else:
-        return s

--- a/dymos/utils/testing_utils.py
+++ b/dymos/utils/testing_utils.py
@@ -1,0 +1,45 @@
+import os
+import shutil
+import tempfile
+
+
+def _new_setup(self):
+    self.startdir = os.getcwd()
+    self.tempdir = tempfile.mkdtemp(prefix='testdir-')
+    os.chdir(self.tempdir)
+    if hasattr(self, 'original_setUp'):
+        self.original_setUp()
+
+
+def _new_teardown(self):
+    if hasattr(self, 'original_tearDown'):
+        self.original_setUp()
+    self.tempdir = os.getcwd()
+    os.chdir(self.startdir)
+    try:
+        shutil.rmtree(self.tempdir)
+    except OSError:
+        pass
+
+
+def use_tempdirs(cls):
+    """
+    Decorator used to run each test in a unittest.TestCase in its own directory.
+
+    TestCase methods setUp and tearDown are replaced with _new_setup and
+    _new_teardown, above.  Method _new_setup creates a temporary directory
+    in which to run the test, stores it in self.tempdir, and then calls
+    the original setUp method.  Method _new_teardown first runs the original
+    tearDown method, and then returns to the original starting directory
+    and deletes the temporary directory.
+    """
+
+    if getattr(cls, 'setUp', None):
+        setattr(cls, 'original_setUp', getattr(cls, 'setUp'))
+    setattr(cls, 'setUp', _new_setup)
+
+    if getattr(cls, 'tearDown', None):
+        setattr(cls, 'original_tearDown', getattr(cls, 'tearDown'))
+    setattr(cls, 'tearDown', _new_teardown)
+
+    return cls

--- a/dymos/utils/testing_utils.py
+++ b/dymos/utils/testing_utils.py
@@ -13,7 +13,7 @@ def _new_setup(self):
 
 def _new_teardown(self):
     if hasattr(self, 'original_tearDown'):
-        self.original_setUp()
+        self.original_tearDown()
     self.tempdir = os.getcwd()
     os.chdir(self.startdir)
     try:


### PR DESCRIPTION
* Added use_tempdirs decorator for parallel testing purposes.  Runs each test in its own temporary subdirectory to avoid I/O collisions when using parallel testing.

* RKPhases can now simulate vector states correctly, but the lack of boundary constraints on vectors means we cannot yet fully test optimized problems.  Removes time_direction/propagation options from states.

* Moved NewtonSolver to the top level of RungeKuttaPhase so that its options may be more easily set.

* RungeKuttaPhase NewtonSolver now has BoundsEnforceLS by default, and respects state lower/upper bounds.
**NOTE** that this has different behavior than the optimizer solved pseusospectral phases!  Path constraints on states in RungeKuttaPhase should not be solved with lower/upper bounds on the states.

* Removed continuity_solver/continuity_solver_options from RungeKutta phase and relevant components.

* added connected_initial functionality to RungeKuttaPhase

* Fixed RK continuity tests.  Fixed use_tempdirs test decorator.

* branching battery simulation implemented with RK with constrained and connected phase linkages

Resolves #122
Resolves #133