### PR TITLE
Undo promotion warning fix

### DIFF
--- a/dymos/phase/test/test_time_targets.py
+++ b/dymos/phase/test/test_time_targets.py
@@ -263,20 +263,16 @@ class TestPhaseTimeTargets(unittest.TestCase):
 
         # Test the iteration ODE
 
-        assert_rel_error(self, p['phase0.rk_solve_group.k_iter_group.ode.time_phase'][-1], 1.8016,
+        assert_rel_error(self, p['phase0.rk_solve_group.ode.time_phase'][-1], 1.8016,
                          tolerance=1.0E-3)
 
-        assert_rel_error(self, p['phase0.rk_solve_group.k_iter_group.ode.t_initial'],
-                         p['phase0.t_initial'])
+        assert_rel_error(self, p['phase0.rk_solve_group.ode.t_initial'], p['phase0.t_initial'])
 
-        assert_rel_error(self, p['phase0.rk_solve_group.k_iter_group.ode.t_duration'],
-                         p['phase0.t_duration'])
+        assert_rel_error(self, p['phase0.rk_solve_group.ode.t_duration'], p['phase0.t_duration'])
 
-        assert_rel_error(self, p['phase0.rk_solve_group.k_iter_group.ode.time_phase'],
-                         time_phase_all)
+        assert_rel_error(self, p['phase0.rk_solve_group.ode.time_phase'], time_phase_all)
 
-        assert_rel_error(self, p['phase0.rk_solve_group.k_iter_group.ode.time'],
-                         time_all)
+        assert_rel_error(self, p['phase0.rk_solve_group.ode.time'], time_all)
 
         # Now test the final ODE
 

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -351,7 +351,7 @@ class Trajectory(Group):
                         path = 'initial_states:{0}'.format(var)
 
                         self.connect('{0}.{1}'.format(phase_name1, source1),
-                                     'phases.{0}.{1}'.format(phase_name2, path))
+                                     '{0}.{1}'.format(phase_name2, path))
 
                     print('       {0:<{2}s} --> {1:<{2}s}'.format(source1, source2,
                                                                   max_varname_length + 9))
@@ -381,28 +381,14 @@ class Trajectory(Group):
         if self.input_parameter_options:
             self._setup_input_parameters()
 
-        phases_group = ParallelGroup()
-
-        promoted_inputs = []
+        phases_group = self.add_subsystem('phases', subsys=ParallelGroup(), promotes_inputs=['*'],
+                                          promotes_outputs=['*'])
 
         for name, phs in iteritems(self._phases):
             g = phases_group.add_subsystem(name, phs, **self._phase_add_kwargs[name])
-            phs.finalize_variables()
-            promoted_inputs.append('{0}.t_initial'.format(name))
-            promoted_inputs.append('{0}.t_duration'.format(name))
-            if phs.input_parameter_options:
-                promoted_inputs.append('{0}.input_parameters:*'.format(name))
-            if phs.traj_parameter_options:
-                promoted_inputs.append('{0}.traj_parameters:*'.format(name))
-            input_controls = [cname for cname, opts in iteritems(phs.control_options) if not opts['opt']]
-            if input_controls:
-                promoted_inputs.append('{0}.controls:*'.format(name))
             # DirectSolvers were moved down into the phases for use with MPI
             g.linear_solver = DirectSolver()
-
-        self.add_subsystem('phases', phases_group,
-                           promotes_inputs=promoted_inputs,
-                           promotes_outputs=['*'])
+            phs.finalize_variables()
 
         if self._linkages:
             self._setup_linkages()

--- a/dymos/transcriptions/runge_kutta/components/runge_kutta_k_iter_group.py
+++ b/dymos/transcriptions/runge_kutta/components/runge_kutta_k_iter_group.py
@@ -65,7 +65,8 @@ class RungeKuttaKIterGroup(Group):
                            subsys=RungeKuttaKComp(method=self.options['method'],
                                                   num_segments=num_seg,
                                                   state_options=state_options,
-                                                  time_units=self.options['time_units']))
+                                                  time_units=self.options['time_units']),
+                           promotes_inputs=['h'])
 
         for state_name, options in iteritems(self.options['state_options']):
             # Connect the state predicted (assumed) value to its targets in the ode

--- a/dymos/transcriptions/runge_kutta/components/runge_kutta_state_continuity_iter_group.py
+++ b/dymos/transcriptions/runge_kutta/components/runge_kutta_state_continuity_iter_group.py
@@ -61,7 +61,8 @@ class RungeKuttaStateContinuityIterGroup(Group):
                                                 ode_init_kwargs=self.options['ode_init_kwargs'],
                                                 solver_class=self.options['k_solver_class'],
                                                 solver_options=self.options['k_solver_options']),
-                           promotes_inputs=['initial_states_per_seg:*'])
+                           promotes_inputs=['*'],
+                           promotes_outputs=['*'])
 
         self.add_subsystem('state_advance_comp',
                            RungeKuttaStateAdvanceComp(num_segments=self.options['num_segments'],
@@ -85,7 +86,7 @@ class RungeKuttaStateContinuityIterGroup(Group):
                            promotes_outputs=['states:*'])
 
         for state_name, options in iteritems(self.options['state_options']):
-            self.connect('k_iter_group.k_comp.k:{0}'.format(state_name),
+            self.connect('k_comp.k:{0}'.format(state_name),
                          'state_advance_comp.k:{0}'.format(state_name))
             row_idxs = np.arange(self.options['num_segments'], dtype=int)
             src_idxs = get_src_indices_by_row(row_idxs, options['shape'])

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_iter_group.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_iter_group.py
@@ -43,12 +43,11 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
                                   k_solver_class=NonlinearRunOnce),
                               promotes_outputs=['states:*'])
 
-        p.model.connect('h', 'cnty_iter_group.k_iter_group.k_comp.h')
-        p.model.connect('time', 'cnty_iter_group.k_iter_group.ode.t')
+        p.model.connect('h', 'cnty_iter_group.h')
+        p.model.connect('time', 'cnty_iter_group.ode.t')
 
         src_idxs = np.arange(16, dtype=int).reshape((num_seg, 4, 1))
-        p.model.connect('cnty_iter_group.k_iter_group.ode.ydot',
-                        'cnty_iter_group.k_iter_group.k_comp.f:y',
+        p.model.connect('cnty_iter_group.ode.ydot', 'cnty_iter_group.k_comp.f:y',
                         src_indices=src_idxs, flat_src_indices=True)
 
         p.model.nonlinear_solver = NonlinearRunOnce()
@@ -62,25 +61,25 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
                                   [4.006818970044454],
                                   [5.301605229265987]])
 
-        p['cnty_iter_group.k_iter_group.k_comp.k:y'] = np.array([[[0.75000000],
-                                                                  [0.90625000],
-                                                                  [0.94531250],
-                                                                  [1.09765625]],
+        p['cnty_iter_group.k_comp.k:y'] = np.array([[[0.75000000],
+                                                     [0.90625000],
+                                                     [0.94531250],
+                                                     [1.09765625]],
 
-                                                                 [[1.087565104166667],
-                                                                  [1.203206380208333],
-                                                                  [1.232116699218750],
-                                                                  [1.328623453776042]],
+                                                    [[1.087565104166667],
+                                                     [1.203206380208333],
+                                                     [1.232116699218750],
+                                                     [1.328623453776042]],
 
-                                                                 [[1.319801330566406],
-                                                                  [1.368501663208008],
-                                                                  [1.380676746368408],
-                                                                  [1.385139703750610]],
+                                                    [[1.319801330566406],
+                                                     [1.368501663208008],
+                                                     [1.380676746368408],
+                                                     [1.385139703750610]],
 
-                                                                 [[1.378409485022227],
-                                                                  [1.316761856277783],
-                                                                  [1.301349949091673],
-                                                                  [1.154084459568063]]])
+                                                    [[1.378409485022227],
+                                                     [1.316761856277783],
+                                                     [1.301349949091673],
+                                                     [1.154084459568063]]])
 
         p.run_model()
         p.model.run_apply_nonlinear()
@@ -131,21 +130,21 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
         ivc.add_output('h', val=np.array([0.5, 0.5, 0.5, 0.5]), units='s')
 
         p.model.add_subsystem('cnty_iter_group',
-                              RungeKuttaStateContinuityIterGroup(num_segments=num_seg,
-                                                                 method='RK4',
-                                                                 state_options=state_options,
-                                                                 time_units='s',
-                                                                 ode_class=TestODE,
-                                                                 ode_init_kwargs={},
-                                                                 k_solver_class=None),
+                              RungeKuttaStateContinuityIterGroup(
+                                  num_segments=num_seg,
+                                  method='RK4',
+                                  state_options=state_options,
+                                  time_units='s',
+                                  ode_class=TestODE,
+                                  ode_init_kwargs={},
+                                  k_solver_class=None),
                               promotes_outputs=['states:*'])
 
-        p.model.connect('h', 'cnty_iter_group.k_iter_group.k_comp.h')
-        p.model.connect('time', 'cnty_iter_group.k_iter_group.ode.t')
+        p.model.connect('h', 'cnty_iter_group.h')
+        p.model.connect('time', 'cnty_iter_group.ode.t')
 
         src_idxs = np.arange(16, dtype=int).reshape((num_seg, 4, 1))
-        p.model.connect('cnty_iter_group.k_iter_group.ode.ydot',
-                        'cnty_iter_group.k_iter_group.k_comp.f:y',
+        p.model.connect('cnty_iter_group.ode.ydot', 'cnty_iter_group.k_comp.f:y',
                         src_indices=src_idxs, flat_src_indices=True)
 
         p.model.nonlinear_solver = NewtonSolver()

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_k_iter_group.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_k_iter_group.py
@@ -38,7 +38,7 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
                                                    solver_class=NonlinearRunOnce))
 
         p.model.connect('t', 'k_iter_group.ode.t')
-        p.model.connect('h', 'k_iter_group.k_comp.h')
+        p.model.connect('h', 'k_iter_group.h')
         p.model.connect('initial_states_per_seg:y', 'k_iter_group.initial_states_per_seg:y')
 
         src_idxs = np.arange(16, dtype=int).reshape((num_seg, num_stages, 1))
@@ -114,7 +114,7 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
                                                    solver_options={'iprint': 2}))
 
         p.model.connect('t', 'k_iter_group.ode.t')
-        p.model.connect('h', 'k_iter_group.k_comp.h')
+        p.model.connect('h', 'k_iter_group.h')
         p.model.connect('initial_states_per_seg:y', 'k_iter_group.initial_states_per_seg:y')
 
         src_idxs = np.arange(16, dtype=int).reshape((num_seg, num_stages, 1))
@@ -173,7 +173,7 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
                                                    solver_options={'iprint': 2}))
 
         p.model.connect('t', 'k_iter_group.ode.t')
-        p.model.connect('h', 'k_iter_group.k_comp.h')
+        p.model.connect('h', 'k_iter_group.h')
         p.model.connect('initial_states_per_seg:y', 'k_iter_group.initial_states_per_seg:y')
 
         src_idxs = np.arange(16, dtype=int).reshape((num_seg, num_stages, 1))


### PR DESCRIPTION
### Summary

This reverts the promotion warning fix since OpenMDAO is removing that verbose warning.  The fix is particularly tricky with dymos where the variables to be promoted from phases are not necessarily known until setup time and require a lot of logic.

In particular, keeping the original behavior makes it easier to "hide" the phases group under trajectory, which houses the phases but promotes everything so as to be transparent to the user.

### Related Issues

This reverts the resolution of #193 

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
