### PR TITLE
Sized input parameters

### DIFF
--- a/dymos/phases/optimizer_based/radau_pseudospectral_phase.py
+++ b/dymos/phases/optimizer_based/radau_pseudospectral_phase.py
@@ -263,7 +263,7 @@ class RadauPseudospectralPhase(OptimizerBasedPhaseBase):
         timeseries_comp._add_timeseries_output('time_phase',
                                                var_class=self._classify_var('time_phase'),
                                                units=time_units)
-        self.connect(src_name='time', tgt_name='timeseries.all_values:time_phase')
+        self.connect(src_name='time_phase', tgt_name='timeseries.all_values:time_phase')
 
         for name, options in iteritems(self.state_options):
             timeseries_comp._add_timeseries_output('states:{0}'.format(name),

--- a/dymos/phases/phase_base.py
+++ b/dymos/phases/phase_base.py
@@ -13,17 +13,14 @@ from openmdao.api import Problem, Group, IndepVarComp, SqliteRecorder
 from openmdao.utils.general_utils import warn_deprecation
 from openmdao.core.system import System
 
-# from dymos.phases.components import BoundaryConstraintComp
 from dymos.phases.components import BoundaryConstraintComp
 from dymos.phases.components import InputParameterComp
-from dymos.phases.components import TimeComp
 from dymos.phases.options import ControlOptionsDictionary, DesignParameterOptionsDictionary, \
     InputParameterOptionsDictionary, StateOptionsDictionary, TimeOptionsDictionary
 from dymos.phases.components import ControlInterpComp
 from dymos.phases.grid_data import GridData
 from dymos.ode_options import ODEOptions
 from dymos.utils.constants import INF_BOUND
-from dymos.utils.misc import get_rate_units
 from dymos.utils.misc import CoerceDesvar
 
 

--- a/dymos/phases/tests/test_sized_input_parameters.py
+++ b/dymos/phases/tests/test_sized_input_parameters.py
@@ -1,0 +1,148 @@
+import unittest
+
+from openmdao.api import Group, ExecComp, Problem
+from openmdao.api import DirectSolver, pyOptSparseDriver
+from openmdao.utils.assert_utils import assert_rel_error
+
+from dymos import declare_time, declare_state, declare_parameter
+from dymos import Phase
+from dymos.utils.lgl import lgl
+from dymos.models.eom import FlightPathEOM2D
+
+import numpy as np
+
+
+class TestInputParameterConnections(unittest.TestCase):
+
+    def test_dynamic_input_parameter_connections(self):
+
+        @declare_time(units='s')
+        @declare_state('v', rate_source='eom.v_dot', units='m/s')
+        @declare_state('h', rate_source='eom.h_dot', units='m')
+        @declare_parameter('m', targets='sum.m', units='kg', shape=(2, 2))
+        class TrajectoryODE(Group):
+            def initialize(self):
+                self.options.declare('num_nodes', types=int)
+
+            def setup(self):
+                nn = self.options['num_nodes']
+
+                self.add_subsystem('sum', ExecComp('m_tot = sum(m)',
+                                                   m={'value': np.zeros((nn, 2, 2))},
+                                                   m_tot={'value': np.zeros(nn)}))
+
+                self.add_subsystem('eom', FlightPathEOM2D(num_nodes=nn))
+
+                self.connect('sum.m_tot', 'eom.m')
+
+
+        optimizer = 'SLSQP'
+        num_segments = 1
+        transcription_order = 5
+
+        p = Problem(model=Group())
+
+        p.driver = pyOptSparseDriver()
+        p.driver.options['optimizer'] = optimizer
+        p.driver.options['dynamic_simul_derivs'] = True
+
+        seg_ends, _ = lgl(num_segments + 1)
+
+        phase = Phase(transcription='radau-ps',
+                      ode_class=TrajectoryODE,
+                      num_segments=num_segments, transcription_order=transcription_order,
+                      segment_ends=seg_ends,
+                      )
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(initial_bounds=(0.0, 100.0), duration_bounds=(0., 100.))
+
+        phase.set_state_options('h', fix_initial=True, fix_final=True, lower=0.0, units='m')
+        phase.set_state_options('v', fix_initial=True, fix_final=False, units='m/s')
+
+        phase.add_input_parameter('m', val=[[1, 2], [3, 4]], units='kg')
+
+        p.model.linear_solver = DirectSolver()
+
+        p.setup(check=True, force_alloc_complex=True)
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 100.0
+
+        p['phase0.states:h'] = phase.interpolate(ys=[20, 0], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, -5], nodes='state_input')
+
+        p.run_model()
+
+        expected = np.broadcast_to(np.array([[1, 2], [3, 4]]),
+                                   (p.model.phase0.grid_data.num_nodes, 2, 2))
+        assert_rel_error(self, p.get_val('phase0.rhs_all.sum.m'), expected)
+
+    def test_static_input_parameter_connections(self):
+
+        @declare_time(units='s')
+        @declare_state('v', rate_source='eom.v_dot', units='m/s')
+        @declare_state('h', rate_source='eom.h_dot', units='m')
+        @declare_parameter('m', targets='sum.m', units='kg', shape=(2, 2), dynamic=False)
+        class TrajectoryODE(Group):
+            def initialize(self):
+                self.options.declare('num_nodes', types=int)
+
+            def setup(self):
+                nn = self.options['num_nodes']
+
+                self.add_subsystem('sum', ExecComp('m_tot = sum(m)',
+                                                   m={'value': np.zeros((2, 2))},
+                                                   m_tot={'value': np.zeros(nn)}))
+
+                self.add_subsystem('eom', FlightPathEOM2D(num_nodes=nn))
+
+                self.connect('sum.m_tot', 'eom.m')
+
+
+        optimizer = 'SLSQP'
+        num_segments = 1
+        transcription_order = 5
+
+        p = Problem(model=Group())
+
+        p.driver = pyOptSparseDriver()
+        p.driver.options['optimizer'] = optimizer
+        p.driver.options['dynamic_simul_derivs'] = True
+
+        seg_ends, _ = lgl(num_segments + 1)
+
+        phase = Phase(transcription='radau-ps',
+                      ode_class=TrajectoryODE,
+                      num_segments=num_segments, transcription_order=transcription_order,
+                      segment_ends=seg_ends,
+                      )
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(initial_bounds=(0.0, 100.0), duration_bounds=(0., 100.))
+
+        phase.set_state_options('h', fix_initial=True, fix_final=True, lower=0.0, units='m')
+        phase.set_state_options('v', fix_initial=True, fix_final=False, units='m/s')
+
+        phase.add_input_parameter('m', val=[[1, 2], [3, 4]], units='kg')
+
+        p.model.linear_solver = DirectSolver()
+
+        p.setup(check=True, force_alloc_complex=True)
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 100.0
+
+        p['phase0.states:h'] = phase.interpolate(ys=[20, 0], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, -5], nodes='state_input')
+
+        p.run_model()
+
+        expected = np.array([[1, 2], [3, 4]])
+        assert_rel_error(self, p.get_val('phase0.rhs_all.sum.m'), expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/dymos/phases/tests/test_sized_input_parameters.py
+++ b/dymos/phases/tests/test_sized_input_parameters.py
@@ -35,7 +35,6 @@ class TestInputParameterConnections(unittest.TestCase):
 
                 self.connect('sum.m_tot', 'eom.m')
 
-
         optimizer = 'SLSQP'
         num_segments = 1
         transcription_order = 5
@@ -99,7 +98,6 @@ class TestInputParameterConnections(unittest.TestCase):
                 self.add_subsystem('eom', FlightPathEOM2D(num_nodes=nn))
 
                 self.connect('sum.m_tot', 'eom.m')
-
 
         optimizer = 'SLSQP'
         num_segments = 1


### PR DESCRIPTION
Fixes data overhead transfer, actually RadauPhase was using time instead of phase_time in the timeseries output.  Resolves #140

Adds tests to verify that sized input parameter connections are working as expected.  Resolves #138 