### PR TITLE
Trajectory Parameter Cleanup

### DIFF
--- a/dymos/docs/feature_reference/trajectories.rst
+++ b/dymos/docs/feature_reference/trajectories.rst
@@ -61,9 +61,20 @@ at the trajectory level which maybe be connected to some output external to the 
 When using Trajectory Design and Input parameters, their values are connected to each phase as an
 Input Parameter within the Phase.  Because ODEs in different phases may have different names
 for parameters (e.g. 'mass', 'm', 'm_total', etc) Dymos allows the user to specify the targeted
-ODE parameters on a phase-by-phase basis.
+ODE parameters on a phase-by-phase basis using the `custom_targets` option.  It can take on the
+following values.
 
-<EXAMPLE OF TARGETS>
+*  Left unspecified (`custom_targets = None`), a trajectory design or input parameter will be connected to a decorated ODE parameter of the same name in each phase.
+
+*  Otherwise, `custom_targets` is specified as a dictionary keyed by phase name.
+
+    * If the name of a phase is omitted from `custom_targets`, the trajectory design or input parameter will be connected to a decorated ODE parameter of the same name in that phase.
+
+    * If the phase is specified with a corresponding value of `None`, **the trajectory parameter will not be passed to the phase**.
+
+    * If the phase is specified and the corresponding value is a string, assume the given value is a decorated ODE parameter to which the trajectory parameter should be connected.
+
+    * If the phase is specified and the corresponding parameter value is a list, assume the list gives ODE-level targets to which the parameter should be connected in that phase.
 
 If a phase exists within the Trajectory that doesn't utilize the trajectory
 design/input parameters, it is simply ignored for the purposes of that phase.

--- a/dymos/examples/brachistochrone/test/test_ex_brachistochrone_vector_states.py
+++ b/dymos/examples/brachistochrone/test/test_ex_brachistochrone_vector_states.py
@@ -6,6 +6,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 
 import dymos.examples.brachistochrone.test.ex_brachistochrone_vector_states as ex_brachistochrone_vs
+from dymos.utils.testing_utils import use_tempdirs
 
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.utils.assert_utils import assert_check_partials
@@ -13,13 +14,8 @@ from openmdao.utils.assert_utils import assert_check_partials
 OPT, OPTIMIZER = set_pyoptsparse_opt('SNOPT')
 
 
+@use_tempdirs
 class TestBrachistochroneVectorStatesExample(unittest.TestCase):
-
-    @classmethod
-    def tearDownClass(cls):
-        for filename in ['phase0_sim.db', 'brachistochrone_sim.db']:
-            if os.path.exists(filename):
-                os.remove(filename)
 
     def assert_results(self, p):
         t_initial = p.get_val('phase0.time')[0]

--- a/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
+++ b/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
@@ -7,15 +7,11 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
+from dymos.utils.testing_utils import use_tempdirs
 
+
+@use_tempdirs
 class TestTwoPhaseCannonballForDocs(unittest.TestCase):
-
-    @classmethod
-    def tearDownClass(cls):
-        for filename in ['ex_two_phase_cannonball.db', 'ex_two_phase_cannonball_sim.db',
-                         'coloring.json']:
-            if os.path.exists(filename):
-                os.remove(filename)
 
     def test_two_phase_cannonball_for_docs(self):
         from openmdao.api import Problem, Group, IndepVarComp, DirectSolver, SqliteRecorder, \
@@ -87,10 +83,11 @@ class TestTwoPhaseCannonballForDocs(unittest.TestCase):
 
         # Add externally-provided design parameters to the trajectory.
         traj.add_input_parameter('mass',
-                                 target_params={'ascent': 'm', 'descent': 'm'},
+                                 custom_targets={'ascent': 'm', 'descent': 'm'},
+                                 units='kg',
                                  val=1.0)
 
-        traj.add_input_parameter('S', val=0.005)
+        traj.add_input_parameter('S', val=0.005, units='m**2')
 
         # Link Phases (link time and all state variables)
         traj.link_phases(phases=['ascent', 'descent'], vars=['*'])

--- a/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
+++ b/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
@@ -10,7 +10,6 @@ import matplotlib.pyplot as plt
 from dymos.utils.testing_utils import use_tempdirs
 
 
-@use_tempdirs
 class TestTwoPhaseCannonballForDocs(unittest.TestCase):
 
     def test_two_phase_cannonball_for_docs(self):

--- a/dymos/examples/cannonball/test/test_two_phase_cannonball_undecorated_ode.py
+++ b/dymos/examples/cannonball/test/test_two_phase_cannonball_undecorated_ode.py
@@ -13,13 +13,6 @@ from dymos.utils.testing_utils import use_tempdirs
 @use_tempdirs
 class TestTwoPhaseCannonball(unittest.TestCase):
 
-    @classmethod
-    def tearDownClass(cls):
-        for filename in ['ex_two_phase_cannonball.db', 'ex_two_phase_cannonball_sim.db',
-                         'coloring.json']:
-            if os.path.exists(filename):
-                os.remove(filename)
-
     def test_two_phase_cannonball_undecorated_ode(self):
         from openmdao.api import Problem, Group, IndepVarComp, DirectSolver, SqliteRecorder, \
             pyOptSparseDriver
@@ -321,31 +314,25 @@ class TestTwoPhaseCannonball(unittest.TestCase):
         # Add internally-managed design parameters to the trajectory.
         traj.add_design_parameter('CD',
                                   targets={'ascent': ['aero.CD']},
-                                  target_params={'descent': 'CD'},
                                   val=0.5, units=None, opt=False)
         traj.add_design_parameter('CL', targets={'ascent': ['aero.CL']},
-                                  target_params={'descent': 'CL'},
                                   val=0.0, units=None, opt=False)
         traj.add_design_parameter('T',
                                   targets={'ascent': ['eom.T']},
-                                  target_params={'descent': 'T'},
                                   val=0.0, units='N', opt=False)
         traj.add_design_parameter('alpha',
-                                  targets={'ascent': ['eom.alpha']},
-                                  target_params={'descent': 'alpha'},
+                                  targets={'ascent': ['eom.alpha'], 'descent': 'alpha'},
                                   val=0.0, units='deg', opt=False)
 
         # Add externally-provided design parameters to the trajectory.
         traj.add_input_parameter('mass',
                                  units='kg',
-                                 targets={'ascent': ['eom.m', 'kinetic_energy.m']},
-                                 target_params={'ascent': 'm', 'descent': 'm'},
+                                 targets={'ascent': ['eom.m', 'kinetic_energy.m'], 'descent': 'm'},
                                  val=1.0)
 
         traj.add_input_parameter('S',
                                  units='m**2',
                                  targets={'ascent': ['aero.S']},
-                                 target_params={'descent': 'S'},
                                  val=0.005)
 
         # Link Phases (link time and all state variables)

--- a/dymos/examples/cannonball/test/test_two_phase_cannonball_undecorated_ode.py
+++ b/dymos/examples/cannonball/test/test_two_phase_cannonball_undecorated_ode.py
@@ -1,6 +1,5 @@
 from __future__ import print_function, division, absolute_import
 
-import os
 import unittest
 
 import matplotlib
@@ -87,33 +86,29 @@ class TestTwoPhaseCannonball(unittest.TestCase):
 
         # Add internally-managed design parameters to the trajectory.
         traj.add_design_parameter('CD',
-                                  targets={'ascent': ['aero.CD'],
-                                           'descent': ['aero.CD']},
+                                  custom_targets={'ascent': ['aero.CD'], 'descent': ['aero.CD']},
                                   val=0.5, units=None, opt=False)
         traj.add_design_parameter('CL',
-                                  targets={'ascent': ['aero.CL'],
-                                           'descent': ['aero.CL']},
+                                  custom_targets={'ascent': ['aero.CL'], 'descent': ['aero.CL']},
                                   val=0.0, units=None, opt=False)
         traj.add_design_parameter('T',
-                                  targets={'ascent': ['eom.T'],
-                                           'descent': ['eom.T']},
+                                  custom_targets={'ascent': ['eom.T'], 'descent': ['eom.T']},
                                   val=0.0, units='N', opt=False)
         traj.add_design_parameter('alpha',
-                                  targets={'ascent': ['eom.alpha'],
-                                           'descent': ['eom.alpha']},
+                                  custom_targets={'ascent': ['eom.alpha'], 'descent': ['eom.alpha']},
                                   val=0.0, units='deg', opt=False)
 
         # Add externally-provided design parameters to the trajectory.
         traj.add_input_parameter('mass',
                                  units='kg',
-                                 targets={'ascent': ['eom.m', 'kinetic_energy.m'],
-                                          'descent': ['eom.m', 'kinetic_energy.m']},
+                                 custom_targets={'ascent': ['eom.m', 'kinetic_energy.m'],
+                                                 'descent': ['eom.m', 'kinetic_energy.m']},
                                  val=1.0)
 
         traj.add_input_parameter('S',
                                  units='m**2',
-                                 targets={'ascent': ['aero.S'],
-                                          'descent': ['aero.S']},
+                                 custom_targets={'ascent': ['aero.S'],
+                                                 'descent': ['aero.S']},
                                  val=0.005)
 
         # Link Phases (link time and all state variables)
@@ -313,26 +308,28 @@ class TestTwoPhaseCannonball(unittest.TestCase):
 
         # Add internally-managed design parameters to the trajectory.
         traj.add_design_parameter('CD',
-                                  targets={'ascent': ['aero.CD']},
+                                  custom_targets={'ascent': ['aero.CD']},
                                   val=0.5, units=None, opt=False)
-        traj.add_design_parameter('CL', targets={'ascent': ['aero.CL']},
+        traj.add_design_parameter('CL',
+                                  custom_targets={'ascent': ['aero.CL']},
                                   val=0.0, units=None, opt=False)
         traj.add_design_parameter('T',
-                                  targets={'ascent': ['eom.T']},
+                                  custom_targets={'ascent': ['eom.T']},
                                   val=0.0, units='N', opt=False)
         traj.add_design_parameter('alpha',
-                                  targets={'ascent': ['eom.alpha'], 'descent': 'alpha'},
+                                  custom_targets={'ascent': ['eom.alpha'], 'descent': 'alpha'},
                                   val=0.0, units='deg', opt=False)
 
         # Add externally-provided design parameters to the trajectory.
         traj.add_input_parameter('mass',
                                  units='kg',
-                                 targets={'ascent': ['eom.m', 'kinetic_energy.m'], 'descent': 'm'},
+                                 custom_targets={'ascent': ['eom.m', 'kinetic_energy.m'],
+                                                 'descent': 'm'},
                                  val=1.0)
 
         traj.add_input_parameter('S',
                                  units='m**2',
-                                 targets={'ascent': ['aero.S']},
+                                 custom_targets={'ascent': ['aero.S']},
                                  val=0.005)
 
         # Link Phases (link time and all state variables)
@@ -441,7 +438,7 @@ class TestTwoPhaseCannonball(unittest.TestCase):
             axes[i].plot(time_exp['ascent'], x_exp['ascent'], 'b--')
             axes[i].plot(time_exp['descent'], x_exp['descent'], 'r--')
 
-        params = ['CL', 'CD', 'T', 'alpha', 'm', 'S']
+        params = ['CL', 'CD', 'T', 'alpha', 'S']
         fig, axes = plt.subplots(nrows=6, ncols=1, figsize=(12, 6))
         for i, param in enumerate(params):
             p_imp = {

--- a/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
@@ -7,10 +7,7 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
-from dymos.utils.testing_utils import use_tempdirs
 
-
-@use_tempdirs
 class TestFiniteBurnOrbitRaise(unittest.TestCase):
 
     def test_finite_burn_orbit_raise(self):

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -236,9 +236,6 @@ class DesignParameterOptionsDictionary(OptionsDictionary):
         self.declare(name='dynamic', types=bool, default=True,
                      desc='True if this parameter can be used as a dynamic control, else False')
 
-        self.declare(name='target_params', types=dict, default=None, allow_none=True,
-                     desc='Used to store target information on a per-phase basis for trajectories.')
-
         self.declare(name='targets', types=Iterable, default=[],
                      desc='Used to store target information for the design parameter.')
 
@@ -279,6 +276,19 @@ class DesignParameterOptionsDictionary(OptionsDictionary):
                           'option is invalid if opt=False.')
 
 
+class TrajDesignParameterOptionsDictionary(DesignParameterOptionsDictionary):
+    """
+    An OptionsDictionary specific to trajectory design parameters.
+    """
+
+    def __init__(self, read_only=False):
+        super(TrajDesignParameterOptionsDictionary, self).__init__(read_only)
+
+        self.declare(name='custom_targets', types=dict, default=None, allow_none=True,
+                     desc='Used to override the default targets of the trajectory input parameter'
+                          ' in each phase.  By default its target will be the same as its name')
+
+
 class InputParameterOptionsDictionary(OptionsDictionary):
     """
     An OptionsDictionary specific to input parameters.
@@ -301,9 +311,6 @@ class InputParameterOptionsDictionary(OptionsDictionary):
         self.declare(name='dynamic', types=bool, default=True,
                      desc='True if this parameter can be used as a dynamic control, else False')
 
-        self.declare(name='target_params', types=dict, default=None, allow_none=True,
-                     desc='Used to store target information on a per-phase basis for trajectories.')
-
         self.declare(name='targets', types=Iterable, default=[],
                      desc='Used to store target information for the input parameter.')
 
@@ -312,6 +319,19 @@ class InputParameterOptionsDictionary(OptionsDictionary):
 
         self.declare(name='shape', types=Iterable, default=(1,),
                      desc='The shape of the design parameter.')
+
+
+class TrajInputParameterOptionsDictionary(InputParameterOptionsDictionary):
+    """
+    An OptionsDictionary specific to trajectory input parameters.
+    """
+
+    def __init__(self, read_only=False):
+        super(TrajInputParameterOptionsDictionary, self).__init__(read_only)
+
+        self.declare(name='custom_targets', types=dict, default=None, allow_none=True,
+                     desc='Used to override the default targets of the trajectory input parameter'
+                          ' in each phase.  By default its target will be the same as its name')
 
 
 class StateOptionsDictionary(OptionsDictionary):

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -288,6 +288,8 @@ class TrajDesignParameterOptionsDictionary(DesignParameterOptionsDictionary):
                      desc='Used to override the default targets of the trajectory input parameter'
                           ' in each phase.  By default its target will be the same as its name')
 
+        self._dict.pop('targets')
+
 
 class InputParameterOptionsDictionary(OptionsDictionary):
     """
@@ -332,6 +334,8 @@ class TrajInputParameterOptionsDictionary(InputParameterOptionsDictionary):
         self.declare(name='custom_targets', types=dict, default=None, allow_none=True,
                      desc='Used to override the default targets of the trajectory input parameter'
                           ' in each phase.  By default its target will be the same as its name')
+
+        self._dict.pop('targets')
 
 
 class StateOptionsDictionary(OptionsDictionary):

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -1,8 +1,8 @@
 from __future__ import print_function, division, absolute_import
 
-from collections import Sequence, OrderedDict
+from collections import Sequence, OrderedDict, Iterable
 import itertools
-from six import iteritems
+from six import iteritems, string_types
 
 try:
     from itertools import izip
@@ -17,7 +17,8 @@ from openmdao.api import SqliteRecorder
 from ..utils.constants import INF_BOUND
 
 from ..transcriptions.common import InputParameterComp, PhaseLinkageComp
-from ..phase.options import DesignParameterOptionsDictionary, InputParameterOptionsDictionary
+from ..phase.options import TrajDesignParameterOptionsDictionary, \
+    TrajInputParameterOptionsDictionary
 
 
 class Trajectory(Group):
@@ -72,18 +73,16 @@ class Trajectory(Group):
             Name of the design parameter.
         val : float or ndarray
             Default value of the design parameter at all nodes.
-        targets : dict or None
-            If None, then the design parameter will be connected to the controllable parameter
-            in the ODE of each phase.  For each phase where no such controllable parameter exists,
-            a warning will be issued.  If targets is given as a dict, the dict should provide
-            the relevant phase names as keys, each associated with the respective controllable
-            parameteter as a value.
+        custom_targets : dict or None
+            By default, the input parameter will be connect to the parameter/targets of the given
+            name in each phase.  This argument can be used to override that behavior on a phase
+            by phase basis.
         units : str or None or 0
             Units in which the design parameter is defined.  If 0, use the units declared
             for the parameter in the ODE.
         """
         if name not in self.input_parameter_options:
-            self.input_parameter_options[name] = InputParameterOptionsDictionary()
+            self.input_parameter_options[name] = TrajInputParameterOptionsDictionary()
 
         for kw in kwargs:
             if kw not in self.input_parameter_options[name]:
@@ -131,7 +130,7 @@ class Trajectory(Group):
 
         """
         if name not in self.design_parameter_options:
-            self.design_parameter_options[name] = DesignParameterOptionsDictionary()
+            self.design_parameter_options[name] = TrajDesignParameterOptionsDictionary()
 
         for kw in kwargs:
             if kw not in self.design_parameter_options[name]:
@@ -155,29 +154,26 @@ class Trajectory(Group):
                 # Connect the input parameter to its target(s) in each phase
                 src_name = 'input_parameters:{0}_out'.format(name)
 
-                # Use target-params to rename the parameter in each phase, if desired.
-                target_params = options['target_params']
-
-                # If the phases have no corresponding parameter (are undecorated),
-                # specify their targets within the ODE here.
-                targets = options['targets']
-
                 for phase_name, phs in iteritems(self._phases):
-                    tgt_param_name = target_params.get(phase_name, None) \
-                        if isinstance(target_params, dict) else name
-                    tgt_names = targets.get(phase_name, None) \
-                        if isinstance(targets, dict) else None
-                    if tgt_param_name is None and tgt_names is not None:
-                        tgt_param_name = name
-                    if tgt_param_name:
-                        kwargs = {'dynamic': options['dynamic'],
-                                  'units': options['units'],
-                                  'val': options['val']}
-                        if tgt_names is not None:
-                            kwargs['targets'] = tgt_names
-                        phs.add_traj_parameter(tgt_param_name, **kwargs)
-                        tgt = '{0}.traj_parameters:{1}'.format(phase_name, tgt_param_name)
-                        self.connect(src_name=src_name, tgt_name=tgt)
+                    # The default target in the phase is name unless otherwise specified.
+                    kwargs = {'dynamic': options['dynamic'],
+                              'units': options['units'],
+                              'val': options['val']}
+
+                    param_name = name
+
+                    if 'custom_targets' in options and options['custom_targets'] is not None:
+                        # Dont add the traj parameter to the phase if it is explicitly excluded.
+                        if options['custom_targets'][phase_name] is None:
+                            continue
+                        if isinstance(options['custom_targets'][phase_name], string_types):
+                            param_name = options['custom_targets'][phase_name]
+                        elif isinstance(options['custom_targets'][phase_name], Iterable):
+                            kwargs['targets'] = options['custom_targets'][phase_name]
+
+                    phs.add_traj_parameter(param_name, **kwargs)
+                    tgt = '{0}.traj_parameters:{1}'.format(phase_name, param_name)
+                    self.connect(src_name=src_name, tgt_name=tgt)
 
     def _setup_design_parameters(self):
         """
@@ -209,29 +205,26 @@ class Trajectory(Group):
                 # Connect the design parameter to its target in each phase
                 src_name = 'design_parameters:{0}'.format(name)
 
-                # Use target-params to rename the parameter in each phase, if desired.
-                target_params = options['target_params']
-
-                # If the phases have no corresponding parameter (are undecorated),
-                # specify their targets within the ODE here.
-                targets = options['targets']
-
                 for phase_name, phs in iteritems(self._phases):
-                    tgt_param_name = target_params.get(phase_name, None) \
-                        if isinstance(target_params, dict) else name
-                    tgt_names = targets.get(phase_name, None) \
-                        if isinstance(targets, dict) else None
-                    if tgt_param_name is None and tgt_names is not None:
-                        tgt_param_name = name
-                    if tgt_param_name:
-                        kwargs = {'dynamic': options['dynamic'],
-                                  'units': options['units'],
-                                  'val': options['val']}
-                        if tgt_names is not None:
-                            kwargs['targets'] = tgt_names
-                        phs.add_traj_parameter(tgt_param_name, **kwargs)
-                        tgt = '{0}.traj_parameters:{1}'.format(phase_name, tgt_param_name)
-                        self.connect(src_name=src_name, tgt_name=tgt)
+                    # The default target in the phase is name unless otherwise specified.
+                    kwargs = {'dynamic': options['dynamic'],
+                              'units': options['units'],
+                              'val': options['val']}
+
+                    param_name = name
+
+                    if 'custom_targets' in options and options['custom_targets'] is not None:
+                        # Dont add the traj parameter to the phase if it is explicitly excluded.
+                        if options['custom_targets'][phase_name] is None:
+                            continue
+                        if isinstance(options['custom_targets'][phase_name], string_types):
+                            param_name = options['custom_targets'][phase_name]
+                        elif isinstance(options['custom_targets'][phase_name], Iterable):
+                            kwargs['targets'] = options['custom_targets'][phase_name]
+
+                    phs.add_traj_parameter(param_name, **kwargs)
+                    tgt = '{0}.traj_parameters:{1}'.format(phase_name, param_name)
+                    self.connect(src_name=src_name, tgt_name=tgt)
 
     def _setup_linkages(self):
         link_comp = None

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -164,12 +164,13 @@ class Trajectory(Group):
 
                     if 'custom_targets' in options and options['custom_targets'] is not None:
                         # Dont add the traj parameter to the phase if it is explicitly excluded.
-                        if options['custom_targets'][phase_name] is None:
-                            continue
-                        if isinstance(options['custom_targets'][phase_name], string_types):
-                            param_name = options['custom_targets'][phase_name]
-                        elif isinstance(options['custom_targets'][phase_name], Iterable):
-                            kwargs['targets'] = options['custom_targets'][phase_name]
+                        if phase_name in options['custom_targets']:
+                            if options['custom_targets'][phase_name] is None:
+                                continue
+                            if isinstance(options['custom_targets'][phase_name], string_types):
+                                param_name = options['custom_targets'][phase_name]
+                            elif isinstance(options['custom_targets'][phase_name], Iterable):
+                                kwargs['targets'] = options['custom_targets'][phase_name]
 
                     phs.add_traj_parameter(param_name, **kwargs)
                     tgt = '{0}.traj_parameters:{1}'.format(phase_name, param_name)
@@ -215,12 +216,13 @@ class Trajectory(Group):
 
                     if 'custom_targets' in options and options['custom_targets'] is not None:
                         # Dont add the traj parameter to the phase if it is explicitly excluded.
-                        if options['custom_targets'][phase_name] is None:
-                            continue
-                        if isinstance(options['custom_targets'][phase_name], string_types):
-                            param_name = options['custom_targets'][phase_name]
-                        elif isinstance(options['custom_targets'][phase_name], Iterable):
-                            kwargs['targets'] = options['custom_targets'][phase_name]
+                        if phase_name in options['custom_targets']:
+                            if options['custom_targets'][phase_name] is None:
+                                continue
+                            if isinstance(options['custom_targets'][phase_name], string_types):
+                                param_name = options['custom_targets'][phase_name]
+                            elif isinstance(options['custom_targets'][phase_name], Iterable):
+                                kwargs['targets'] = options['custom_targets'][phase_name]
 
                     phs.add_traj_parameter(param_name, **kwargs)
                     tgt = '{0}.traj_parameters:{1}'.format(phase_name, param_name)

--- a/dymos/transcriptions/runge_kutta/components/runge_kutta_state_continuity_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/runge_kutta_state_continuity_comp.py
@@ -11,7 +11,8 @@ from openmdao.core.implicitcomponent import ImplicitComponent
 
 class RungeKuttaStateContinuityComp(ImplicitComponent):
     """
-    A simple equation balance for solving implicit equations.
+    Implicitly solve the RungeKutta state continuity by forcing final state values to
+    equal initial state values plus the state integral over each segment.
 
     Attributes
     ----------

--- a/dymos/utils/testing_utils.py
+++ b/dymos/utils/testing_utils.py
@@ -14,7 +14,6 @@ def _new_setup(self):
 def _new_teardown(self):
     if hasattr(self, 'original_tearDown'):
         self.original_tearDown()
-    self.tempdir = os.getcwd()
     os.chdir(self.startdir)
     try:
         shutil.rmtree(self.tempdir)


### PR DESCRIPTION
### Summary

Specifying targets for trajectory design and input parameters within each constituent phase is now done with the `custom_targets` argument to `Trajectory.add_design_parameter` and `Trajectory.add_input_parameter`.

- If `custom_targets` is not specified, the target of a trajectory parameter in each phase is assumed to be a decorated ODE parameter of the same name.
- Otherwise `custom_targets` is given as a dictionary keyed by phase name with the following rules
  - If the value associated with the name of a phase is `None`, the trajectory parameter is _not_ connected to that phase.
  - If the value associated with the name of a phase is a string, the trajectory parameter is connected to a decorated ODE parameter of the same name within the phase.
  - If the value associated with the name of a phase is a list, it is assumed to be a list of targets relative to the ODE within that phase.

### Related Issues

- Resolves #185 

### Status

- [x] Ready for merge

### Backwards incompatibilities

Removes `targets` and `target_params` from `Trajectory.add_design_parameter` and `Trajectory.add_input_parameter`, replaced by `custom_targets`.

### New Dependencies

None
