### PR TITLE
added tolerance check for RK4 shooting method test

### DIFF
--- a/dymos/examples/brachistochrone/test/test_brachistochrone_rk4.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_rk4.py
@@ -422,7 +422,8 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
 
         # Test the results
         assert_rel_error(self, p['phase0.time'][-1], 1.8016, tolerance=1.0E-3)
-        assert_rel_error(self, p.get_val('phase0.timeseries.control_rates:theta_rate2')[-1, 0], 0)
+        assert_rel_error(self, p.get_val('phase0.timeseries.control_rates:theta_rate2')[-1, 0], 0,
+                         tolerance=1.0E-6)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()


### PR DESCRIPTION
### Summary

Resolves an issue that can periodically cause a brachistochrone RK4 test to fail due to an unnecessarily strict tolerance.

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
