### PR TITLE
use snopt for finite burn orbit raise in tests if available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os:
   - linux
 
 env:
-  - PY=2.7
+  - PY=2.7 PETSc=3.8.1
   - PY=3.6 UPLOAD_DOCS=1 PETSc=3.9.1
 
 language: generic

--- a/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise.py
@@ -263,7 +263,7 @@ class TestExampleTwoBurnOrbitRaiseConnected(unittest.TestCase):
         _, optimizer = set_pyoptsparse_opt('SNOPT', fallback=False)
 
         p = two_burn_orbit_raise_problem(transcription='gauss-lobatto', transcription_order=3,
-                                         compressed=False, optimizer='SLSQP',
+                                         compressed=False, optimizer=optimizer,
                                          show_output=False, connected=True)
 
         if p.model.traj.phases.burn2 in p.model.traj.phases._subsystems_myproc:


### PR DESCRIPTION
### Summary

Ensure that two burn orbit raise examples are run using SNOPT if it is available.

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
