### PR TITLE
Default defect_ref change

### DIFF
--- a/dymos/examples/ssto/ex_ssto_earth.py
+++ b/dymos/examples/ssto/ex_ssto_earth.py
@@ -31,11 +31,11 @@ def ssto_earth(transcription='gauss-lobatto', num_seg=10, transcription_order=5,
 
     phase.set_time_options(initial_bounds=(0, 0), duration_bounds=(10, 500))
 
-    phase.set_state_options('x', fix_initial=True, scaler=1.0E-5)
-    phase.set_state_options('y', fix_initial=True, scaler=1.0E-5)
-    phase.set_state_options('vx', fix_initial=True, scaler=1.0E-3)
-    phase.set_state_options('vy', fix_initial=True, scaler=1.0E-3)
-    phase.set_state_options('m', fix_initial=True, scaler=1.0E-3)
+    phase.set_state_options('x', fix_initial=True, ref=1.0E5, defect_ref=1.0)
+    phase.set_state_options('y', fix_initial=True, ref=1.0E5, defect_ref=1.0)
+    phase.set_state_options('vx', fix_initial=True, ref=1.0E3, defect_ref=1.0)
+    phase.set_state_options('vy', fix_initial=True, ref=1.0E3, defect_ref=1.0)
+    phase.set_state_options('m', fix_initial=True, ref=1.0E3, defect_ref=1.0)
 
     phase.add_boundary_constraint('y', loc='final', equals=1.85E5, linear=True)
     phase.add_boundary_constraint('vx', loc='final', equals=7796.6961)

--- a/dymos/examples/ssto/ex_ssto_moon.py
+++ b/dymos/examples/ssto/ex_ssto_moon.py
@@ -33,11 +33,11 @@ def ssto_moon(transcription='gauss-lobatto', num_seg=10, optimizer='SLSQP', tran
 
     phase.set_time_options(initial_bounds=(0, 0), duration_bounds=(10, 1000))
 
-    phase.set_state_options('x', fix_initial=True, scaler=1.0E-5, lower=0)
-    phase.set_state_options('y', fix_initial=True, scaler=1.0E-5, lower=0)
-    phase.set_state_options('vx', fix_initial=True, scaler=1.0E-3, lower=0)
-    phase.set_state_options('vy', fix_initial=True, scaler=1.0E-3)
-    phase.set_state_options('m', fix_initial=True, scaler=1.0E-3)
+    phase.set_state_options('x', fix_initial=True, ref=1.0E5, defect_ref=1.0, lower=0)
+    phase.set_state_options('y', fix_initial=True, ref=1.0E5, defect_ref=1.0, lower=0)
+    phase.set_state_options('vx', fix_initial=True, ref=1.0E3, defect_ref=1.0, lower=0)
+    phase.set_state_options('vy', fix_initial=True, ref=1.0E3, defect_ref=1.0)
+    phase.set_state_options('m', fix_initial=True, ref=1.0E3, defect_ref=1.0)
 
     phase.add_boundary_constraint('y', loc='final', equals=1.85E5, linear=True)
     phase.add_boundary_constraint('vx', loc='final', equals=1627.0)
@@ -52,7 +52,7 @@ def ssto_moon(transcription='gauss-lobatto', num_seg=10, optimizer='SLSQP', tran
     phase.add_design_parameter('thrust', units='N', opt=False, val=3.0 * 50000.0 * 1.61544)
     phase.add_design_parameter('Isp', units='s', opt=False, val=1.0E6)
 
-    phase.add_objective('time', index=-1, scaler=0.01)
+    phase.add_objective('time', index=-1, ref=100)
 
     p.model.linear_solver = DirectSolver()
 

--- a/dymos/examples/ssto/ex_ssto_moon_linear_tangent.py
+++ b/dymos/examples/ssto/ex_ssto_moon_linear_tangent.py
@@ -56,11 +56,11 @@ def ssto_moon_linear_tangent(transcription='gauss-lobatto', num_seg=10, transcri
 
     phase.set_time_options(initial_bounds=(0, 0), duration_bounds=(10, 1000))
 
-    phase.set_state_options('x', fix_initial=True, scaler=1.0E-5, lower=0)
-    phase.set_state_options('y', fix_initial=True, scaler=1.0E-5, lower=0)
-    phase.set_state_options('vx', fix_initial=True, scaler=1.0E-3, lower=0)
-    phase.set_state_options('vy', fix_initial=True, scaler=1.0E-3)
-    phase.set_state_options('m', fix_initial=True, scaler=1.0E-3)
+    phase.set_state_options('x', fix_initial=True, lower=0)
+    phase.set_state_options('y', fix_initial=True, lower=0)
+    phase.set_state_options('vx', fix_initial=True, lower=0)
+    phase.set_state_options('vy', fix_initial=True)
+    phase.set_state_options('m', fix_initial=True)
 
     phase.add_boundary_constraint('y', loc='final', equals=1.85E5, linear=True)
     phase.add_boundary_constraint('vx', loc='final', equals=1627.0)

--- a/dymos/examples/ssto/test/test_ex_ssto_earth.py
+++ b/dymos/examples/ssto/test/test_ex_ssto_earth.py
@@ -5,14 +5,14 @@ import os
 import itertools
 import unittest
 
-import matplotlib
-matplotlib.use('Agg')
-
 from numpy.testing import assert_almost_equal
 
 from parameterized import parameterized
 
 import dymos.examples.ssto.ex_ssto_earth as ex_ssto_earth
+
+import matplotlib
+matplotlib.use('Agg')
 
 
 class TestExampleSSTOEarth(unittest.TestCase):

--- a/dymos/examples/ssto/test/test_ex_ssto_moon.py
+++ b/dymos/examples/ssto/test/test_ex_ssto_moon.py
@@ -17,7 +17,7 @@ class TestExampleSSTOMoon(unittest.TestCase):
 
     def test_results_gl_compressed(self):
         p = ex_ssto_moon.ssto_moon('gauss-lobatto', num_seg=10, transcription_order=5,
-                                   compressed=True)
+                                   compressed=True, optimizer='SLSQP')
 
         p.setup(check=True)
 
@@ -57,7 +57,7 @@ class TestExampleSSTOMoon(unittest.TestCase):
         p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0
-        p['phase0.t_duration'] = 500.0
+        p['phase0.t_duration'] = 300.0
 
         phase = p.model.phase0
         p['phase0.states:x'] = phase.interpolate(ys=[0, 350000.0], nodes='state_input')
@@ -87,12 +87,12 @@ class TestExampleSSTOMoon(unittest.TestCase):
 
     def test_results_gl_uncompressed(self):
         p = ex_ssto_moon.ssto_moon('gauss-lobatto', num_seg=10, transcription_order=5,
-                                   compressed=False)
+                                   optimizer='SLSQP', compressed=False)
 
         p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0
-        p['phase0.t_duration'] = 500.0
+        p['phase0.t_duration'] = 300.0
 
         phase = p.model.phase0
         p['phase0.states:x'] = phase.interpolate(ys=[0, 350000.0], nodes='state_input')
@@ -110,7 +110,7 @@ class TestExampleSSTOMoon(unittest.TestCase):
                                 0.0, decimal=5)
 
         # Ensure time found is the known solution
-        assert_almost_equal(p['phase0.t_duration'], 481.8, decimal=1)
+        assert_rel_error(self, p['phase0.t_duration'], 481.8, tolerance=0.01)
 
         # Ensure the tangent of theta is (approximately) linear
         time = p.get_val('phase0.timeseries.time').flatten()
@@ -127,7 +127,7 @@ class TestExampleSSTOMoon(unittest.TestCase):
         p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0
-        p['phase0.t_duration'] = 500.0
+        p['phase0.t_duration'] = 300.0
 
         phase = p.model.phase0
         p['phase0.states:x'] = phase.interpolate(ys=[0, 350000.0], nodes='state_input')
@@ -165,7 +165,7 @@ class TestExampleSSTOMoon(unittest.TestCase):
         p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0
-        p['phase0.t_duration'] = 500.0
+        p['phase0.t_duration'] = 300.0
 
         phase = p.model.phase0
 

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -401,17 +401,21 @@ class StateOptionsDictionary(OptionsDictionary):
                           'This option is invalid if opt=False.')
 
         self.declare(name='defect_scaler',
-                     types=(Iterable, Number), default=1.0,
+                     types=(Iterable, Number), default=None,
                      allow_none=True,
-                     desc='Scaler of the state variable defects at the collocation nodes. This '
-                          'option is invalid if opt=False.')
+                     desc='Scaler of the state variable defects at the collocation nodes. '
+                          'If defect_scaler and defect_ref are both None but the state scaler '
+                          'or ref are provided, use those values as the defect scaler or ref. '
+                          'This option is invalid if opt=False.')
 
         self.declare(name='defect_ref',
                      types=(Iterable, Number), default=None,
                      allow_none=True,
                      desc='Unit-reference value of the state defects at the collocation nodes. This'
-                          ' option is invalid if opt=False.  If provide, this option overrides'
-                          ' defect_scaler.')
+                          ' option is invalid if opt=False.  If provided, this option overrides'
+                          ' defect_scaler. If defect_scaler and defect_ref are both None but the '
+                          'state scaler or ref are provided, use those values as the defect '
+                          'scaler or ref.')
 
         self.declare(name='continuity', types=(bool, dict), default=True,
                      desc='Enforce continuity of state values at segment boundaries. This '

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -137,9 +137,9 @@ class Phase(Group):
             The zero-reference value of the state at the nodes of the phase.
         ref : float or ndarray or None (None)
             The unit-reference value of the state at the nodes of the phase
-        defect_scaler : float or ndarray (1.0)
+        defect_scaler : float or ndarray
             The scaler of the state defect at the collocation nodes of the phase.
-        defect_ref : float or ndarray (1.0)
+        defect_ref : float or ndarray
             The unit-reference value of the state defect at the collocation nodes of the phase. If
             provided, this value overrides defect_scaler.
         solve_segments : bool(False)

--- a/dymos/transcriptions/pseudospectral/components/collocation_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/collocation_comp.py
@@ -75,16 +75,19 @@ class CollocationComp(ExplicitComponent):
                 units=units)
 
             if 'defect_ref' in options and options['defect_ref'] is not None:
-                def_scl = 1.0 / options['defect_ref']
-            elif 'defect_scaler' in options:
-                def_scl = options['defect_scaler']
+                defect_ref = options['defect_ref']
             else:
-                def_scl = 1.0
+                if 'ref' in options and options['ref'] is not None:
+                    defect_ref = options['ref']
+                elif 'scaler' in options and options['scaler'] is not None:
+                    defect_ref = 1.0 / options['scaler']
+                else:
+                    defect_ref = 1.0
 
             if not options['solve_segments']:
                 self.add_constraint(name=var_names['defect'],
                                     equals=0.0,
-                                    scaler=def_scl)
+                                    ref=defect_ref)
 
         # Setup partials
         num_col_nodes = self.options['grid_data'].subset_num_nodes['col']

--- a/dymos/transcriptions/pseudospectral/components/collocation_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/collocation_comp.py
@@ -76,6 +76,8 @@ class CollocationComp(ExplicitComponent):
 
             if 'defect_ref' in options and options['defect_ref'] is not None:
                 defect_ref = options['defect_ref']
+            elif 'defect_scaler' in options and options['defect_scaler'] is not None:
+                defect_ref = 1.0 / options['defect_scaler']
             else:
                 if 'ref' in options and options['ref'] is not None:
                     defect_ref = options['ref']

--- a/dymos/transcriptions/runge_kutta/components/runge_kutta_state_continuity_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/runge_kutta_state_continuity_comp.py
@@ -48,12 +48,6 @@ class RungeKuttaStateContinuityComp(ImplicitComponent):
             units = options['units']
             var_names = self._var_names[state_name]
 
-            res_ref = 1.0
-            if options['defect_ref']:
-                res_ref = options['defect_ref']
-            elif options['defect_scaler']:
-                res_ref = 1.0 / options['defect_scaler']
-
             # The implicit variable is the state values at all segment endpoints.
             self.add_output(name=var_names['states'],
                             shape=(num_seg + 1,) + shape,

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_comp.py
@@ -17,7 +17,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_scalar_no_iteration_fwd(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'],
-                               'defect_scaler': 1.0, 'defect_ref': None,
+                               'defect_scaler': None, 'defect_ref': None,
                                'lower': None, 'upper': None, 'connected_initial': False}}
 
         p = Problem(model=Group())
@@ -82,7 +82,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_connected_scalar_no_iteration_fwd(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'],
-                               'defect_scaler': 1.0, 'defect_ref': None,
+                               'defect_scaler': None, 'defect_ref': None,
                                'lower': None, 'upper': None, 'connected_initial': True}}
 
         p = Problem(model=Group())
@@ -152,7 +152,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_scalar_nonlinearblockgs_fwd(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'defect_scaler': 1.0, 'defect_ref': None,
+                               'fix_final': False, 'defect_scaler': None, 'defect_ref': None,
                                'lower': None, 'upper': None, 'connected_initial': False}}
 
         p = Problem(model=Group())
@@ -217,7 +217,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_connected_scalar_nonlinearblockgs_fwd(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'defect_scaler': 1.0, 'defect_ref': None,
+                               'fix_final': False, 'defect_scaler': None, 'defect_ref': None,
                                'lower': None, 'upper': None, 'connected_initial': True}}
 
         p = Problem(model=Group())
@@ -287,7 +287,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_scalar_newton_fwd(self):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'defect_scaler': 1.0, 'defect_ref': None,
+                               'fix_final': False, 'defect_scaler': None, 'defect_ref': None,
                                'lower': None, 'upper': None, 'connected_initial': False}}
 
         p = Problem(model=Group())
@@ -407,7 +407,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_vector_nonlinearblockgs_fwd(self):
         num_seg = 2
         state_options = {'y': {'shape': (2,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
-                               'fix_final': False, 'defect_ref': 1, 'lower': None, 'upper': None,
+                               'fix_final': False, 'defect_ref': None, 'lower': None, 'upper': None,
                                'connected_initial': False}}
 
         p = Problem(model=Group())
@@ -461,7 +461,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
     def test_continuity_comp_connected_vector_nonlinearblockgs_fwd(self):
         num_seg = 2
         state_options = {'y': {'shape': (2,), 'units': 'm', 'targets': ['y'], 'fix_initial': False,
-                               'fix_final': False, 'defect_ref': 1, 'lower': None, 'upper': None,
+                               'fix_final': False, 'defect_ref': None, 'lower': None, 'upper': None,
                                'connected_initial': True}}
 
         p = Problem(model=Group())

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_iter_group.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_iter_group.py
@@ -18,7 +18,7 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y'], 'fix_initial': True,
                                'fix_final': False, 'propagation': 'forward', 'defect_scaler': None,
-                               'defect_ref': 1.0, 'lower': None, 'upper': None,
+                               'defect_ref': None, 'lower': None, 'upper': None,
                                'connected_initial': False}}
 
         p = Problem(model=Group())


### PR DESCRIPTION
### Summary

By default, the `ref` scale factor on state collocation defects is now based on the value of the state scaler/ref.  In most cases, this should make default scaling a little bit easier.  In some cases this may change convergence behavior, see backward incompatibility notes below.

### Related Issues

Resolves #158 

### Status

- [x] Ready for merge

### Backwards incompatibilities

Certain cases may see changes in converged behavior.  If a state scaler/ref is specified but defect_scaler/defect_ref is unspecified, setting `defect_ref=1` will restore the previous behavior.

### New Dependencies

None
