### PR TITLE
Vector constraints

### DIFF
--- a/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
@@ -20,7 +20,7 @@ except:
 
 class TestAircraftCruise(unittest.TestCase):
 
-    def test_cruise_results(self):
+    def test_cruise_results_gl(self):
         p = Problem(model=Group())
         if optimizer == 'SNOPT':
             p.driver = pyOptSparseDriver()
@@ -100,6 +100,88 @@ class TestAircraftCruise(unittest.TestCase):
         range = p.get_val('phase0.timeseries.states:range')
 
         assert_rel_error(self, range, tas*time, tolerance=1.0E-4)
+
+    def test_cruise_results_radau(self):
+        p = Problem(model=Group())
+        if optimizer == 'SNOPT':
+            p.driver = pyOptSparseDriver()
+            p.driver.options['optimizer'] = optimizer
+            p.driver.options['dynamic_simul_derivs'] = True
+            p.driver.opt_settings['Major iterations limit'] = 100
+            p.driver.opt_settings['Major step limit'] = 0.05
+            p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
+            p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
+            p.driver.opt_settings["Linesearch tolerance"] = 0.10
+            p.driver.opt_settings['iSumm'] = 6
+            p.driver.opt_settings['Verify level'] = 3
+        else:
+            p.driver = ScipyOptimizeDriver()
+            p.driver.options['dynamic_simul_derivs'] = True
+
+        phase = Phase('radau-ps',
+                      ode_class=AircraftODE,
+                      num_segments=1,
+                      transcription_order=13)
+
+        # Pass Reference Area from an external source
+        assumptions = p.model.add_subsystem('assumptions', IndepVarComp())
+        assumptions.add_output('S', val=427.8, units='m**2')
+        assumptions.add_output('mass_empty', val=1.0, units='kg')
+        assumptions.add_output('mass_payload', val=1.0, units='kg')
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(initial_bounds=(0, 0),
+                               duration_bounds=(3600, 3600),
+                               duration_ref=3600)
+
+        phase.set_state_options('range', units='km', fix_initial=True, fix_final=False, scaler=0.01,
+                                defect_scaler=0.01)
+        phase.set_state_options('mass_fuel', fix_final=True, upper=20000.0, lower=0.0,
+                                scaler=1.0E-4, defect_scaler=1.0E-2)
+        phase.set_state_options('alt', units='km', fix_initial=True)
+
+        phase.add_control('mach', units=None, opt=False)
+        phase.add_control('climb_rate', units='m/s', opt=False)
+
+        phase.add_input_parameter('S', units='m**2')
+        phase.add_input_parameter('mass_empty', units='kg')
+        phase.add_input_parameter('mass_payload', units='kg')
+
+        phase.add_path_constraint('propulsion.tau', lower=0.01, upper=1.0)
+
+        phase.add_timeseries_output('tas_comp.TAS', units='m/s')
+
+        p.model.connect('assumptions.S', 'phase0.input_parameters:S')
+        p.model.connect('assumptions.mass_empty', 'phase0.input_parameters:mass_empty')
+        p.model.connect('assumptions.mass_payload', 'phase0.input_parameters:mass_payload')
+
+        phase.add_objective('time', loc='final', ref=3600)
+
+        p.model.linear_solver = DirectSolver()
+
+        p.setup()
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 1.515132 * 3600.0
+        p['phase0.states:range'] = phase.interpolate(ys=(0, 1296.4), nodes='state_input')
+        p['phase0.states:mass_fuel'] = phase.interpolate(ys=(12236.594555, 0), nodes='state_input')
+        p['phase0.states:alt'] = 5.0
+        p['phase0.controls:mach'] = 0.8
+        p['phase0.controls:climb_rate'] = 0.0
+
+        p['assumptions.S'] = 427.8
+        p['assumptions.mass_empty'] = 0.15E6
+        p['assumptions.mass_payload'] = 84.02869 * 400
+
+        p.run_driver()
+
+        time = p.get_val('phase0.timeseries.time')
+        tas = p.get_val('phase0.timeseries.TAS', units='km/s')
+        range = p.get_val('phase0.timeseries.states:range')
+
+        assert_rel_error(self, range, tas*time, tolerance=1.0E-4)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_vector_boundary_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_vector_boundary_constraints.py
@@ -1,0 +1,291 @@
+from __future__ import print_function, division, absolute_import
+
+import unittest
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+from openmdao.api import Problem, Group, pyOptSparseDriver, ScipyOptimizeDriver, DirectSolver
+from openmdao.utils.assert_utils import assert_rel_error
+
+from dymos import Phase
+from dymos.examples.brachistochrone.brachistochrone_vector_states_ode \
+    import BrachistochroneVectorStatesODE
+
+SHOW_PLOTS = False
+
+
+class TestBrachistochroneVectorBoundaryConstraints(unittest.TestCase):
+
+    def test_brachistochrone_vector_boundary_constraints_radau_no_indices(self):
+
+        p = Problem(model=Group())
+
+        p.driver = ScipyOptimizeDriver()
+        p.driver.options['dynamic_simul_derivs'] = True
+
+        phase = Phase('radau-ps',
+                      ode_class=BrachistochroneVectorStatesODE,
+                      num_segments=20,
+                      transcription_order=3)
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
+
+        phase.set_state_options('pos', fix_initial=True, fix_final=False)
+        phase.set_state_options('v', fix_initial=True, fix_final=False)
+
+        phase.add_control('theta', continuity=True, rate_continuity=True,
+                          units='deg', lower=0.01, upper=179.9)
+
+        phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
+
+        phase.add_boundary_constraint('pos', loc='final', equals=[10, 5])
+
+        # Minimize time at the end of the phase
+        phase.add_objective('time', loc='final', scaler=10)
+
+        p.model.linear_solver = DirectSolver()
+        p.setup(check=True, force_alloc_complex=True)
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 2.0
+
+        pos0 = [0, 10]
+        posf = [10, 5]
+
+        p['phase0.states:pos'] = phase.interpolate(ys=[pos0, posf], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100], nodes='control_input')
+        p['phase0.design_parameters:g'] = 9.80665
+
+        p.run_driver()
+
+        assert_rel_error(self, p.get_val('phase0.time')[-1], 1.8016, tolerance=1.0E-3)
+
+        # Plot results
+        if SHOW_PLOTS:
+            p.run_driver()
+            exp_out = phase.simulate(times=50, record=False)
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_imp = p.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            x_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('x (m)')
+            ax.set_ylabel('y (m)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.time')
+            y_imp = p.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            x_exp = exp_out.get_val('phase0.timeseries.time')
+            y_exp = exp_out.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('time (s)')
+            ax.set_ylabel('theta rate2 (rad/s**2)')
+            ax.grid(True)
+            ax.legend(loc='lower right')
+
+            plt.show()
+
+        return p
+
+    def test_brachistochrone_vector_boundary_constraints_radau_full_indices(self):
+
+        p = Problem(model=Group())
+        p.driver = ScipyOptimizeDriver()
+        p.driver.options['dynamic_simul_derivs'] = True
+
+        phase = Phase('radau-ps',
+                      ode_class=BrachistochroneVectorStatesODE,
+                      num_segments=20,
+                      transcription_order=3)
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
+
+        phase.set_state_options('pos', fix_initial=True, fix_final=False)
+        phase.set_state_options('v', fix_initial=True, fix_final=False)
+
+        phase.add_control('theta', continuity=True, rate_continuity=True,
+                          units='deg', lower=0.01, upper=179.9)
+
+        phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
+
+        phase.add_boundary_constraint('pos', loc='final', equals=[10, 5], indices=[0, 1])
+
+        # Minimize time at the end of the phase
+        phase.add_objective('time', loc='final', scaler=10)
+
+        p.model.linear_solver = DirectSolver()
+        p.setup(check=True, force_alloc_complex=True)
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 2.0
+
+        pos0 = [0, 10]
+        posf = [10, 5]
+
+        p['phase0.states:pos'] = phase.interpolate(ys=[pos0, posf], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100], nodes='control_input')
+        p['phase0.design_parameters:g'] = 9.80665
+
+        p.run_driver()
+
+        assert_rel_error(self, p.get_val('phase0.time')[-1], 1.8016, tolerance=1.0E-3)
+
+        # Plot results
+        if SHOW_PLOTS:
+            p.run_driver()
+            exp_out = phase.simulate(times=50, record=False)
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_imp = p.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            x_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('x (m)')
+            ax.set_ylabel('y (m)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.time')
+            y_imp = p.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            x_exp = exp_out.get_val('phase0.timeseries.time')
+            y_exp = exp_out.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('time (s)')
+            ax.set_ylabel('theta rate2 (rad/s**2)')
+            ax.grid(True)
+            ax.legend(loc='lower right')
+
+            plt.show()
+
+        return p
+
+    def test_brachistochrone_vector_boundary_constraints_radau_partial_indices(self):
+
+        p = Problem(model=Group())
+        p.driver = ScipyOptimizeDriver()
+        p.driver.options['dynamic_simul_derivs'] = True
+
+        phase = Phase('radau-ps',
+                      ode_class=BrachistochroneVectorStatesODE,
+                      num_segments=20,
+                      transcription_order=3)
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
+
+        phase.set_state_options('pos', fix_initial=True, fix_final=[True, False])
+        phase.set_state_options('v', fix_initial=True, fix_final=False)
+
+        phase.add_control('theta', continuity=True, rate_continuity=True,
+                          units='deg', lower=0.01, upper=179.9)
+
+        phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
+
+        phase.add_boundary_constraint('pos', loc='final', equals=5, indices=[1])
+
+        # Minimize time at the end of the phase
+        phase.add_objective('time', loc='final', scaler=10)
+
+        p.model.linear_solver = DirectSolver()
+        p.setup(check=True, force_alloc_complex=True)
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 2.0
+
+        pos0 = [0, 10]
+        posf = [10, 5]
+
+        p['phase0.states:pos'] = phase.interpolate(ys=[pos0, posf], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100], nodes='control_input')
+        p['phase0.design_parameters:g'] = 9.80665
+
+        p.run_driver()
+
+        assert_rel_error(self, p.get_val('phase0.time')[-1], 1.8016, tolerance=1.0E-3)
+
+        # Plot results
+        if SHOW_PLOTS:
+            p.run_driver()
+            exp_out = phase.simulate(times=50, record=False)
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_imp = p.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            x_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('x (m)')
+            ax.set_ylabel('y (m)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.time')
+            y_imp = p.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            x_exp = exp_out.get_val('phase0.timeseries.time')
+            y_exp = exp_out.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('time (s)')
+            ax.set_ylabel('theta rate2 (rad/s**2)')
+            ax.grid(True)
+            ax.legend(loc='lower right')
+
+            plt.show()
+
+        return p
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
@@ -1,0 +1,438 @@
+from __future__ import print_function, division, absolute_import
+
+import unittest
+
+import numpy as np
+
+import matplotlib
+# matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+from openmdao.api import Problem, Group, pyOptSparseDriver, ScipyOptimizeDriver, DirectSolver
+from openmdao.utils.assert_utils import assert_rel_error
+
+from dymos import Phase
+from dymos.examples.brachistochrone.brachistochrone_vector_states_ode \
+    import BrachistochroneVectorStatesODE
+
+SHOW_PLOTS = True
+
+
+class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
+
+    def test_brachistochrone_vector_state_path_constraints_radau_partial_indices(self):
+
+        p = Problem(model=Group())
+
+        p.driver = ScipyOptimizeDriver()
+        p.driver.options['dynamic_simul_derivs'] = True
+
+        phase = Phase('radau-ps',
+                      ode_class=BrachistochroneVectorStatesODE,
+                      num_segments=20,
+                      transcription_order=3)
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
+
+        phase.set_state_options('pos', fix_initial=True, fix_final=True)
+        phase.set_state_options('v', fix_initial=True, fix_final=False)
+
+        phase.add_control('theta', continuity=True, rate_continuity=True,
+                          units='deg', lower=0.01, upper=179.9)
+
+        phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
+
+        phase.add_path_constraint('pos', indices=[1], lower=5)
+
+        phase.add_timeseries_output('pos_dot', shape=(2,), units='m/s')
+
+        # Minimize time at the end of the phase
+        phase.add_objective('time', loc='final', scaler=10)
+
+        p.model.linear_solver = DirectSolver()
+        p.setup(check=True, force_alloc_complex=True)
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 2.0
+
+        pos0 = [0, 10]
+        posf = [10, 5]
+
+        p['phase0.states:pos'] = phase.interpolate(ys=[pos0, posf], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100], nodes='control_input')
+        p['phase0.design_parameters:g'] = 9.80665
+
+        p.run_driver()
+
+        assert_rel_error(self, p.get_val('phase0.time')[-1], 1.8016, tolerance=1.0E-3)
+
+        # Plot results
+        if SHOW_PLOTS:
+            p.run_driver()
+            exp_out = phase.simulate(times=50, record=False)
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_imp = p.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            x_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('x (m)')
+            ax.set_ylabel('y (m)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution\nVelocity')
+
+            t_imp = p.get_val('phase0.timeseries.time')
+            t_exp = exp_out.get_val('phase0.timeseries.time')
+
+            xdot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 0]
+            ydot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 1]
+
+            xdot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 0]
+            ydot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 1]
+
+            ax.plot(t_imp, xdot_imp, 'bo', label='implicit')
+            ax.plot(t_exp, xdot_exp, 'b-', label='explicit')
+
+            ax.plot(t_imp, ydot_imp, 'ro', label='implicit')
+            ax.plot(t_exp, ydot_exp, 'r-', label='explicit')
+
+            ax.set_xlabel('t (s)')
+            ax.set_ylabel('v (m/s)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.time')
+            y_imp = p.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            x_exp = exp_out.get_val('phase0.timeseries.time')
+            y_exp = exp_out.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('time (s)')
+            ax.set_ylabel('theta rate2 (rad/s**2)')
+            ax.grid(True)
+            ax.legend(loc='lower right')
+
+            plt.show()
+
+        return p
+
+    def test_brachistochrone_vector_ode_path_constraints_radau_partial_indices(self):
+
+        p = Problem(model=Group())
+
+        p.driver = pyOptSparseDriver()
+        p.driver.options['optimizer'] = 'SNOPT'
+        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.opt_settings['iSumm'] = 6
+
+        phase = Phase('radau-ps',
+                      ode_class=BrachistochroneVectorStatesODE,
+                      num_segments=20,
+                      transcription_order=3)
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
+
+        phase.set_state_options('pos', fix_initial=True, fix_final=True)
+        phase.set_state_options('v', fix_initial=True, fix_final=False)
+
+        phase.add_control('theta', continuity=True, rate_continuity=True,
+                          units='deg', lower=0.01, upper=179.9)
+
+        phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
+
+        phase.add_path_constraint('pos_dot', shape=(2,), units='m/s', indices=[1],
+                                  lower=-4, upper=4)
+
+        # Minimize time at the end of the phase
+        phase.add_objective('time', loc='final', scaler=10)
+
+        p.model.linear_solver = DirectSolver()
+        p.setup(check=True, force_alloc_complex=True)
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 2.0
+
+        pos0 = [0, 10]
+        posf = [10, 5]
+
+        p['phase0.states:pos'] = phase.interpolate(ys=[pos0, posf], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100], nodes='control_input')
+        p['phase0.design_parameters:g'] = 9.80665
+
+        p.run_driver()
+
+        assert_rel_error(self,
+                         np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
+                         -4,
+                         tolerance=1.0E-2)
+
+        # Plot results
+        if SHOW_PLOTS:
+            p.run_driver()
+            exp_out = phase.simulate(times=50, record=False)
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_imp = p.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            x_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('x (m)')
+            ax.set_ylabel('y (m)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution\nVelocity')
+
+            t_imp = p.get_val('phase0.timeseries.time')
+            t_exp = exp_out.get_val('phase0.timeseries.time')
+
+            xdot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 0]
+            ydot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 1]
+
+            xdot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 0]
+            ydot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 1]
+
+            ax.plot(t_imp, xdot_imp, 'bo', label='implicit')
+            ax.plot(t_exp, xdot_exp, 'b-', label='explicit')
+
+            ax.plot(t_imp, ydot_imp, 'ro', label='implicit')
+            ax.plot(t_exp, ydot_exp, 'r-', label='explicit')
+
+            ax.set_xlabel('t (s)')
+            ax.set_ylabel('v (m/s)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.time')
+            y_imp = p.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            x_exp = exp_out.get_val('phase0.timeseries.time')
+            y_exp = exp_out.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('time (s)')
+            ax.set_ylabel('theta rate2 (rad/s**2)')
+            ax.grid(True)
+            ax.legend(loc='lower right')
+
+            plt.show()
+
+        return p
+
+
+    def test_brachistochrone_vector_boundary_constraints_radau_full_indices(self):
+
+        p = Problem(model=Group())
+        p.driver = ScipyOptimizeDriver()
+        p.driver.options['dynamic_simul_derivs'] = True
+
+        phase = Phase('radau-ps',
+                      ode_class=BrachistochroneVectorStatesODE,
+                      num_segments=20,
+                      transcription_order=3)
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
+
+        phase.set_state_options('pos', fix_initial=True, fix_final=False)
+        phase.set_state_options('v', fix_initial=True, fix_final=False)
+
+        phase.add_control('theta', continuity=True, rate_continuity=True,
+                          units='deg', lower=0.01, upper=179.9)
+
+        phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
+
+        phase.add_boundary_constraint('pos', loc='final', equals=[10, 5], indices=[0, 1])
+
+        # Minimize time at the end of the phase
+        phase.add_objective('time', loc='final', scaler=10)
+
+        p.model.linear_solver = DirectSolver()
+        p.setup(check=True, force_alloc_complex=True)
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 2.0
+
+        pos0 = [0, 10]
+        posf = [10, 5]
+
+        p['phase0.states:pos'] = phase.interpolate(ys=[pos0, posf], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100], nodes='control_input')
+        p['phase0.design_parameters:g'] = 9.80665
+
+        p.run_driver()
+
+        assert_rel_error(self, p.get_val('phase0.time')[-1], 1.8016, tolerance=1.0E-3)
+
+        # Plot results
+        if SHOW_PLOTS:
+            p.run_driver()
+            exp_out = phase.simulate(times=50, record=False)
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_imp = p.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            x_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('x (m)')
+            ax.set_ylabel('y (m)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.time')
+            y_imp = p.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            x_exp = exp_out.get_val('phase0.timeseries.time')
+            y_exp = exp_out.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('time (s)')
+            ax.set_ylabel('theta rate2 (rad/s**2)')
+            ax.grid(True)
+            ax.legend(loc='lower right')
+
+            plt.show()
+
+        return p
+
+    def test_brachistochrone_vector_boundary_constraints_radau_partial_indices(self):
+
+        p = Problem(model=Group())
+        p.driver = ScipyOptimizeDriver()
+        p.driver.options['dynamic_simul_derivs'] = True
+
+        phase = Phase('radau-ps',
+                      ode_class=BrachistochroneVectorStatesODE,
+                      num_segments=20,
+                      transcription_order=3)
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
+
+        phase.set_state_options('pos', fix_initial=True, fix_final=[True, False])
+        phase.set_state_options('v', fix_initial=True, fix_final=False)
+
+        phase.add_control('theta', continuity=True, rate_continuity=True,
+                          units='deg', lower=0.01, upper=179.9)
+
+        phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
+
+        phase.add_boundary_constraint('pos', loc='final', equals=5, indices=[1])
+
+        # Minimize time at the end of the phase
+        phase.add_objective('time', loc='final', scaler=10)
+
+        p.model.linear_solver = DirectSolver()
+        p.setup(check=True, force_alloc_complex=True)
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 2.0
+
+        pos0 = [0, 10]
+        posf = [10, 5]
+
+        p['phase0.states:pos'] = phase.interpolate(ys=[pos0, posf], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100], nodes='control_input')
+        p['phase0.design_parameters:g'] = 9.80665
+
+        p.run_driver()
+
+        assert_rel_error(self, p.get_val('phase0.time')[-1], 1.8016, tolerance=1.0E-3)
+
+        # Plot results
+        if SHOW_PLOTS:
+            p.run_driver()
+            exp_out = phase.simulate(times=50, record=False)
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_imp = p.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            x_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('x (m)')
+            ax.set_ylabel('y (m)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.time')
+            y_imp = p.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            x_exp = exp_out.get_val('phase0.timeseries.time')
+            y_exp = exp_out.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('time (s)')
+            ax.set_ylabel('theta rate2 (rad/s**2)')
+            ax.grid(True)
+            ax.legend(loc='lower right')
+
+            plt.show()
+
+        return p
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
@@ -138,10 +138,8 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         p = Problem(model=Group())
 
-        p.driver = pyOptSparseDriver()
-        p.driver.options['optimizer'] = 'SNOPT'
+        p.driver = ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
-        p.driver.opt_settings['iSumm'] = 6
 
         phase = Phase('radau-ps',
                       ode_class=BrachistochroneVectorStatesODE,
@@ -258,10 +256,8 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         p = Problem(model=Group())
 
-        p.driver = pyOptSparseDriver()
-        p.driver.options['optimizer'] = 'SNOPT'
+        p.driver = ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
-        p.driver.opt_settings['iSumm'] = 6
 
         phase = Phase('radau-ps',
                       ode_class=BrachistochroneVectorStatesODE,
@@ -492,10 +488,8 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         p = Problem(model=Group())
 
-        p.driver = pyOptSparseDriver()
-        p.driver.options['optimizer'] = 'SNOPT'
+        p.driver = ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
-        p.driver.opt_settings['iSumm'] = 6
 
         phase = Phase('gauss-lobatto',
                       ode_class=BrachistochroneVectorStatesODE,
@@ -612,10 +606,8 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         p = Problem(model=Group())
 
-        p.driver = pyOptSparseDriver()
-        p.driver.options['optimizer'] = 'SNOPT'
+        p.driver = ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
-        p.driver.opt_settings['iSumm'] = 6
 
         phase = Phase('gauss-lobatto',
                       ode_class=BrachistochroneVectorStatesODE,
@@ -728,17 +720,14 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         return p
 
-    #TODO: Address this when the rk_phase_linkages update is merged
-    @unittest.expectedFailure
     def test_brachistochrone_vector_state_path_constraints_rk_partial_indices(self):
-
         p = Problem(model=Group())
 
         p.driver = ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
         phase = RungeKuttaPhase(ode_class=BrachistochroneVectorStatesODE,
-                                num_segments=20,
+                                num_segments=50,
                                 method='rk4')
 
         p.model.add_subsystem('phase0', phase)
@@ -777,7 +766,8 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self, p.get_val('phase0.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_rel_error(self, np.min(p.get_val('phase0.timeseries.states:pos')[:, 1]), 5.0,
+                         tolerance=1.0E-3)
 
         # Plot results
         if SHOW_PLOTS:
@@ -844,16 +834,12 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         return p
 
-    #TODO: Address this when the rk_phase_linkages update is merged
-    @unittest.expectedFailure
     def test_brachistochrone_vector_ode_path_constraints_rk_partial_indices(self):
 
         p = Problem(model=Group())
 
-        p.driver = pyOptSparseDriver()
-        p.driver.options['optimizer'] = 'SNOPT'
+        p.driver = ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
-        p.driver.opt_settings['iSumm'] = 6
 
         phase = RungeKuttaPhase(ode_class=BrachistochroneVectorStatesODE,
                                 num_segments=20,
@@ -863,13 +849,15 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
 
-        phase.set_state_options('pos', fix_initial=True, fix_final=True)
+        phase.set_state_options('pos', fix_initial=True, fix_final=False)
         phase.set_state_options('v', fix_initial=True, fix_final=False)
 
         phase.add_control('theta', continuity=True, rate_continuity=True,
                           units='deg', lower=0.01, upper=179.9)
 
         phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
+
+        phase.add_boundary_constraint('pos', loc='final', equals=[10, 5])
 
         phase.add_path_constraint('pos_dot', shape=(2,), units='m/s', indices=[1],
                                   lower=-4, upper=4)
@@ -964,17 +952,13 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
             plt.show()
 
         return p
-    
-    #TODO: Address this when the rk_phase_linkages update is merged
-    @unittest.expectedFailure
+
     def test_brachistochrone_vector_ode_path_constraints_rk_no_indices(self):
 
         p = Problem(model=Group())
 
-        p.driver = pyOptSparseDriver()
-        p.driver.options['optimizer'] = 'SNOPT'
+        p.driver = ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
-        p.driver.opt_settings['iSumm'] = 6
 
         phase = RungeKuttaPhase(ode_class=BrachistochroneVectorStatesODE,
                                 num_segments=20,
@@ -984,13 +968,15 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
 
-        phase.set_state_options('pos', fix_initial=True, fix_final=True)
+        phase.set_state_options('pos', fix_initial=True, fix_final=False)
         phase.set_state_options('v', fix_initial=True, fix_final=False)
 
         phase.add_control('theta', continuity=True, rate_continuity=True,
                           units='deg', lower=0.01, upper=179.9)
 
         phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
+
+        phase.add_boundary_constraint('pos', loc='final', equals=[10, 5])
 
         phase.add_path_constraint('pos_dot', shape=(2,), units='m/s',
                                   lower=-4, upper=12)

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
@@ -5,13 +5,13 @@ import unittest
 import numpy as np
 
 import matplotlib
-# matplotlib.use('Agg')
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
 from openmdao.api import Problem, Group, pyOptSparseDriver, ScipyOptimizeDriver, DirectSolver
 from openmdao.utils.assert_utils import assert_rel_error
 
-from dymos import Phase
+from dymos import Phase, RungeKuttaPhase
 from dymos.examples.brachistochrone.brachistochrone_vector_states_ode \
     import BrachistochroneVectorStatesODE
 
@@ -71,7 +71,6 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         # Plot results
         if SHOW_PLOTS:
-            p.run_driver()
             exp_out = phase.simulate(times=50, record=False)
 
             fig, ax = plt.subplots()
@@ -164,6 +163,8 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         phase.add_path_constraint('pos_dot', shape=(2,), units='m/s', indices=[1],
                                   lower=-4, upper=4)
 
+        phase.add_timeseries_output('pos_dot', shape=(2,), units='m/s')
+
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
@@ -190,7 +191,6 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         # Plot results
         if SHOW_PLOTS:
-            p.run_driver()
             exp_out = phase.simulate(times=50, record=False)
 
             fig, ax = plt.subplots()
@@ -254,12 +254,14 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         return p
 
-
-    def test_brachistochrone_vector_boundary_constraints_radau_full_indices(self):
+    def test_brachistochrone_vector_ode_path_constraints_radau_no_indices(self):
 
         p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+
+        p.driver = pyOptSparseDriver()
+        p.driver.options['optimizer'] = 'SNOPT'
         p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.opt_settings['iSumm'] = 6
 
         phase = Phase('radau-ps',
                       ode_class=BrachistochroneVectorStatesODE,
@@ -270,7 +272,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
 
-        phase.set_state_options('pos', fix_initial=True, fix_final=False)
+        phase.set_state_options('pos', fix_initial=True, fix_final=True)
         phase.set_state_options('v', fix_initial=True, fix_final=False)
 
         phase.add_control('theta', continuity=True, rate_continuity=True,
@@ -278,7 +280,10 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
 
-        phase.add_boundary_constraint('pos', loc='final', equals=[10, 5], indices=[0, 1])
+        phase.add_path_constraint('pos_dot', shape=(2,), units='m/s',
+                                  lower=-4, upper=12)
+
+        phase.add_timeseries_output('pos_dot', shape=(2,), units='m/s')
 
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
@@ -299,11 +304,13 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self, p.get_val('phase0.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_rel_error(self,
+                         np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
+                         -4,
+                         tolerance=1.0E-2)
 
         # Plot results
         if SHOW_PLOTS:
-            p.run_driver()
             exp_out = phase.simulate(times=50, record=False)
 
             fig, ax = plt.subplots()
@@ -320,6 +327,29 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
             ax.set_xlabel('x (m)')
             ax.set_ylabel('y (m)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution\nVelocity')
+
+            t_imp = p.get_val('phase0.timeseries.time')
+            t_exp = exp_out.get_val('phase0.timeseries.time')
+
+            xdot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 0]
+            ydot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 1]
+
+            xdot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 0]
+            ydot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 1]
+
+            ax.plot(t_imp, xdot_imp, 'bo', label='implicit')
+            ax.plot(t_exp, xdot_exp, 'b-', label='explicit')
+
+            ax.plot(t_imp, ydot_imp, 'ro', label='implicit')
+            ax.plot(t_exp, ydot_exp, 'r-', label='explicit')
+
+            ax.set_xlabel('t (s)')
+            ax.set_ylabel('v (m/s)')
             ax.grid(True)
             ax.legend(loc='upper right')
 
@@ -344,13 +374,14 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         return p
 
-    def test_brachistochrone_vector_boundary_constraints_radau_partial_indices(self):
+    def test_brachistochrone_vector_state_path_constraints_gl_partial_indices(self):
 
         p = Problem(model=Group())
+
         p.driver = ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase('radau-ps',
+        phase = Phase('gauss-lobatto',
                       ode_class=BrachistochroneVectorStatesODE,
                       num_segments=20,
                       transcription_order=3)
@@ -359,7 +390,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
 
-        phase.set_state_options('pos', fix_initial=True, fix_final=[True, False])
+        phase.set_state_options('pos', fix_initial=True, fix_final=True)
         phase.set_state_options('v', fix_initial=True, fix_final=False)
 
         phase.add_control('theta', continuity=True, rate_continuity=True,
@@ -367,7 +398,9 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
 
-        phase.add_boundary_constraint('pos', loc='final', equals=5, indices=[1])
+        phase.add_path_constraint('pos', indices=[1], lower=5)
+
+        phase.add_timeseries_output('pos_dot', shape=(2,), units='m/s')
 
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
@@ -392,7 +425,6 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         # Plot results
         if SHOW_PLOTS:
-            p.run_driver()
             exp_out = phase.simulate(times=50, record=False)
 
             fig, ax = plt.subplots()
@@ -409,6 +441,627 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
             ax.set_xlabel('x (m)')
             ax.set_ylabel('y (m)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution\nVelocity')
+
+            t_imp = p.get_val('phase0.timeseries.time')
+            t_exp = exp_out.get_val('phase0.timeseries.time')
+
+            xdot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 0]
+            ydot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 1]
+
+            xdot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 0]
+            ydot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 1]
+
+            ax.plot(t_imp, xdot_imp, 'bo', label='implicit')
+            ax.plot(t_exp, xdot_exp, 'b-', label='explicit')
+
+            ax.plot(t_imp, ydot_imp, 'ro', label='implicit')
+            ax.plot(t_exp, ydot_exp, 'r-', label='explicit')
+
+            ax.set_xlabel('t (s)')
+            ax.set_ylabel('v (m/s)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.time')
+            y_imp = p.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            x_exp = exp_out.get_val('phase0.timeseries.time')
+            y_exp = exp_out.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('time (s)')
+            ax.set_ylabel('theta rate2 (rad/s**2)')
+            ax.grid(True)
+            ax.legend(loc='lower right')
+
+            plt.show()
+
+        return p
+
+    def test_brachistochrone_vector_ode_path_constraints_gl_partial_indices(self):
+
+        p = Problem(model=Group())
+
+        p.driver = pyOptSparseDriver()
+        p.driver.options['optimizer'] = 'SNOPT'
+        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.opt_settings['iSumm'] = 6
+
+        phase = Phase('gauss-lobatto',
+                      ode_class=BrachistochroneVectorStatesODE,
+                      num_segments=20,
+                      transcription_order=3)
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
+
+        phase.set_state_options('pos', fix_initial=True, fix_final=True)
+        phase.set_state_options('v', fix_initial=True, fix_final=False)
+
+        phase.add_control('theta', continuity=True, rate_continuity=True,
+                          units='deg', lower=0.01, upper=179.9)
+
+        phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
+
+        phase.add_path_constraint('pos_dot', shape=(2,), units='m/s', indices=[1],
+                                  lower=-4, upper=4)
+
+        phase.add_timeseries_output('pos_dot', shape=(2,), units='m/s')
+
+        # Minimize time at the end of the phase
+        phase.add_objective('time', loc='final', scaler=10)
+
+        p.model.linear_solver = DirectSolver()
+        p.setup(check=True, force_alloc_complex=True)
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 2.0
+
+        pos0 = [0, 10]
+        posf = [10, 5]
+
+        p['phase0.states:pos'] = phase.interpolate(ys=[pos0, posf], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100], nodes='control_input')
+        p['phase0.design_parameters:g'] = 9.80665
+
+        p.run_driver()
+
+        assert_rel_error(self,
+                         np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
+                         -4,
+                         tolerance=1.0E-2)
+
+        # Plot results
+        if SHOW_PLOTS:
+            exp_out = phase.simulate(times=50, record=False)
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_imp = p.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            x_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('x (m)')
+            ax.set_ylabel('y (m)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution\nVelocity')
+
+            t_imp = p.get_val('phase0.timeseries.time')
+            t_exp = exp_out.get_val('phase0.timeseries.time')
+
+            xdot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 0]
+            ydot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 1]
+
+            xdot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 0]
+            ydot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 1]
+
+            ax.plot(t_imp, xdot_imp, 'bo', label='implicit')
+            ax.plot(t_exp, xdot_exp, 'b-', label='explicit')
+
+            ax.plot(t_imp, ydot_imp, 'ro', label='implicit')
+            ax.plot(t_exp, ydot_exp, 'r-', label='explicit')
+
+            ax.set_xlabel('t (s)')
+            ax.set_ylabel('v (m/s)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.time')
+            y_imp = p.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            x_exp = exp_out.get_val('phase0.timeseries.time')
+            y_exp = exp_out.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('time (s)')
+            ax.set_ylabel('theta rate2 (rad/s**2)')
+            ax.grid(True)
+            ax.legend(loc='lower right')
+
+            plt.show()
+
+        return p
+
+    def test_brachistochrone_vector_ode_path_constraints_gl_no_indices(self):
+
+        p = Problem(model=Group())
+
+        p.driver = pyOptSparseDriver()
+        p.driver.options['optimizer'] = 'SNOPT'
+        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.opt_settings['iSumm'] = 6
+
+        phase = Phase('gauss-lobatto',
+                      ode_class=BrachistochroneVectorStatesODE,
+                      num_segments=20,
+                      transcription_order=3)
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
+
+        phase.set_state_options('pos', fix_initial=True, fix_final=True)
+        phase.set_state_options('v', fix_initial=True, fix_final=False)
+
+        phase.add_control('theta', continuity=True, rate_continuity=True,
+                          units='deg', lower=0.01, upper=179.9)
+
+        phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
+
+        phase.add_path_constraint('pos_dot', shape=(2,), units='m/s',
+                                  lower=-4, upper=12)
+
+        phase.add_timeseries_output('pos_dot', shape=(2,), units='m/s')
+
+        # Minimize time at the end of the phase
+        phase.add_objective('time', loc='final', scaler=10)
+
+        p.model.linear_solver = DirectSolver()
+        p.setup(check=True, force_alloc_complex=True)
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 2.0
+
+        pos0 = [0, 10]
+        posf = [10, 5]
+
+        p['phase0.states:pos'] = phase.interpolate(ys=[pos0, posf], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100], nodes='control_input')
+        p['phase0.design_parameters:g'] = 9.80665
+
+        p.run_driver()
+
+        assert_rel_error(self,
+                         np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
+                         -4,
+                         tolerance=1.0E-2)
+
+        # Plot results
+        if SHOW_PLOTS:
+            exp_out = phase.simulate(times=50, record=False)
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_imp = p.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            x_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('x (m)')
+            ax.set_ylabel('y (m)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution\nVelocity')
+
+            t_imp = p.get_val('phase0.timeseries.time')
+            t_exp = exp_out.get_val('phase0.timeseries.time')
+
+            xdot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 0]
+            ydot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 1]
+
+            xdot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 0]
+            ydot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 1]
+
+            ax.plot(t_imp, xdot_imp, 'bo', label='implicit')
+            ax.plot(t_exp, xdot_exp, 'b-', label='explicit')
+
+            ax.plot(t_imp, ydot_imp, 'ro', label='implicit')
+            ax.plot(t_exp, ydot_exp, 'r-', label='explicit')
+
+            ax.set_xlabel('t (s)')
+            ax.set_ylabel('v (m/s)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.time')
+            y_imp = p.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            x_exp = exp_out.get_val('phase0.timeseries.time')
+            y_exp = exp_out.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('time (s)')
+            ax.set_ylabel('theta rate2 (rad/s**2)')
+            ax.grid(True)
+            ax.legend(loc='lower right')
+
+            plt.show()
+
+        return p
+
+    #TODO: Address this when the rk_phase_linkages update is merged
+    @unittest.expectedFailure
+    def test_brachistochrone_vector_state_path_constraints_rk_partial_indices(self):
+
+        p = Problem(model=Group())
+
+        p.driver = ScipyOptimizeDriver()
+        p.driver.options['dynamic_simul_derivs'] = True
+
+        phase = RungeKuttaPhase(ode_class=BrachistochroneVectorStatesODE,
+                                num_segments=20,
+                                method='rk4')
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
+
+        phase.set_state_options('pos', fix_initial=True, fix_final=False)
+        phase.set_state_options('v', fix_initial=True, fix_final=False)
+
+        phase.add_control('theta', continuity=True, rate_continuity=True,
+                          units='deg', lower=0.01, upper=179.9)
+
+        phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
+
+        phase.add_boundary_constraint('pos', loc='final', equals=[10, 5])
+        phase.add_path_constraint('pos', indices=[1], lower=5)
+
+        phase.add_timeseries_output('pos_dot', shape=(2,), units='m/s')
+
+        # Minimize time at the end of the phase
+        phase.add_objective('time', loc='final', scaler=10)
+
+        p.model.linear_solver = DirectSolver()
+        p.setup(check=True, force_alloc_complex=True)
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 2.0
+
+        pos0 = [0, 10]
+        posf = [10, 5]
+
+        p['phase0.states:pos'] = phase.interpolate(ys=[pos0, posf], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100], nodes='control_input')
+        p['phase0.design_parameters:g'] = 9.80665
+
+        p.run_driver()
+
+        assert_rel_error(self, p.get_val('phase0.time')[-1], 1.8016, tolerance=1.0E-3)
+
+        # Plot results
+        if SHOW_PLOTS:
+            exp_out = phase.simulate(times=50, record=False)
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_imp = p.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            x_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('x (m)')
+            ax.set_ylabel('y (m)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution\nVelocity')
+
+            t_imp = p.get_val('phase0.timeseries.time')
+            t_exp = exp_out.get_val('phase0.timeseries.time')
+
+            xdot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 0]
+            ydot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 1]
+
+            xdot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 0]
+            ydot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 1]
+
+            ax.plot(t_imp, xdot_imp, 'bo', label='implicit')
+            ax.plot(t_exp, xdot_exp, 'b-', label='explicit')
+
+            ax.plot(t_imp, ydot_imp, 'ro', label='implicit')
+            ax.plot(t_exp, ydot_exp, 'r-', label='explicit')
+
+            ax.set_xlabel('t (s)')
+            ax.set_ylabel('v (m/s)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.time')
+            y_imp = p.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            x_exp = exp_out.get_val('phase0.timeseries.time')
+            y_exp = exp_out.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('time (s)')
+            ax.set_ylabel('theta rate2 (rad/s**2)')
+            ax.grid(True)
+            ax.legend(loc='lower right')
+
+            plt.show()
+
+        return p
+
+    #TODO: Address this when the rk_phase_linkages update is merged
+    @unittest.expectedFailure
+    def test_brachistochrone_vector_ode_path_constraints_rk_partial_indices(self):
+
+        p = Problem(model=Group())
+
+        p.driver = pyOptSparseDriver()
+        p.driver.options['optimizer'] = 'SNOPT'
+        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.opt_settings['iSumm'] = 6
+
+        phase = RungeKuttaPhase(ode_class=BrachistochroneVectorStatesODE,
+                                num_segments=20,
+                                method='rk4')
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
+
+        phase.set_state_options('pos', fix_initial=True, fix_final=True)
+        phase.set_state_options('v', fix_initial=True, fix_final=False)
+
+        phase.add_control('theta', continuity=True, rate_continuity=True,
+                          units='deg', lower=0.01, upper=179.9)
+
+        phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
+
+        phase.add_path_constraint('pos_dot', shape=(2,), units='m/s', indices=[1],
+                                  lower=-4, upper=4)
+
+        phase.add_timeseries_output('pos_dot', shape=(2,), units='m/s')
+
+        # Minimize time at the end of the phase
+        phase.add_objective('time', loc='final', scaler=10)
+
+        p.model.linear_solver = DirectSolver()
+        p.setup(check=True, force_alloc_complex=True)
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 2.0
+
+        pos0 = [0, 10]
+        posf = [10, 5]
+
+        p['phase0.states:pos'] = phase.interpolate(ys=[pos0, posf], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100], nodes='control_input')
+        p['phase0.design_parameters:g'] = 9.80665
+
+        p.run_driver()
+
+        assert_rel_error(self,
+                         np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
+                         -4,
+                         tolerance=1.0E-2)
+
+        # Plot results
+        if SHOW_PLOTS:
+            exp_out = phase.simulate(times=50, record=False)
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_imp = p.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            x_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('x (m)')
+            ax.set_ylabel('y (m)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution\nVelocity')
+
+            t_imp = p.get_val('phase0.timeseries.time')
+            t_exp = exp_out.get_val('phase0.timeseries.time')
+
+            xdot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 0]
+            ydot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 1]
+
+            xdot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 0]
+            ydot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 1]
+
+            ax.plot(t_imp, xdot_imp, 'bo', label='implicit')
+            ax.plot(t_exp, xdot_exp, 'b-', label='explicit')
+
+            ax.plot(t_imp, ydot_imp, 'ro', label='implicit')
+            ax.plot(t_exp, ydot_exp, 'r-', label='explicit')
+
+            ax.set_xlabel('t (s)')
+            ax.set_ylabel('v (m/s)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.time')
+            y_imp = p.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            x_exp = exp_out.get_val('phase0.timeseries.time')
+            y_exp = exp_out.get_val('phase0.timeseries.control_rates:theta_rate2')
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('time (s)')
+            ax.set_ylabel('theta rate2 (rad/s**2)')
+            ax.grid(True)
+            ax.legend(loc='lower right')
+
+            plt.show()
+
+        return p
+    
+    #TODO: Address this when the rk_phase_linkages update is merged
+    @unittest.expectedFailure
+    def test_brachistochrone_vector_ode_path_constraints_rk_no_indices(self):
+
+        p = Problem(model=Group())
+
+        p.driver = pyOptSparseDriver()
+        p.driver.options['optimizer'] = 'SNOPT'
+        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.opt_settings['iSumm'] = 6
+
+        phase = RungeKuttaPhase(ode_class=BrachistochroneVectorStatesODE,
+                                num_segments=20,
+                                method='rk4')
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
+
+        phase.set_state_options('pos', fix_initial=True, fix_final=True)
+        phase.set_state_options('v', fix_initial=True, fix_final=False)
+
+        phase.add_control('theta', continuity=True, rate_continuity=True,
+                          units='deg', lower=0.01, upper=179.9)
+
+        phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
+
+        phase.add_path_constraint('pos_dot', shape=(2,), units='m/s',
+                                  lower=-4, upper=12)
+
+        phase.add_timeseries_output('pos_dot', shape=(2,), units='m/s')
+
+        # Minimize time at the end of the phase
+        phase.add_objective('time', loc='final', scaler=10)
+
+        p.model.linear_solver = DirectSolver()
+        p.setup(check=True, force_alloc_complex=True)
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 2.0
+
+        pos0 = [0, 10]
+        posf = [10, 5]
+
+        p['phase0.states:pos'] = phase.interpolate(ys=[pos0, posf], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+        p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100], nodes='control_input')
+        p['phase0.design_parameters:g'] = 9.80665
+
+        p.run_driver()
+
+        assert_rel_error(self,
+                         np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
+                         -4,
+                         tolerance=1.0E-2)
+
+        # Plot results
+        if SHOW_PLOTS:
+            exp_out = phase.simulate(times=50, record=False)
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution')
+
+            x_imp = p.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_imp = p.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            x_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 0]
+            y_exp = exp_out.get_val('phase0.timeseries.states:pos')[:, 1]
+
+            ax.plot(x_imp, y_imp, 'ro', label='implicit')
+            ax.plot(x_exp, y_exp, 'b-', label='explicit')
+
+            ax.set_xlabel('x (m)')
+            ax.set_ylabel('y (m)')
+            ax.grid(True)
+            ax.legend(loc='upper right')
+
+            fig, ax = plt.subplots()
+            fig.suptitle('Brachistochrone Solution\nVelocity')
+
+            t_imp = p.get_val('phase0.timeseries.time')
+            t_exp = exp_out.get_val('phase0.timeseries.time')
+
+            xdot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 0]
+            ydot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 1]
+
+            xdot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 0]
+            ydot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 1]
+
+            ax.plot(t_imp, xdot_imp, 'bo', label='implicit')
+            ax.plot(t_exp, xdot_exp, 'b-', label='explicit')
+
+            ax.plot(t_imp, ydot_imp, 'ro', label='implicit')
+            ax.plot(t_exp, ydot_exp, 'r-', label='explicit')
+
+            ax.set_xlabel('t (s)')
+            ax.set_ylabel('v (m/s)')
             ax.grid(True)
             ax.legend(loc='upper right')
 

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
@@ -8,7 +8,7 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
-from openmdao.api import Problem, Group, pyOptSparseDriver, ScipyOptimizeDriver, DirectSolver
+from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
 from openmdao.utils.assert_utils import assert_rel_error
 
 from dymos import Phase, RungeKuttaPhase

--- a/dymos/examples/min_time_climb/ex_min_time_climb.py
+++ b/dymos/examples/min_time_climb/ex_min_time_climb.py
@@ -33,7 +33,7 @@ def min_time_climb(optimizer='SLSQP', num_seg=3, transcription='gauss-lobatto',
         p.driver.opt_settings['Major step limit'] = 0.5
         # p.driver.opt_settings['Verify level'] = 3
 
-    phase = Phase('gauss-lobatto',
+    phase = Phase(transcription,
                   ode_class=MinTimeClimbODE,
                   num_segments=num_seg,
                   compressed=True,

--- a/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
+++ b/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
@@ -8,9 +8,6 @@ from shutil import rmtree
 from tempfile import mkdtemp
 import errno
 
-import numpy as np
-from numpy.testing import assert_almost_equal
-
 from parameterized import parameterized
 
 from openmdao.utils.assert_utils import assert_rel_error

--- a/dymos/phases/components/boundary_constraint_comp.py
+++ b/dymos/phases/components/boundary_constraint_comp.py
@@ -28,8 +28,6 @@ class BoundaryConstraintComp(ExplicitComponent):
                                 'output_name': output_name,
                                 'shape': kwargs['shape']}
 
-            # self._vars.append((input_name, output_name, kwargs['shape']))
-
             input_kwargs = {k: kwargs[k] for k in ('units', 'shape', 'desc')}
             self.add_input(input_name, **input_kwargs)
 
@@ -59,7 +57,8 @@ class BoundaryConstraintComp(ExplicitComponent):
         for name, options in iteritems(self._vars):
             outputs[options['output_name']] = inputs[options['input_name']]
 
-    def _add_constraint(self, name, shape=(1,), units=None, res_units=None, desc='',
+    def _add_constraint(self, name, units=None, res_units=None, desc='',
+                        shape=None, indices=None, flat_indices=True,
                         lower=None, upper=None, equals=None,
                         scaler=None, adder=None, ref=1.0, ref0=0.0,
                         linear=False, res_ref=1.0, distributed=False):
@@ -75,11 +74,16 @@ class BoundaryConstraintComp(ExplicitComponent):
         shape : int or tuple or list or None
             Shape of this variable, only required if val is not an array.
             Default is None.
+        indices : tuple, list, ndarray, or None
+            The indices of the output variable to be boundary constrained.  If provided, the
+            resulting constraint is always a 1D vector with the number of elements provided in
+            indices.  Indices should be a 1D sequence of tuples, each providing an index into the
+            source output if flat_indices is False, or integers if flat_indices is True.
+        flat_indices : bool
+            Whether or not indices is provided as 'flat' indices per OpenMDAO's flat_source_indices
+            option when connecting variables.
         units : str or None
             Units in which the output variables will be provided to the component during execution.
-            Default is None, which means it has no units.
-        res_units : str or None
-            Units in which the residuals of this output will be given to the user when requested.
             Default is None, which means it has no units.
         desc : str
             description of the variable
@@ -106,15 +110,13 @@ class BoundaryConstraintComp(ExplicitComponent):
             the scaled value is 0. Default is 0.
         linear : bool
             True if the *total* derivative of the constrained variable is linear, otherwise False.
-        res_ref : float
-            Scaling parameter. The value in the user-defined res_units of this output's residual
-            when the scaled value is 1. Default is 1.
         distributed : bool
             If True, this variable is distributed across multiple processes.
         """
         lower = -INF_BOUND if upper is not None and lower is None else lower
         upper = INF_BOUND if lower is not None and upper is None else upper
-        kwargs = {'shape': shape, 'units': units, 'res_units': res_units, 'desc': desc,
+        kwargs = {'units': units, 'res_units': res_units, 'desc': desc,
+                  'shape': shape, 'indices': indices, 'flat_indices': flat_indices,
                   'lower': lower, 'upper': upper, 'equals': equals,
                   'scaler': scaler, 'adder': adder, 'ref': ref, 'ref0': ref0, 'linear': linear,
                   'res_ref': res_ref, 'distributed': distributed}

--- a/dymos/phases/components/path_constraint_comp.py
+++ b/dymos/phases/components/path_constraint_comp.py
@@ -131,6 +131,13 @@ class GaussLobattoPathConstraintComp(PathConstraintCompBase):
             constraint_kwargs = {k: kwargs.get(k, None)
                                  for k in ('lower', 'upper', 'equals', 'ref', 'ref0', 'adder',
                                            'scaler', 'indices', 'linear')}
+
+            # Convert indices from those in one time instance to those in all time instances
+            template = np.zeros(np.prod(kwargs['shape']), dtype=int)
+            template[kwargs['indices']] = 1
+            template = np.tile(template, num_nodes)
+            constraint_kwargs['indices'] = np.nonzero(template)[0]
+
             self.add_constraint(output_name, **constraint_kwargs)
 
             # Setup partials

--- a/dymos/phases/components/path_constraint_comp.py
+++ b/dymos/phases/components/path_constraint_comp.py
@@ -16,9 +16,9 @@ class PathConstraintCompBase(ExplicitComponent):
         self._vars = []
         self.options.declare('grid_data', types=GridData, desc='Container object for grid info')
 
-    def _add_path_constraint(self, name, var_class, shape=(1,), units=None, res_units=None, desc='',
-                             lower=None, upper=None, equals=None, scaler=None, adder=None,
-                             ref=None, ref0=None, linear=False, res_ref=1.0, type_=None,
+    def _add_path_constraint(self, name, var_class, shape=None, units=None, res_units=None, desc='',
+                             indices=None, lower=None, upper=None, equals=None, scaler=None,
+                             adder=None, ref=None, ref0=None, linear=False, res_ref=1.0, type_=None,
                              distributed=False):
         """
         Add a final constraint to this component
@@ -36,6 +36,11 @@ class PathConstraintCompBase(ExplicitComponent):
         shape : int or tuple or list or None
             Shape of this variable, only required if val is not an array.
             Default is None.
+        indices : tuple or list or ndarray or None
+            Indices that specify which elements in shape are to be path constrained.  If None,
+            then the constraint will apply to all values and lower/upper/equals must be scalar
+            or of the same shape.  Indices assumes C-order flattening.  For instance, if
+            constraining element [0, 1] of a variable with shape [2, 2], indices=[3].
         units : str or None
             Units in which the output variables will be provided to the component during execution.
             Default is None, which means it has no units.
@@ -66,7 +71,7 @@ class PathConstraintCompBase(ExplicitComponent):
             Scaling parameter. The value in the user-defined res_units of this output's residual
             when the scaled value is 1. Default is 1.
         type_ : str
-            One of 'state', 'indep_control', 'input_control', 'control_rate', 'control_rate2'.
+            The kind of variable be constrained, as returned by _classify_var.
         distributed : bool
             If True, this variable is distributed across multiple processes.
         """
@@ -75,9 +80,10 @@ class PathConstraintCompBase(ExplicitComponent):
         lower = -INF_BOUND if upper is not None and lower is None else lower
         upper = INF_BOUND if lower is not None and upper is None else upper
         kwargs = {'shape': shape, 'units': units, 'res_units': res_units, 'desc': desc,
-                  'lower': lower, 'upper': upper, 'equals': equals, 'scaler': scaler,
-                  'adder': adder, 'ref': ref, 'ref0': ref0, 'linear': linear, 'src_all': src_all,
-                  'res_ref': res_ref, 'distributed': distributed, 'type_': type_}
+                  'indices': indices, 'lower': lower, 'upper': upper, 'equals': equals,
+                  'scaler': scaler, 'adder': adder, 'ref': ref, 'ref0': ref0, 'linear': linear,
+                  'src_all': src_all, 'res_ref': res_ref, 'distributed': distributed,
+                  'type_': type_}
         self._path_constraints.append((name, kwargs))
 
 
@@ -182,7 +188,7 @@ class GaussLobattoPathConstraintComp(PathConstraintCompBase):
                     cols=np.arange(col_size),
                     val=1.0)
 
-    def compute(self, inputs, outputs):
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         disc_indices = self.options['grid_data'].subset_node_indices['state_disc']
         col_indices = self.options['grid_data'].subset_node_indices['col']
         for (disc_input_name, col_input_name, all_inp_name, src_all, output_name, _) in self._vars:
@@ -218,11 +224,18 @@ class RadauPathConstraintComp(PathConstraintCompBase):
             constraint_kwargs = {k: kwargs.get(k, None)
                                  for k in ('lower', 'upper', 'equals', 'ref', 'ref0', 'adder',
                                            'scaler', 'indices', 'linear')}
+
+            # Convert indices from those in one time instance to those in all time instances
+            template = np.zeros(np.prod(kwargs['shape']), dtype=int)
+            template[kwargs['indices']] = 1
+            template = np.tile(template, num_nodes)
+            constraint_kwargs['indices'] = np.nonzero(template)[0]
+
             self.add_constraint(output_name, **constraint_kwargs)
 
             self._vars.append((input_name, output_name, kwargs['shape']))
-            # Setup partials
 
+            # Setup partials
             all_shape = (num_nodes,) + kwargs['shape']
             var_size = np.prod(kwargs['shape'])
             all_size = np.prod(all_shape)
@@ -241,6 +254,6 @@ class RadauPathConstraintComp(PathConstraintCompBase):
                 cols=np.arange(all_size),
                 val=1.0)
 
-    def compute(self, inputs, outputs):
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         for (input_name, output_name, _) in self._vars:
             outputs[output_name] = inputs[input_name]

--- a/dymos/phases/components/path_constraint_comp.py
+++ b/dymos/phases/components/path_constraint_comp.py
@@ -1,7 +1,5 @@
 from __future__ import division, print_function
 
-from six import iteritems
-
 import numpy as np
 from openmdao.api import ExplicitComponent
 
@@ -31,8 +29,6 @@ class PathConstraintCompBase(ExplicitComponent):
             The 'class' of the variable as given by phase.classify_var.  One of 'time', 'state',
             'indep_control', 'input_control', 'design_parameter', 'input_parameter',
             'control_rate', 'control_rate2', or 'ode'.
-        val : float or list or tuple or ndarray
-            The initial value of the variable being added in user-defined units. Default is 1.0.
         shape : int or tuple or list or None
             Shape of this variable, only required if val is not an array.
             Default is None.

--- a/dymos/phases/components/tests/test_boundary_constraint_comp.py
+++ b/dymos/phases/components/tests/test_boundary_constraint_comp.py
@@ -23,7 +23,7 @@ class TestInitialScalarBoundaryValue(unittest.TestCase):
         self.p.model.add_design_var('x', lower=0, upper=100)
 
         bv_comp = self.p.model.add_subsystem('bv_comp', BoundaryConstraintComp(loc='initial'))
-        bv_comp._add_constraint(name='x')
+        bv_comp._add_constraint(name='x', shape=(1,))
 
         self.p.model.connect('x', 'bv_comp.initial_value_in:x', src_indices=[0])
 
@@ -52,7 +52,7 @@ class TestFinalScalarBoundaryValue(unittest.TestCase):
         self.p.model.add_design_var('x', lower=0, upper=100)
 
         bv_comp = self.p.model.add_subsystem('bv_comp', BoundaryConstraintComp(loc='final'))
-        bv_comp._add_constraint(name='x')
+        bv_comp._add_constraint(name='x', shape=(1,))
 
         self.p.model.connect('x', 'bv_comp.final_value_in:x', src_indices=[-1])
 

--- a/dymos/phases/optimizer_based/gauss_lobatto_phase.py
+++ b/dymos/phases/optimizer_based/gauss_lobatto_phase.py
@@ -234,9 +234,10 @@ class GaussLobattoPhase(OptimizerBasedPhaseBase):
                 options['shape'] = state_shape
                 options['units'] = state_units if con_units is None else con_units
                 options['linear'] = False
+                src_idxs = get_src_indices_by_row(gd.input_maps['state_input_to_disc'], state_shape)
                 self.connect(src_name='states:{0}'.format(var),
                              tgt_name='path_constraints.disc_values:{0}'.format(con_name),
-                             src_indices=gd.input_maps['state_input_to_disc'])
+                             src_indices=src_idxs, flat_src_indices=True)
                 self.connect(src_name='state_interp.state_col:{0}'.format(var),
                              tgt_name='path_constraints.col_values:{0}'.format(con_name))
 

--- a/dymos/phases/optimizer_based/gauss_lobatto_phase.py
+++ b/dymos/phases/optimizer_based/gauss_lobatto_phase.py
@@ -276,8 +276,13 @@ class GaussLobattoPhase(OptimizerBasedPhaseBase):
                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
 
             else:
-                # Failed to find variable, assume it is in the RHS
+                # Failed to find variable, assume it is in the ODE
                 options['linear'] = False
+                if options['shape'] is None:
+                    warnings.warn('Unable to infer shape of path constraint {0}. Assuming scalar.\n'
+                                  'In Dymos 1.0 the shape of ODE outputs must be explictly provided'
+                                  ' via the add_path_constraint method.', DeprecationWarning)
+                    options['shape'] = (1,)
                 self.connect(src_name='rhs_disc.{0}'.format(var),
                              tgt_name='path_constraints.disc_values:{0}'.format(con_name))
                 self.connect(src_name='rhs_col.{0}'.format(var),

--- a/dymos/phases/optimizer_based/optimizer_based_phase_base.py
+++ b/dymos/phases/optimizer_based/optimizer_based_phase_base.py
@@ -448,7 +448,6 @@ class OptimizerBasedPhaseBase(PhaseBase):
                 constraint_path = 'rhs_all.{0}'.format(var)
             else:
                 raise ValueError('Invalid transcription')
-            # TODO: Account for non-scalar variables here.
             shape = None
             units = None
             linear = False

--- a/dymos/phases/optimizer_based/optimizer_based_phase_base.py
+++ b/dymos/phases/optimizer_based/optimizer_based_phase_base.py
@@ -449,7 +449,7 @@ class OptimizerBasedPhaseBase(PhaseBase):
             else:
                 raise ValueError('Invalid transcription')
             # TODO: Account for non-scalar variables here.
-            shape = (1,)
+            shape = None
             units = None
             linear = False
 

--- a/dymos/phases/phase_base.py
+++ b/dymos/phases/phase_base.py
@@ -544,8 +544,6 @@ class PhaseBase(Group):
         if constraint_name is None:
             constraint_name = name.split('.')[-1]
 
-        self.add_timeseries_output(name, constraint_name, units=units, shape=shape)
-
         bc_dict = self._initial_boundary_constraints \
             if loc == 'initial' else self._final_boundary_constraints
 
@@ -616,8 +614,6 @@ class PhaseBase(Group):
         if name not in self._path_constraints:
             self._path_constraints[name] = {}
             self._path_constraints[name]['constraint_name'] = constraint_name
-
-        self.add_timeseries_output(name, constraint_name, units=units, shape=shape)
 
         self._path_constraints[name]['lower'] = lower
         self._path_constraints[name]['upper'] = upper

--- a/dymos/phases/phase_base.py
+++ b/dymos/phases/phase_base.py
@@ -1288,10 +1288,11 @@ class PhaseBase(Group):
 
             shape = options['shape'] if shape is None else shape
             if shape is None:
-                logger = get_logger('check_config', use_format=True)
-                logger.warning('Unable to infer shape of boundary constraint {0}. Assuming scalar. '
-                               'If variable is not scalar, provide shape in '
-                               'add_boundary_constraint.'.format(var))
+                warnings.warn('\nUnable to infer shape of boundary constraint {0}. Assuming scalar. '
+                              '\nIf variable is not scalar, provide shape in '
+                              'add_boundary_constraint. \nIn Dymos 1.0 an error will be raised if '
+                              'a constrained ODE output shape is not specified in '
+                              'add_boundary_constraint.'.format(var), DeprecationWarning)
                 shape = (1,)
 
             if options['indices'] is not None:

--- a/dymos/phases/runge_kutta/components/runge_kutta_path_constraint_comp.py
+++ b/dymos/phases/runge_kutta/components/runge_kutta_path_constraint_comp.py
@@ -30,6 +30,13 @@ class RungeKuttaPathConstraintComp(PathConstraintCompBase):
                 constraint_kwargs = {k: kwargs.get(k, None)
                                      for k in ('lower', 'upper', 'equals', 'ref', 'ref0', 'adder',
                                                'scaler', 'indices', 'linear')}
+
+                # Convert indices from those in one time instance to those in all time instances
+                template = np.zeros(np.prod(kwargs['shape']), dtype=int)
+                template[kwargs['indices']] = 1
+                template = np.tile(template, num_nodes)
+                constraint_kwargs['indices'] = np.nonzero(template)[0]
+
                 self.add_constraint(output_name, **constraint_kwargs)
 
                 self._vars.append((input_name, output_name, kwargs['shape']))

--- a/dymos/phases/runge_kutta/runge_kutta_phase.py
+++ b/dymos/phases/runge_kutta/runge_kutta_phase.py
@@ -566,10 +566,14 @@ class RungeKuttaPhase(PhaseBase):
             else:
                 # Failed to find variable, assume it is in the ODE
                 options['linear'] = False
-                shape = (1,)
+                if options['shape'] is None:
+                    warnings.warn('Unable to infer shape of path constraint {0}. Assuming scalar.\n'
+                                  'In Dymos 1.0 the shape of ODE outputs must be explictly provided'
+                                  ' via the add_path_constraint method.', DeprecationWarning)
+                    options['shape'] = (1,)
 
                 src_rows = np.arange(num_seg * 2, dtype=int)
-                src_idxs = get_src_indices_by_row(src_rows, shape=shape)
+                src_idxs = get_src_indices_by_row(src_rows, shape=options['shape'])
 
                 src = 'ode.{0}'.format(var)
                 tgt = 'path_constraints.all_values:{0}'.format(con_name)


### PR DESCRIPTION
Adds support for shaped boundary and path constraints.

### Backwards incompatibilities
For ODE output variables, we cannot yet infer the their shape at setup time.  For now, DeprecationWarning is issued and a shape of `(1,)` is assumed (scalar).  In the future we will either require the shape of these variables in `add_path_constraint` and `add_boundary_constraint`, or resolve a way of determining their shape during setup.

### Issues Addressed
Resolves #146 