### PR TITLE
OpenMDAO API updates

### DIFF
--- a/benchmark/benchmark_brachistochrone.py
+++ b/benchmark/benchmark_brachistochrone.py
@@ -1,7 +1,7 @@
 
 import unittest
 
-from openmdao.api import Problem, Group, pyOptSparseDriver, DirectSolver
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 import dymos as dm
 from dymos.examples.brachistochrone import BrachistochroneODE
@@ -9,10 +9,10 @@ from dymos.examples.brachistochrone import BrachistochroneODE
 
 def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, transcription_order=3,
                              compressed=True, optimizer='SLSQP', simul_derivs=True):
-    p = Problem(model=Group())
+    p = om.Problem(model=om.Group())
 
     # if optimizer == 'SNOPT':
-    p.driver = pyOptSparseDriver()
+    p.driver = om.pyOptSparseDriver()
     p.driver.options['optimizer'] = optimizer
     p.driver.options['dynamic_simul_derivs'] = simul_derivs
 
@@ -49,7 +49,7 @@ def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, tran
     # Minimize time at the end of the phase
     phase.add_objective('time_phase', loc='final', scaler=10)
 
-    p.model.linear_solver = DirectSolver()
+    p.model.linear_solver = om.DirectSolver()
     p.setup(check=True)
 
     p['phase0.t_initial'] = 0.0

--- a/benchmark/benchmark_brachistochrone.py
+++ b/benchmark/benchmark_brachistochrone.py
@@ -14,7 +14,9 @@ def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, tran
     # if optimizer == 'SNOPT':
     p.driver = om.pyOptSparseDriver()
     p.driver.options['optimizer'] = optimizer
-    p.driver.options['dynamic_simul_derivs'] = simul_derivs
+
+    if simul_derivs:
+        p.driver.declare_coloring()
 
     if transcription == 'gauss-lobatto':
         t = dm.GaussLobatto(num_segments=num_segments,

--- a/dymos/docs/examples/brachistochrone.rst
+++ b/dymos/docs/examples/brachistochrone.rst
@@ -57,7 +57,7 @@ Finally, note that we are specifying rows and columns when declaring the partial
 Since our inputs and outputs are scalars *at each point in time*, and the value at an input at
 one time only directly impacts the values of an output at the same point in time, the partial
 derivative jacobian will be diagonal.  Specifying the partial derivatives as being sparse
-greatly improves the performance of Dymos when the driver option ``dynamic_simul_derivs`` is used.
+greatly improves the performance of Dymos when the driver function ``declare_coloring`` is used.
 Using a sparse optimizer like SNOPT or IPOPT can provide significant addition improvements in
 performance.
 

--- a/dymos/docs/examples/figures/ssto_linear_tangent_xdsm.py
+++ b/dymos/docs/examples/figures/ssto_linear_tangent_xdsm.py
@@ -2,12 +2,12 @@ from __future__ import print_function, division, absolute_import
 
 from pyxdsm.XDSM import XDSM
 
-from openmdao.api import Problem
+import openmdao.api as om
 from dymos.examples.ssto.launch_vehicle_linear_tangent_ode import LaunchVehicleLinearTangentODE
 
 
 def main():  # pragma: no cover
-    p = Problem()
+    p = om.Problem()
     p.model = LaunchVehicleLinearTangentODE(num_nodes=1)
     p.setup()
 

--- a/dymos/docs/examples/figures/ssto_xdsm.py
+++ b/dymos/docs/examples/figures/ssto_xdsm.py
@@ -2,12 +2,12 @@ from __future__ import print_function, division, absolute_import
 
 from pyxdsm.XDSM import XDSM
 
-from openmdao.api import Problem
+import openmdao.api as om
 from dymos.examples.ssto.launch_vehicle_ode import LaunchVehicleODE
 
 
 def main():  # pragma: no cover
-    p = Problem()
+    p = om.Problem()
     p.model = LaunchVehicleODE(num_nodes=1)
     p.setup()
 

--- a/dymos/docs/examples/multibranch_trajectory.rst
+++ b/dymos/docs/examples/multibranch_trajectory.rst
@@ -25,7 +25,7 @@ phases are connected to the output of a single phase.  This way you can simulate
 trajectory paths in the same model. For this example, we will start with a single phase ("phase0")
 that simulates the model for one hour. Three follow-on phases will be linked to the output of the
 first phase: "phase1" will run as normal, "phase1_bfail" will fail one of the battery cells, and
-"phase1_bfail" will fail a motor. All three of these phases start where "phase0" leaves off, so
+"phase1_mfail" will fail a motor. All three of these phases start where "phase0" leaves off, so
 they share the same initial time and state of charge.
 
 

--- a/dymos/docs/feature_reference/simultaneous_derivs.rst
+++ b/dymos/docs/feature_reference/simultaneous_derivs.rst
@@ -38,11 +38,30 @@ Step 1: Using OpenMDAO's Simul-Coloring Capability
 
 OpenMDAO supports dynamic simul-coloring, meaning it can automatically run the Jacobian coloring
 algorithm before handing the problem to the optimizer.  To enable this capability, simply
-add the following lines to the driver.
+add the following line to the driver.
 
 .. code-block:: python
 
-    driver.options['dynamic_simul_derivs'] = True
+    driver.declare_coloring()
+
+By default the coloring algorithm will attempt to determine the sparsity pattern of the total jacobian
+by filling the partial jacobian matrices with random noise and searching for nonzeros in the resulting
+total jacobian.  At times this might report that it failed to converge on a number of nonzero entries.
+This is due to the introduction of noise during the matrix inversion by the system's linear solver.
+This can be remedied by using a different linear solver, such as PETScKrylov, or by telling the
+coloring algorithm to accept a given tolerance on the nonzero elements rather than trying to determine
+it automatically.  This can be accomplished with the following options to declare coloring:
+
+.. code-block:: python
+
+    driver.declare_coloring(tol=1.0E-12, orders=None)
+
+Setting `orders` to None prevents the automatic tolerance detection.  The value of `tol` is up to
+the user.  If it is too large, then some nonzero values will erroneously be determined to be zeros
+and the total derivative will be incorrect.  If `tol` is too small then the sparsity pattern may be
+overly conservative and degrade performance somewhat.  We recommend letting the coloring algorithm
+detect the sparsity automatically and only resorting to a fixed tolerance if necessary.
+
 
 The simul_coloring script outputs the following information about our problem:
 

--- a/dymos/docs/feature_reference/transcriptions/figures/gauss-lobatto/plot_high_order_gauss_lobatto.py
+++ b/dymos/docs/feature_reference/transcriptions/figures/gauss-lobatto/plot_high_order_gauss_lobatto.py
@@ -6,13 +6,13 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
-from openmdao.api import Problem, Group
-from dymos import Phase, GaussLobatto
+import openmdao.api as om
+import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-p = Problem(model=Group())
-phase = Phase(ode_class=BrachistochroneODE,
-              transcription=GaussLobatto(num_segments=4, order=[3, 5, 3, 5]))
+p = om.Problem(model=om.Group())
+phase = dm.Phase(ode_class=BrachistochroneODE,
+                 transcription=dm.GaussLobatto(num_segments=4, order=[3, 5, 3, 5]))
 p.model.add_subsystem('phase0', phase)
 
 p.setup()

--- a/dymos/docs/feature_reference/transcriptions/figures/radau-pseudospectral/plot_radau-pseudospectral.py
+++ b/dymos/docs/feature_reference/transcriptions/figures/radau-pseudospectral/plot_radau-pseudospectral.py
@@ -6,13 +6,13 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
-from openmdao.api import Problem, Group
-from dymos import Phase, Radau
+import openmdao.api as om
+import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-p = Problem(model=Group())
-phase = Phase(ode_class=BrachistochroneODE,
-              transcription=Radau(num_segments=4, order=[3, 5, 3, 5]))
+p = om.Problem(model=om.Group())
+phase = dm.Phase(ode_class=BrachistochroneODE,
+                 transcription=dm.Radau(num_segments=4, order=[3, 5, 3, 5]))
 p.model.add_subsystem('phase0', phase)
 
 p.setup()

--- a/dymos/examples/aircraft_steady_flight/aero/aero_coef_comp.py
+++ b/dymos/examples/aircraft_steady_flight/aero/aero_coef_comp.py
@@ -1,13 +1,12 @@
 from __future__ import print_function, division, absolute_import
 
 import numpy as np
-
-from openmdao.api import MetaModelStructuredComp
+import openmdao.api as om
 
 from .crm_data import h_bp, alpha_bp, mach_bp, eta_bp, CL_data, CD_data, CM_data
 
 
-class AeroCoefComp(MetaModelStructuredComp):
+class AeroCoefComp(om.MetaModelStructuredComp):
     """ Interpolates aerodynamic coefficients for the NASA Common Research Model. """
 
     def setup(self):

--- a/dymos/examples/aircraft_steady_flight/aero/aero_forces_comp.py
+++ b/dymos/examples/aircraft_steady_flight/aero/aero_forces_comp.py
@@ -2,10 +2,10 @@ from __future__ import print_function, division, absolute_import
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class AeroForcesComp(ExplicitComponent):
+class AeroForcesComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)

--- a/dymos/examples/aircraft_steady_flight/aero/aerodynamics_group.py
+++ b/dymos/examples/aircraft_steady_flight/aero/aerodynamics_group.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
-from openmdao.api import Group
-
+import openmdao.api as om
 from .aero_coef_comp import AeroCoefComp
 from .aero_forces_comp import AeroForcesComp
 from .mbi_aero_coef_comp import MBIAeroCoeffComp, setup_surrogates_all
@@ -12,7 +11,7 @@ except ImportError:
     MBI = None
 
 
-class AerodynamicsGroup(Group):
+class AerodynamicsGroup(om.Group):
     """
     The purpose of the Aerodynamics is to compute the lift and
     drag forces on the aircraft.

--- a/dymos/examples/aircraft_steady_flight/aero/mbi_aero_coef_comp.py
+++ b/dymos/examples/aircraft_steady_flight/aero/mbi_aero_coef_comp.py
@@ -5,8 +5,7 @@ __author__ = 'rfalck'
 import os.path
 
 import numpy as np
-from openmdao.api import ExplicitComponent
-
+import openmdao.api as om
 try:
     import MBI
 except ImportError:
@@ -60,7 +59,7 @@ def setup_surrogates_all(model_name='CRM'):
     return [CL_arr, CD_arr, CM_arr, nums]
 
 
-class MBIAeroCoeffComp(ExplicitComponent):
+class MBIAeroCoeffComp(om.ExplicitComponent):
     """ Compute the lift, drag, and moment coefficients of the aircraft """
     def initialize(self):
         self.options.declare('vec_size', types=int)

--- a/dymos/examples/aircraft_steady_flight/aero/test/test_aero_coef_comp.py
+++ b/dymos/examples/aircraft_steady_flight/aero/test/test_aero_coef_comp.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 from numpy import array
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 from dymos.examples.aircraft_steady_flight.aero.aero_coef_comp import AeroCoefComp
@@ -17,11 +17,11 @@ class TestAeroCoefComp(unittest.TestCase):
 
         nn = 100
 
-        prob = Problem(model=Group())
+        prob = om.Problem(model=om.Group())
 
         prob.model.add_subsystem(name='aero', subsys=AeroCoefComp(vec_size=nn, method='quintic'))
 
-        ivc = prob.model.add_subsystem(name='ivc', subsys=IndepVarComp(), promotes_outputs=['*'])
+        ivc = prob.model.add_subsystem(name='ivc', subsys=om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('mach', val=np.zeros(nn), units=None)
         ivc.add_output('alpha', val=np.zeros(nn), units='rad')

--- a/dymos/examples/aircraft_steady_flight/aero/test/test_mbi_aero_coef_comp.py
+++ b/dymos/examples/aircraft_steady_flight/aero/test/test_mbi_aero_coef_comp.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 from dymos.examples.aircraft_steady_flight.aero.mbi_aero_coef_comp import setup_surrogates_all, \
@@ -22,7 +22,7 @@ class TestAeroCoefComp(unittest.TestCase):
         NUM_NODES = 100
         MODEL = 'CRM'
 
-        prob = Problem(root=Group())
+        prob = om.Problem(model=om.Group())
 
         mbi_CL, mbi_CD, mbi_CM, mbi_num = setup_surrogates_all(MODEL)
 
@@ -32,16 +32,16 @@ class TestAeroCoefComp(unittest.TestCase):
                                                          mbi_num=mbi_num))
 
         prob.model.add_subsystem(name='M_ivc',
-                                 subsys=IndepVarComp('M', val=np.zeros(NUM_NODES), units=None),
+                                 subsys=om.IndepVarComp('M', val=np.zeros(NUM_NODES), units=None),
                                  promotes=['M'])
         prob.model.add_subsystem(name='alpha_ivc',
-                                 subsys=IndepVarComp('alpha', val=np.zeros(NUM_NODES), units='rad'),
+                                 subsys=om.IndepVarComp('alpha', val=np.zeros(NUM_NODES), units='rad'),
                                  promotes=['alpha'])
         prob.model.add_subsystem(name='eta_ivc',
-                                 subsys=IndepVarComp('eta', val=np.zeros(NUM_NODES), units='rad'),
+                                 subsys=om.IndepVarComp('eta', val=np.zeros(NUM_NODES), units='rad'),
                                  promotes=['eta'])
         prob.model.add_subsystem(name='h_ivc',
-                                 subsys=IndepVarComp('h', val=np.zeros(NUM_NODES), units='km'),
+                                 subsys=om.IndepVarComp('h', val=np.zeros(NUM_NODES), units='km'),
                                  promotes=['h'])
 
         prob.model.connect('M', 'aero.M')

--- a/dymos/examples/aircraft_steady_flight/aircraft_ode.py
+++ b/dymos/examples/aircraft_steady_flight/aircraft_ode.py
@@ -1,8 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
-from openmdao.api import Group, DirectSolver, NewtonSolver, BoundsEnforceLS
-
-from dymos import declare_time, declare_state, declare_parameter
+import openmdao.api as om
+import dymos as dm
 from dymos.models.atmosphere import USatm1976Comp
 
 from .steady_flight_path_angle_comp import SteadyFlightPathAngleComp
@@ -14,19 +13,18 @@ from .true_airspeed_comp import TrueAirspeedComp
 from .mass_comp import MassComp
 
 
-@declare_time(units='s')
-@declare_state('range', rate_source='range_rate_comp.dXdt:range', units='m')
-@declare_state('mass_fuel', targets=['mass_comp.mass_fuel'],
-               rate_source='propulsion.dXdt:mass_fuel', units='kg')
-@declare_state('alt', targets=['atmos.h', 'aero.alt', 'propulsion.alt'],
-               rate_source='climb_rate', units='m')
-# @declare_parameter('alt', targets=['atmos.h', 'aero.alt', 'propulsion.alt'], units='m')
-@declare_parameter('climb_rate', targets=['gam_comp.climb_rate'], units='m/s')
-@declare_parameter('mach', targets=['tas_comp.mach', 'aero.mach'], units='m/s')
-@declare_parameter('S', targets=['aero.S', 'flight_equilibrium.S', 'propulsion.S'], units='m**2')
-@declare_parameter('mass_empty', targets=['mass_comp.mass_empty'], units='kg')
-@declare_parameter('mass_payload', targets=['mass_comp.mass_payload'], units='kg')
-class AircraftODE(Group):
+@dm.declare_time(units='s')
+@dm.declare_state('range', rate_source='range_rate_comp.dXdt:range', units='m')
+@dm.declare_state('mass_fuel', targets=['mass_comp.mass_fuel'],
+                  rate_source='propulsion.dXdt:mass_fuel', units='kg')
+@dm.declare_state('alt', targets=['atmos.h', 'aero.alt', 'propulsion.alt'],
+                  rate_source='climb_rate', units='m')
+@dm.declare_parameter('climb_rate', targets=['gam_comp.climb_rate'], units='m/s')
+@dm.declare_parameter('mach', targets=['tas_comp.mach', 'aero.mach'], units='m/s')
+@dm.declare_parameter('S', targets=['aero.S', 'flight_equilibrium.S', 'propulsion.S'], units='m**2')
+@dm.declare_parameter('mass_empty', targets=['mass_comp.mass_empty'], units='kg')
+@dm.declare_parameter('mass_payload', targets=['mass_comp.mass_payload'], units='kg')
+class AircraftODE(om.Group):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int,

--- a/dymos/examples/aircraft_steady_flight/doc/test_doc_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/doc/test_doc_aircraft_steady_flight.py
@@ -20,7 +20,7 @@ class TestSteadyAircraftFlightForDocs(unittest.TestCase):
     def test_steady_aircraft_for_docs(self):
         import matplotlib.pyplot as plt
 
-        from openmdao.api import Problem, Group, pyOptSparseDriver, IndepVarComp
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
 
         import dymos as dm
@@ -29,8 +29,8 @@ class TestSteadyAircraftFlightForDocs(unittest.TestCase):
         from dymos.examples.plotting import plot_results
         from dymos.utils.lgl import lgl
 
-        p = Problem(model=Group())
-        p.driver = pyOptSparseDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'SLSQP'
         p.driver.options['dynamic_simul_derivs'] = True
 
@@ -46,7 +46,7 @@ class TestSteadyAircraftFlightForDocs(unittest.TestCase):
                                                                order=3, compressed=False)))
 
         # Pass Reference Area from an external source
-        assumptions = p.model.add_subsystem('assumptions', IndepVarComp())
+        assumptions = p.model.add_subsystem('assumptions', om.IndepVarComp())
         assumptions.add_output('S', val=427.8, units='m**2')
         assumptions.add_output('mass_empty', val=1.0, units='kg')
         assumptions.add_output('mass_payload', val=1.0, units='kg')

--- a/dymos/examples/aircraft_steady_flight/doc/test_doc_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/doc/test_doc_aircraft_steady_flight.py
@@ -32,7 +32,7 @@ class TestSteadyAircraftFlightForDocs(unittest.TestCase):
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'SLSQP'
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         num_seg = 15
         seg_ends, _ = lgl(num_seg + 1)

--- a/dymos/examples/aircraft_steady_flight/doc/test_doc_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/doc/test_doc_aircraft_steady_flight.py
@@ -13,7 +13,7 @@ class TestSteadyAircraftFlightForDocs(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        for filename in ['coloring.json', 'test_doc_aircraft_steady_flight_rec.db', 'SLSQP.out']:
+        for filename in ['total_coloring.pkl', 'test_doc_aircraft_steady_flight_rec.db', 'SLSQP.out']:
             if os.path.exists(filename):
                 os.remove(filename)
 

--- a/dymos/examples/aircraft_steady_flight/dynamic_pressure_comp.py
+++ b/dymos/examples/aircraft_steady_flight/dynamic_pressure_comp.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, division, absolute_import
 
 import numpy as np
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class DynamicPressureComp(ExplicitComponent):
+class DynamicPressureComp(om.ExplicitComponent):
     """ Compute the dynamic pressure based on the velocity and the atmospheric density. """
     def initialize(self):
         self.options.declare('num_nodes', types=int)

--- a/dymos/examples/aircraft_steady_flight/flight_equlibrium/lift_equilibrium_comp.py
+++ b/dymos/examples/aircraft_steady_flight/flight_equlibrium/lift_equilibrium_comp.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class LiftEquilibriumComp(ExplicitComponent):
+class LiftEquilibriumComp(om.ExplicitComponent):
     """
     Compute the rates of TAS and flight path angle required to match a given
     flight condition.

--- a/dymos/examples/aircraft_steady_flight/flight_equlibrium/steady_flight_equilibrium_group.py
+++ b/dymos/examples/aircraft_steady_flight/flight_equlibrium/steady_flight_equilibrium_group.py
@@ -2,15 +2,14 @@ from __future__ import print_function, division, absolute_import
 
 import numpy as np
 
-from openmdao.api import Group, BalanceComp, NewtonSolver, DirectSolver, ArmijoGoldsteinLS, \
-    BoundsEnforceLS
+import openmdao.api as om
 
 from ..aero.aerodynamics_group import AerodynamicsGroup
 from .lift_equilibrium_comp import LiftEquilibriumComp
 from .thrust_equilibrium_comp import ThrustEquilibriumComp
 
 
-class SteadyFlightEquilibriumGroup(Group):
+class SteadyFlightEquilibriumGroup(om.Group):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int,
@@ -33,7 +32,7 @@ class SteadyFlightEquilibriumGroup(Group):
                            promotes_outputs=['CL_eq'])
 
         bal = self.add_subsystem(name='alpha_eta_balance',
-                                 subsys=BalanceComp(),
+                                 subsys=om.BalanceComp(),
                                  promotes_outputs=['alpha', 'eta'])
 
         self.connect('alpha', ('aero.alpha'))
@@ -50,8 +49,8 @@ class SteadyFlightEquilibriumGroup(Group):
         self.connect('aero.CM', 'alpha_eta_balance.CM')
         self.connect('CL_eq', ('alpha_eta_balance.CL_eq'))
 
-        self.linear_solver = DirectSolver()
-        self.nonlinear_solver = NewtonSolver()
+        self.linear_solver = om.DirectSolver()
+        self.nonlinear_solver = om.NewtonSolver()
         self.nonlinear_solver.options['atol'] = 1e-14
         self.nonlinear_solver.options['rtol'] = 1e-14
         self.nonlinear_solver.options['solve_subsystems'] = True
@@ -59,6 +58,5 @@ class SteadyFlightEquilibriumGroup(Group):
         self.nonlinear_solver.options['max_sub_solves'] = 10
         self.nonlinear_solver.options['maxiter'] = 150
         self.nonlinear_solver.options['iprint'] = -1
-        # self.nonlinear_solver.linesearch = ArmijoGoldsteinLS()
-        self.nonlinear_solver.linesearch = BoundsEnforceLS()
+        self.nonlinear_solver.linesearch = om.BoundsEnforceLS()
         self.nonlinear_solver.linesearch.options['print_bound_enforce'] = True

--- a/dymos/examples/aircraft_steady_flight/flight_equlibrium/test/test_flight_equilibrium_group.py
+++ b/dymos/examples/aircraft_steady_flight/flight_equlibrium/test/test_flight_equilibrium_group.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division, absolute_import
 import unittest
 
 import numpy as np
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
 
 from dymos.examples.aircraft_steady_flight.flight_equlibrium.steady_flight_equilibrium_group \
@@ -23,9 +23,9 @@ class TestFlightEquilibriumGroup(unittest.TestCase):
     def setUpClass(cls):
         cls.n = 10
 
-        cls.p = Problem(model=Group())
+        cls.p = om.Problem(model=om.Group())
 
-        ivc = cls.p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = cls.p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('alt', val=3000 * np.ones(cls.n), units='m', desc='altitude above MSL')
         ivc.add_output('TAS', val=250.0 * np.ones(cls.n), units='m/s', desc='true airspeed')

--- a/dymos/examples/aircraft_steady_flight/flight_equlibrium/thrust_equilibrium_comp.py
+++ b/dymos/examples/aircraft_steady_flight/flight_equlibrium/thrust_equilibrium_comp.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class ThrustEquilibriumComp(ExplicitComponent):
+class ThrustEquilibriumComp(om.ExplicitComponent):
     """
     Compute the rates of TAS and flight path angle required to match a given
     flight condition.

--- a/dymos/examples/aircraft_steady_flight/mass_comp.py
+++ b/dymos/examples/aircraft_steady_flight/mass_comp.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class MassComp(ExplicitComponent):
+class MassComp(om.ExplicitComponent):
     """ Compute the total mass of the aircraft """
 
     def initialize(self):

--- a/dymos/examples/aircraft_steady_flight/propulsion/fuel_burn_rate_comp.py
+++ b/dymos/examples/aircraft_steady_flight/propulsion/fuel_burn_rate_comp.py
@@ -2,10 +2,10 @@ from __future__ import print_function, division, absolute_import
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class FuelBurnRateComp(ExplicitComponent):
+class FuelBurnRateComp(om.ExplicitComponent):
     """ Computes the fuel burn rate (rate of change of fuel weight) based on SFC and thrust. """
     def initialize(self):
         self.options.declare('num_nodes', types=int)

--- a/dymos/examples/aircraft_steady_flight/propulsion/max_thrust_comp.py
+++ b/dymos/examples/aircraft_steady_flight/propulsion/max_thrust_comp.py
@@ -2,10 +2,10 @@ from __future__ import print_function, division, absolute_import
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class MaxThrustComp(ExplicitComponent):
+class MaxThrustComp(om.ExplicitComponent):
     """ Compute the maximum thrust given the current aircraft state and its
         maximum sea-level thrust with a simple pressure correction.
     """

--- a/dymos/examples/aircraft_steady_flight/propulsion/propulsion_group.py
+++ b/dymos/examples/aircraft_steady_flight/propulsion/propulsion_group.py
@@ -1,8 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
-import numpy as np
-
-from openmdao.api import Group, IndepVarComp
+import openmdao.api as om
 
 from .thrust_comp import ThrustComp
 from .max_thrust_comp import MaxThrustComp
@@ -11,7 +9,7 @@ from .tsfc_comp import SFCComp
 from .fuel_burn_rate_comp import FuelBurnRateComp
 
 
-class PropulsionGroup(Group):
+class PropulsionGroup(om.Group):
     """
     The PropulsionGroup computes propulsive forces (thrust), the specific fuel consumption and
     fuel expenditure rate, and the aircraft throttle setting.
@@ -22,7 +20,7 @@ class PropulsionGroup(Group):
     def setup(self):
         n = self.options['num_nodes']
 
-        assumptions = self.add_subsystem('assumptions', subsys=IndepVarComp())
+        assumptions = self.add_subsystem('assumptions', subsys=om.IndepVarComp())
 
         assumptions.add_output('tsfc_sl', val=2 * 8.951e-6 * 9.80665, units='1/s',
                                desc='thrust specific fuel consumption at sea-level')

--- a/dymos/examples/aircraft_steady_flight/propulsion/test/test_propulsion_group.py
+++ b/dymos/examples/aircraft_steady_flight/propulsion/test/test_propulsion_group.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division, absolute_import
 import unittest
 
 import numpy as np
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
 
 from dymos.examples.aircraft_steady_flight.propulsion.propulsion_group import PropulsionGroup
@@ -15,9 +15,9 @@ class TestPropulsionComp(unittest.TestCase):
     def setUpClass(cls):
         cls.n = 10
 
-        cls.p = Problem(model=Group())
+        cls.p = om.Problem(model=om.Group())
 
-        ivc = cls.p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = cls.p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('alt', val=np.zeros(cls.n), units='m', desc='altitude above MSL')
 

--- a/dymos/examples/aircraft_steady_flight/propulsion/throttle_comp.py
+++ b/dymos/examples/aircraft_steady_flight/propulsion/throttle_comp.py
@@ -2,10 +2,10 @@ from __future__ import print_function, division, absolute_import
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class ThrottleComp(ExplicitComponent):
+class ThrottleComp(om.ExplicitComponent):
     """ Compute 'tau' (throttle parameter) which is the ratio of the current thrust
         (as determined to provie flight equilibrium) with the maximum thrust given
         the current aircraft state.

--- a/dymos/examples/aircraft_steady_flight/propulsion/thrust_comp.py
+++ b/dymos/examples/aircraft_steady_flight/propulsion/thrust_comp.py
@@ -2,10 +2,10 @@ from __future__ import print_function, division, absolute_import
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class ThrustComp(ExplicitComponent):
+class ThrustComp(om.ExplicitComponent):
     """ Compute thrust from the thrust coefficient
     """
     def initialize(self):

--- a/dymos/examples/aircraft_steady_flight/propulsion/tsfc_comp.py
+++ b/dymos/examples/aircraft_steady_flight/propulsion/tsfc_comp.py
@@ -2,10 +2,10 @@ from __future__ import print_function, division, absolute_import
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class SFCComp(ExplicitComponent):
+class SFCComp(om.ExplicitComponent):
     """ Compute the specific fuel consumption based on the altitude
     and the sea-level specific fuel consumption.
     """

--- a/dymos/examples/aircraft_steady_flight/range_rate_comp.py
+++ b/dymos/examples/aircraft_steady_flight/range_rate_comp.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, division, absolute_import
 
 import numpy as np
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class RangeRateComp(ExplicitComponent):
+class RangeRateComp(om.ExplicitComponent):
     """
     Calculates range rate based on true airspeed and flight path angle.
     """

--- a/dymos/examples/aircraft_steady_flight/steady_flight_path_angle_comp.py
+++ b/dymos/examples/aircraft_steady_flight/steady_flight_path_angle_comp.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class SteadyFlightPathAngleComp(ExplicitComponent):
+class SteadyFlightPathAngleComp(om.ExplicitComponent):
     """ Compute the flight path angle (gamma) based on true airspeed and climb rate. """
 
     def initialize(self):

--- a/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
@@ -24,7 +24,7 @@ class TestAircraftCruise(unittest.TestCase):
         if optimizer == 'SNOPT':
             p.driver = om.pyOptSparseDriver()
             p.driver.options['optimizer'] = optimizer
-            p.driver.options['dynamic_simul_derivs'] = True
+            p.driver.declare_coloring()
             p.driver.opt_settings['Major iterations limit'] = 100
             p.driver.opt_settings['Major step limit'] = 0.05
             p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
@@ -34,7 +34,7 @@ class TestAircraftCruise(unittest.TestCase):
             p.driver.opt_settings['Verify level'] = 3
         else:
             p.driver = om.ScipyOptimizeDriver()
-            p.driver.options['dynamic_simul_derivs'] = True
+            p.driver.declare_coloring()
 
         transcription = dm.GaussLobatto(num_segments=1,
                                         order=13,
@@ -104,7 +104,7 @@ class TestAircraftCruise(unittest.TestCase):
         if optimizer == 'SNOPT':
             p.driver = om.pyOptSparseDriver()
             p.driver.options['optimizer'] = optimizer
-            p.driver.options['dynamic_simul_derivs'] = True
+            p.driver.declare_coloring()
             p.driver.opt_settings['Major iterations limit'] = 100
             p.driver.opt_settings['Major step limit'] = 0.05
             p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
@@ -114,7 +114,7 @@ class TestAircraftCruise(unittest.TestCase):
             p.driver.opt_settings['Verify level'] = 3
         else:
             p.driver = om.ScipyOptimizeDriver()
-            p.driver.options['dynamic_simul_derivs'] = True
+            p.driver.declare_coloring()
 
         transcription = dm.GaussLobatto(num_segments=1,
                                         order=13,

--- a/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
@@ -3,11 +3,10 @@ from __future__ import print_function, division, absolute_import
 import os
 import unittest
 
-from openmdao.api import Problem, Group, IndepVarComp, DirectSolver, \
-    pyOptSparseDriver, ScipyOptimizeDriver
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
-from dymos import Phase, GaussLobatto
+import dymos as dm
 from dymos.examples.aircraft_steady_flight.aircraft_ode import AircraftODE
 
 optimizer = os.environ.get('DYMOS_DEFAULT_OPT', 'SLSQP')
@@ -21,9 +20,9 @@ except:
 class TestAircraftCruise(unittest.TestCase):
 
     def test_cruise_results_gl(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
         if optimizer == 'SNOPT':
-            p.driver = pyOptSparseDriver()
+            p.driver = om.pyOptSparseDriver()
             p.driver.options['optimizer'] = optimizer
             p.driver.options['dynamic_simul_derivs'] = True
             p.driver.opt_settings['Major iterations limit'] = 100
@@ -34,17 +33,17 @@ class TestAircraftCruise(unittest.TestCase):
             p.driver.opt_settings['iSumm'] = 6
             p.driver.opt_settings['Verify level'] = 3
         else:
-            p.driver = ScipyOptimizeDriver()
+            p.driver = om.ScipyOptimizeDriver()
             p.driver.options['dynamic_simul_derivs'] = True
 
-        transcription = GaussLobatto(num_segments=1,
-                                     order=13,
-                                     compressed=False)
-        phase = Phase(ode_class=AircraftODE, transcription=transcription)
+        transcription = dm.GaussLobatto(num_segments=1,
+                                        order=13,
+                                        compressed=False)
+        phase = dm.Phase(ode_class=AircraftODE, transcription=transcription)
         p.model.add_subsystem('phase0', phase)
 
         # Pass Reference Area from an external source
-        assumptions = p.model.add_subsystem('assumptions', IndepVarComp())
+        assumptions = p.model.add_subsystem('assumptions', om.IndepVarComp())
         assumptions.add_output('S', val=427.8, units='m**2')
         assumptions.add_output('mass_empty', val=1.0, units='kg')
         assumptions.add_output('mass_payload', val=1.0, units='kg')
@@ -76,7 +75,7 @@ class TestAircraftCruise(unittest.TestCase):
 
         phase.add_objective('time', loc='final', ref=3600)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -101,9 +100,9 @@ class TestAircraftCruise(unittest.TestCase):
         assert_rel_error(self, range, tas*time, tolerance=1.0E-4)
 
     def test_cruise_results_radau(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
         if optimizer == 'SNOPT':
-            p.driver = pyOptSparseDriver()
+            p.driver = om.pyOptSparseDriver()
             p.driver.options['optimizer'] = optimizer
             p.driver.options['dynamic_simul_derivs'] = True
             p.driver.opt_settings['Major iterations limit'] = 100
@@ -114,17 +113,17 @@ class TestAircraftCruise(unittest.TestCase):
             p.driver.opt_settings['iSumm'] = 6
             p.driver.opt_settings['Verify level'] = 3
         else:
-            p.driver = ScipyOptimizeDriver()
+            p.driver = om.ScipyOptimizeDriver()
             p.driver.options['dynamic_simul_derivs'] = True
 
-        transcription = GaussLobatto(num_segments=1,
-                                     order=13,
-                                     compressed=False)
-        phase = Phase(ode_class=AircraftODE, transcription=transcription)
+        transcription = dm.GaussLobatto(num_segments=1,
+                                        order=13,
+                                        compressed=False)
+        phase = dm.Phase(ode_class=AircraftODE, transcription=transcription)
         p.model.add_subsystem('phase0', phase)
 
         # Pass Reference Area from an external source
-        assumptions = p.model.add_subsystem('assumptions', IndepVarComp())
+        assumptions = p.model.add_subsystem('assumptions', om.IndepVarComp())
         assumptions.add_output('S', val=427.8, units='m**2')
         assumptions.add_output('mass_empty', val=1.0, units='kg')
         assumptions.add_output('mass_payload', val=1.0, units='kg')
@@ -156,7 +155,7 @@ class TestAircraftCruise(unittest.TestCase):
 
         phase.add_objective('time', loc='final', ref=3600)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 

--- a/dymos/examples/aircraft_steady_flight/test/test_aircraft_ode.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_aircraft_ode.py
@@ -3,8 +3,8 @@ from __future__ import print_function, division, absolute_import
 import unittest
 
 import numpy as np
-from openmdao.api import Problem, Group, IndepVarComp, DirectSolver
-from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+import openmdao.api as om
+from openmdao.utils.assert_utils import assert_rel_error
 
 from dymos.examples.aircraft_steady_flight.aircraft_ode import AircraftODE
 
@@ -22,9 +22,9 @@ class TestAircraftODEGroup(unittest.TestCase):
     def setUpClass(cls):
         cls.n = 10
 
-        cls.p = Problem(model=Group())
+        cls.p = om.Problem(model=om.Group())
 
-        ivc = cls.p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = cls.p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('mass_fuel', val=20000 * np.ones(cls.n), units='kg',
                        desc='aircraft fuel mass')
@@ -47,7 +47,7 @@ class TestAircraftODEGroup(unittest.TestCase):
         cls.p.model.connect('climb_rate', ['ode.gam_comp.climb_rate'])
         cls.p.model.connect('S', ('ode.aero.S', 'ode.flight_equilibrium.S', 'ode.propulsion.S'))
 
-        cls.p.model.linear_solver = DirectSolver()
+        cls.p.model.linear_solver = om.DirectSolver()
 
         cls.p.setup(check=True, force_alloc_complex=True)
 

--- a/dymos/examples/aircraft_steady_flight/test/test_ex_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_ex_aircraft_steady_flight.py
@@ -3,7 +3,7 @@ from __future__ import print_function, absolute_import, division
 import os
 import unittest
 
-from openmdao.api import Problem, Group, pyOptSparseDriver, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.utils.assert_utils import assert_rel_error
 
@@ -14,8 +14,8 @@ from dymos.examples.aircraft_steady_flight.aircraft_ode import AircraftODE
 
 def ex_aircraft_steady_flight(optimizer='SLSQP', solve_segments=False,
                               use_boundary_constraints=False, compressed=False):
-    p = Problem(model=Group())
-    p.driver = pyOptSparseDriver()
+    p = om.Problem(model=om.Group())
+    p.driver = om.pyOptSparseDriver()
     _, optimizer = set_pyoptsparse_opt(optimizer, fallback=False)
     p.driver.options['optimizer'] = optimizer
     p.driver.options['dynamic_simul_derivs'] = True
@@ -37,7 +37,7 @@ def ex_aircraft_steady_flight(optimizer='SLSQP', solve_segments=False,
                                             solve_segments=solve_segments))
 
     # Pass Reference Area from an external source
-    assumptions = p.model.add_subsystem('assumptions', IndepVarComp())
+    assumptions = p.model.add_subsystem('assumptions', om.IndepVarComp())
     assumptions.add_output('S', val=427.8, units='m**2')
     assumptions.add_output('mass_empty', val=1.0, units='kg')
     assumptions.add_output('mass_payload', val=1.0, units='kg')

--- a/dymos/examples/aircraft_steady_flight/test/test_ex_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_ex_aircraft_steady_flight.py
@@ -102,7 +102,7 @@ class TestExSteadyAircraftFlight(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        for filename in ['coloring.json', 'test_ex_aircraft_steady_flight_rec.db', 'SLSQP.out']:
+        for filename in ['total_coloring.pkl', 'test_ex_aircraft_steady_flight_rec.db', 'SLSQP.out']:
             if os.path.exists(filename):
                 os.remove(filename)
 

--- a/dymos/examples/aircraft_steady_flight/test/test_ex_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_ex_aircraft_steady_flight.py
@@ -18,7 +18,7 @@ def ex_aircraft_steady_flight(optimizer='SLSQP', solve_segments=False,
     p.driver = om.pyOptSparseDriver()
     _, optimizer = set_pyoptsparse_opt(optimizer, fallback=False)
     p.driver.options['optimizer'] = optimizer
-    p.driver.options['dynamic_simul_derivs'] = True
+    p.driver.declare_coloring()
     if optimizer == 'SNOPT':
         p.driver.opt_settings['Major iterations limit'] = 20
         p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6

--- a/dymos/examples/aircraft_steady_flight/true_airspeed_comp.py
+++ b/dymos/examples/aircraft_steady_flight/true_airspeed_comp.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class TrueAirspeedComp(ExplicitComponent):
+class TrueAirspeedComp(om.ExplicitComponent):
     """ Compute Mach number based on true airspeed and the local speed of sound. """
 
     def initialize(self):

--- a/dymos/examples/battery_multibranch/batteries.py
+++ b/dymos/examples/battery_multibranch/batteries.py
@@ -6,14 +6,13 @@ from __future__ import print_function, division, absolute_import
 import numpy as np
 from scipy.interpolate import Akima1DInterpolator
 
-from openmdao.api import ExplicitComponent
-
+import openmdao.api as om
 # Data for open circuit voltage model.
 train_SOC = np.array([0., 0.1, 0.25, 0.5, 0.75, 0.9, 1.0])
 train_V_oc = np.array([3.5, 3.55, 3.65, 3.75, 3.9, 4.1, 4.2])
 
 
-class Battery(ExplicitComponent):
+class Battery(om.ExplicitComponent):
     """
     Model of a Lithium Ion battery.
     """
@@ -113,10 +112,10 @@ class Battery(ExplicitComponent):
 
 if __name__ == '__main__':
 
-    from openmdao.api import Problem, IndepVarComp
+    import openmdao.api as om
     num_nodes = 1
 
-    prob = Problem(model=Battery(num_nodes=num_nodes))
+    prob = om.Problem(model=Battery(num_nodes=num_nodes))
     model = prob.model
 
     prob.setup()

--- a/dymos/examples/battery_multibranch/doc/test_multibranch_trajectory_for_docs.py
+++ b/dymos/examples/battery_multibranch/doc/test_multibranch_trajectory_for_docs.py
@@ -25,7 +25,7 @@ class TestBatteryBranchingPhasesForDocs(unittest.TestCase):
         prob = om.Problem()
 
         opt = prob.driver = om.ScipyOptimizeDriver()
-        opt.options['dynamic_simul_derivs'] = True
+        opt.declare_coloring()
         opt.options['optimizer'] = 'SLSQP'
 
         num_seg = 5

--- a/dymos/examples/battery_multibranch/doc/test_multibranch_trajectory_for_docs.py
+++ b/dymos/examples/battery_multibranch/doc/test_multibranch_trajectory_for_docs.py
@@ -15,27 +15,27 @@ class TestBatteryBranchingPhasesForDocs(unittest.TestCase):
     def test_basic(self):
         import matplotlib.pyplot as plt
 
-        from openmdao.api import Problem, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
 
-        from dymos import Trajectory, Phase, Radau
+        import dymos as dm
         from dymos.examples.battery_multibranch.battery_multibranch_ode import BatteryODE
         from dymos.utils.lgl import lgl
 
-        prob = Problem()
+        prob = om.Problem()
 
-        opt = prob.driver = ScipyOptimizeDriver()
+        opt = prob.driver = om.ScipyOptimizeDriver()
         opt.options['dynamic_simul_derivs'] = True
         opt.options['optimizer'] = 'SLSQP'
 
         num_seg = 5
         seg_ends, _ = lgl(num_seg + 1)
 
-        traj = prob.model.add_subsystem('traj', Trajectory())
+        traj = prob.model.add_subsystem('traj', dm.Trajectory())
 
         # First phase: normal operation.
-        transcription = Radau(num_segments=num_seg, order=5, segment_ends=seg_ends, compressed=False)
-        phase0 = Phase(ode_class=BatteryODE, transcription=transcription)
+        transcription = dm.Radau(num_segments=num_seg, order=5, segment_ends=seg_ends, compressed=False)
+        phase0 = dm.Phase(ode_class=BatteryODE, transcription=transcription)
         traj_p0 = traj.add_phase('phase0', phase0)
 
         traj_p0.set_time_options(fix_initial=True, fix_duration=True)
@@ -43,7 +43,7 @@ class TestBatteryBranchingPhasesForDocs(unittest.TestCase):
 
         # Second phase: normal operation.
 
-        phase1 = Phase(ode_class=BatteryODE, transcription=transcription)
+        phase1 = dm.Phase(ode_class=BatteryODE, transcription=transcription)
         traj_p1 = traj.add_phase('phase1', phase1)
 
         traj_p1.set_time_options(fix_initial=False, fix_duration=True)
@@ -52,8 +52,8 @@ class TestBatteryBranchingPhasesForDocs(unittest.TestCase):
 
         # Second phase, but with battery failure.
 
-        phase1_bfail = Phase(ode_class=BatteryODE, ode_init_kwargs={'num_battery': 2},
-                             transcription=transcription)
+        phase1_bfail = dm.Phase(ode_class=BatteryODE, ode_init_kwargs={'num_battery': 2},
+                                transcription=transcription)
         traj_p1_bfail = traj.add_phase('phase1_bfail', phase1_bfail)
 
         traj_p1_bfail.set_time_options(fix_initial=False, fix_duration=True)
@@ -61,8 +61,8 @@ class TestBatteryBranchingPhasesForDocs(unittest.TestCase):
 
         # Second phase, but with motor failure.
 
-        phase1_mfail = Phase(ode_class=BatteryODE, ode_init_kwargs={'num_motor': 2},
-                             transcription=transcription)
+        phase1_mfail = dm.Phase(ode_class=BatteryODE, ode_init_kwargs={'num_motor': 2},
+                                transcription=transcription)
         traj_p1_mfail = traj.add_phase('phase1_mfail', phase1_mfail)
 
         traj_p1_mfail.set_time_options(fix_initial=False, fix_duration=True)
@@ -73,7 +73,7 @@ class TestBatteryBranchingPhasesForDocs(unittest.TestCase):
         traj.link_phases(phases=['phase0', 'phase1_mfail'], vars=['state_of_charge', 'time'])
 
         prob.model.options['assembled_jac_type'] = 'csc'
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
         prob.setup()
 

--- a/dymos/examples/battery_multibranch/motors.py
+++ b/dymos/examples/battery_multibranch/motors.py
@@ -5,10 +5,10 @@ from __future__ import print_function, division, absolute_import
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class Motors(ExplicitComponent):
+class Motors(om.ExplicitComponent):
     """
     Model for motors in parallel.
     """
@@ -56,7 +56,7 @@ class Motors(ExplicitComponent):
         partials['power_in_motor', 'current_in_motor'] = 0.3 * power_out / (n_parallel * eff**2)
 
 
-class MotorsStaticGearboxPower(ExplicitComponent):
+class MotorsStaticGearboxPower(om.ExplicitComponent):
     """
     Model for motors in parallel.
     """
@@ -107,10 +107,10 @@ class MotorsStaticGearboxPower(ExplicitComponent):
 
 if __name__ == '__main__':
 
-    from openmdao.api import Problem, IndepVarComp
+    import openmdao.api as om
     num_nodes = 1
 
-    prob = Problem(model=Motors(num_nodes=num_nodes))
+    prob = om.Problem(model=Motors(num_nodes=num_nodes))
     model = prob.model
 
     prob.setup()

--- a/dymos/examples/battery_multibranch/test/test_multibranch_trajectory.py
+++ b/dymos/examples/battery_multibranch/test/test_multibranch_trajectory.py
@@ -6,10 +6,10 @@ from __future__ import print_function, division, absolute_import
 import os
 import unittest
 
-from openmdao.api import Problem, pyOptSparseDriver, ScipyOptimizeDriver, DirectSolver
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
-from dymos import Trajectory, Phase, Radau, RungeKutta
+import dymos as dm
 from dymos.examples.battery_multibranch.battery_multibranch_ode import BatteryODE
 from dymos.utils.lgl import lgl
 
@@ -20,10 +20,10 @@ class TestBatteryBranchingPhases(unittest.TestCase):
 
     def test_optimizer_defects(self):
 
-        prob = Problem()
+        prob = om.Problem()
 
         if optimizer == 'SNOPT':
-            opt = prob.driver = pyOptSparseDriver()
+            opt = prob.driver = om.pyOptSparseDriver()
             opt.options['optimizer'] = optimizer
             opt.options['dynamic_simul_derivs'] = True
 
@@ -34,18 +34,17 @@ class TestBatteryBranchingPhases(unittest.TestCase):
             opt.opt_settings['iSumm'] = 6
 
         else:
-            opt = prob.driver = ScipyOptimizeDriver()
+            opt = prob.driver = om.ScipyOptimizeDriver()
             opt.options['dynamic_simul_derivs'] = True
 
         num_seg = 5
         seg_ends, _ = lgl(num_seg + 1)
 
-        traj = prob.model.add_subsystem('traj', Trajectory())
+        traj = prob.model.add_subsystem('traj',  dm.Trajectory())
 
         # First phase: normal operation.
-
-        transcription = Radau(num_segments=5, order=5, segment_ends=seg_ends, compressed=False)
-        phase0 = Phase(ode_class=BatteryODE, transcription=transcription)
+        transcription = dm.Radau(num_segments=5, order=5, segment_ends=seg_ends, compressed=False)
+        phase0 = dm.Phase(ode_class=BatteryODE, transcription=transcription)
         traj_p0 = traj.add_phase('phase0', phase0)
 
         traj_p0.set_time_options(fix_initial=True, fix_duration=True)
@@ -53,7 +52,7 @@ class TestBatteryBranchingPhases(unittest.TestCase):
 
         # Second phase: normal operation.
 
-        phase1 = Phase(ode_class=BatteryODE, transcription=transcription)
+        phase1 = dm.Phase(ode_class=BatteryODE, transcription=transcription)
         traj_p1 = traj.add_phase('phase1', phase1)
 
         traj_p1.set_time_options(fix_initial=False, fix_duration=True)
@@ -62,8 +61,8 @@ class TestBatteryBranchingPhases(unittest.TestCase):
 
         # Second phase, but with battery failure.
 
-        phase1_bfail = Phase(ode_class=BatteryODE, ode_init_kwargs={'num_battery': 2},
-                             transcription=transcription)
+        phase1_bfail = dm.Phase(ode_class=BatteryODE, ode_init_kwargs={'num_battery': 2},
+                                transcription=transcription)
         traj_p1_bfail = traj.add_phase('phase1_bfail', phase1_bfail)
 
         traj_p1_bfail.set_time_options(fix_initial=False, fix_duration=True)
@@ -71,8 +70,8 @@ class TestBatteryBranchingPhases(unittest.TestCase):
 
         # Second phase, but with motor failure.
 
-        phase1_mfail = Phase(ode_class=BatteryODE, ode_init_kwargs={'num_motor': 2},
-                             transcription=transcription)
+        phase1_mfail = dm.Phase(ode_class=BatteryODE, ode_init_kwargs={'num_motor': 2},
+                                transcription=transcription)
         traj_p1_mfail = traj.add_phase('phase1_mfail', phase1_mfail)
 
         traj_p1_mfail.set_time_options(fix_initial=False, fix_duration=True)
@@ -83,7 +82,7 @@ class TestBatteryBranchingPhases(unittest.TestCase):
         traj.link_phases(phases=['phase0', 'phase1_mfail'], vars=['state_of_charge', 'time'])
 
         prob.model.options['assembled_jac_type'] = 'csc'
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
         prob.setup()
 
@@ -114,17 +113,17 @@ class TestBatteryBranchingPhases(unittest.TestCase):
         assert_rel_error(self, soc1m[-1], 0.18625395, 1e-6)
 
     def test_solver_defects(self):
-        prob = Problem()
+        prob = om.Problem()
 
         num_seg = 5
         seg_ends, _ = lgl(num_seg + 1)
 
-        traj = prob.model.add_subsystem('traj', Trajectory())
+        traj = prob.model.add_subsystem('traj',  dm.Trajectory())
 
         # First phase: normal operation.
 
-        transcription = Radau(num_segments=5, order=5, segment_ends=seg_ends, compressed=True)
-        phase0 = Phase(ode_class=BatteryODE, transcription=transcription)
+        transcription = dm.Radau(num_segments=5, order=5, segment_ends=seg_ends, compressed=True)
+        phase0 = dm.Phase(ode_class=BatteryODE, transcription=transcription)
         traj_p0 = traj.add_phase('phase0', phase0)
 
         traj_p0.set_time_options(fix_initial=True, fix_duration=True)
@@ -132,7 +131,7 @@ class TestBatteryBranchingPhases(unittest.TestCase):
                                   solve_segments=True)
 
         # Second phase: normal operation.
-        phase1 = Phase(ode_class=BatteryODE, transcription=transcription)
+        phase1 = dm.Phase(ode_class=BatteryODE, transcription=transcription)
         traj_p1 = traj.add_phase('phase1', phase1)
 
         traj_p1.set_time_options(fix_initial=False, fix_duration=True)
@@ -141,8 +140,8 @@ class TestBatteryBranchingPhases(unittest.TestCase):
         traj_p1.add_objective('time', loc='final')
 
         # Second phase, but with battery failure.
-        phase1_bfail = Phase(ode_class=BatteryODE, ode_init_kwargs={'num_battery': 2},
-                             transcription=transcription)
+        phase1_bfail = dm.Phase(ode_class=BatteryODE, ode_init_kwargs={'num_battery': 2},
+                                transcription=transcription)
         traj_p1_bfail = traj.add_phase('phase1_bfail', phase1_bfail)
 
         traj_p1_bfail.set_time_options(fix_initial=False, fix_duration=True)
@@ -150,8 +149,8 @@ class TestBatteryBranchingPhases(unittest.TestCase):
                                         solve_segments=True)
 
         # Second phase, but with motor failure.
-        phase1_mfail = Phase(ode_class=BatteryODE, ode_init_kwargs={'num_motor': 2},
-                             transcription=transcription)
+        phase1_mfail = dm.Phase(ode_class=BatteryODE, ode_init_kwargs={'num_motor': 2},
+                                transcription=transcription)
         traj_p1_mfail = traj.add_phase('phase1_mfail', phase1_mfail)
 
         traj_p1_mfail.set_time_options(fix_initial=False, fix_duration=True)
@@ -196,15 +195,15 @@ class TestBatteryBranchingPhases(unittest.TestCase):
         assert_rel_error(self, soc1m[-1], 0.18625395, 1e-6)
 
     def test_solver_defects_single_phase_reverse_propagation(self):
-        prob = Problem()
+        prob = om.Problem()
 
         num_seg = 5
         seg_ends, _ = lgl(num_seg + 1)
 
         # First phase: normal operation.
 
-        transcription = Radau(num_segments=5, order=5, segment_ends=seg_ends, compressed=True)
-        phase0 = Phase(ode_class=BatteryODE, transcription=transcription)
+        transcription = dm.Radau(num_segments=5, order=5, segment_ends=seg_ends, compressed=True)
+        phase0 = dm.Phase(ode_class=BatteryODE, transcription=transcription)
         traj_p0 = prob.model.add_subsystem('phase0', phase0)
 
         traj_p0.set_time_options(fix_initial=True, fix_duration=True)
@@ -224,16 +223,16 @@ class TestBatteryBranchingPhases(unittest.TestCase):
         assert_rel_error(self, soc0[-1], 1.0, 1e-6)
 
     def test_solver_defects_reverse_propagation(self):
-        prob = Problem()
+        prob = om.Problem()
 
         num_seg = 5
         seg_ends, _ = lgl(num_seg + 1)
 
-        traj = prob.model.add_subsystem('traj', Trajectory())
+        traj = prob.model.add_subsystem('traj',  dm.Trajectory())
 
         # First phase: normal operation.
-        transcription = Radau(num_segments=5, order=5, segment_ends=seg_ends, compressed=True)
-        phase0 = Phase(ode_class=BatteryODE, transcription=transcription)
+        transcription = dm.Radau(num_segments=5, order=5, segment_ends=seg_ends, compressed=True)
+        phase0 = dm.Phase(ode_class=BatteryODE, transcription=transcription)
         traj_p0 = traj.add_phase('phase0', phase0)
 
         traj_p0.set_time_options(fix_initial=True, fix_duration=True)
@@ -241,7 +240,7 @@ class TestBatteryBranchingPhases(unittest.TestCase):
                                   solve_segments=True)
 
         # Second phase: normal operation.
-        phase1 = Phase(ode_class=BatteryODE, transcription=transcription)
+        phase1 = dm.Phase(ode_class=BatteryODE, transcription=transcription)
         traj_p1 = traj.add_phase('phase1', phase1)
 
         traj_p1.set_time_options(fix_initial=False, fix_duration=True)
@@ -268,10 +267,10 @@ class TestBatteryBranchingPhases(unittest.TestCase):
         assert_rel_error(self, soc1[-1], 1.0, 1e-6)
 
     def test_optimizer_segments_direct_connections(self):
-        prob = Problem()
+        prob = om.Problem()
 
         if optimizer == 'SNOPT':
-            opt = prob.driver = pyOptSparseDriver()
+            opt = prob.driver = om.pyOptSparseDriver()
             opt.options['optimizer'] = optimizer
             opt.options['dynamic_simul_derivs'] = True
 
@@ -282,40 +281,40 @@ class TestBatteryBranchingPhases(unittest.TestCase):
             opt.opt_settings['iSumm'] = 6
 
         else:
-            opt = prob.driver = ScipyOptimizeDriver()
+            opt = prob.driver = om.ScipyOptimizeDriver()
             opt.options['dynamic_simul_derivs'] = True
 
         num_seg = 5
         seg_ends, _ = lgl(num_seg + 1)
 
-        traj = prob.model.add_subsystem('traj', Trajectory())
+        traj = prob.model.add_subsystem('traj',  dm.Trajectory())
 
         # First phase: normal operation.
-        transcription = Radau(num_segments=5, order=5, segment_ends=seg_ends, compressed=True)
-        phase0 = Phase(ode_class=BatteryODE, transcription=transcription)
+        transcription = dm.Radau(num_segments=5, order=5, segment_ends=seg_ends, compressed=True)
+        phase0 = dm.Phase(ode_class=BatteryODE, transcription=transcription)
         traj_p0 = traj.add_phase('phase0', phase0)
         traj_p0.set_time_options(fix_initial=True, fix_duration=True)
         traj_p0.set_state_options('state_of_charge', fix_initial=True, fix_final=False)
 
         # Second phase: normal operation.
 
-        phase1 = Phase(ode_class=BatteryODE, transcription=transcription)
+        phase1 = dm.Phase(ode_class=BatteryODE, transcription=transcription)
         traj_p1 = traj.add_phase('phase1', phase1)
         traj_p1.set_time_options(fix_initial=False, fix_duration=True)
         traj_p1.set_state_options('state_of_charge', fix_initial=False, fix_final=False)
         traj_p1.add_objective('time', loc='final')
 
         # Second phase, but with battery failure.
-        phase1_bfail = Phase(ode_class=BatteryODE, ode_init_kwargs={'num_battery': 2},
-                             transcription=transcription)
+        phase1_bfail = dm.Phase(ode_class=BatteryODE, ode_init_kwargs={'num_battery': 2},
+                                transcription=transcription)
         traj_p1_bfail = traj.add_phase('phase1_bfail', phase1_bfail)
         traj_p1_bfail.set_time_options(fix_initial=False, fix_duration=True)
         traj_p1_bfail.set_state_options('state_of_charge', fix_initial=False, fix_final=False)
 
         # Second phase, but with motor failure.
 
-        phase1_mfail = Phase(ode_class=BatteryODE, ode_init_kwargs={'num_motor': 2},
-                             transcription=transcription)
+        phase1_mfail = dm.Phase(ode_class=BatteryODE, ode_init_kwargs={'num_motor': 2},
+                                transcription=transcription)
         traj_p1_mfail = traj.add_phase('phase1_mfail', phase1_mfail)
         traj_p1_mfail.set_time_options(fix_initial=False, fix_duration=True)
         traj_p1_mfail.set_state_options('state_of_charge', fix_initial=False, fix_final=False)
@@ -328,7 +327,7 @@ class TestBatteryBranchingPhases(unittest.TestCase):
                          connected=True)
 
         prob.model.options['assembled_jac_type'] = 'csc'
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
         prob.setup()
 
@@ -362,10 +361,10 @@ class TestBatteryBranchingPhases(unittest.TestCase):
 class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
 
     def test_constraint_linkages_rk(self):
-        prob = Problem()
+        prob = om.Problem()
 
         if optimizer == 'SNOPT':
-            opt = prob.driver = pyOptSparseDriver()
+            opt = prob.driver = om.pyOptSparseDriver()
             opt.options['optimizer'] = optimizer
             opt.options['dynamic_simul_derivs'] = True
 
@@ -376,17 +375,17 @@ class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
             opt.opt_settings['iSumm'] = 6
 
         else:
-            opt = prob.driver = ScipyOptimizeDriver()
+            opt = prob.driver = om.ScipyOptimizeDriver()
             opt.options['dynamic_simul_derivs'] = True
 
         num_seg = 20
         seg_ends, _ = lgl(num_seg + 1)
 
-        traj = prob.model.add_subsystem('traj', Trajectory())
+        traj = prob.model.add_subsystem('traj',  dm.Trajectory())
 
         # First phase: normal operation.
-        transcription = RungeKutta(num_segments=num_seg)
-        phase0 = Phase(ode_class=BatteryODE, transcription=transcription)
+        transcription = dm.RungeKutta(num_segments=num_seg)
+        phase0 = dm.Phase(ode_class=BatteryODE, transcription=transcription)
         traj_p0 = traj.add_phase('phase0', phase0)
 
         traj_p0.set_time_options(fix_initial=True, fix_duration=True)
@@ -394,7 +393,7 @@ class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
 
         # Second phase: normal operation.
 
-        phase1 = Phase(ode_class=BatteryODE, transcription=transcription)
+        phase1 = dm.Phase(ode_class=BatteryODE, transcription=transcription)
         traj_p1 = traj.add_phase('phase1', phase1)
 
         traj_p1.set_time_options(fix_initial=False, fix_duration=True)
@@ -403,8 +402,8 @@ class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
 
         # Second phase, but with battery failure.
 
-        phase1_bfail = Phase(ode_class=BatteryODE, ode_init_kwargs={'num_battery': 2},
-                             transcription=transcription)
+        phase1_bfail = dm.Phase(ode_class=BatteryODE, ode_init_kwargs={'num_battery': 2},
+                                transcription=transcription)
         traj_p1_bfail = traj.add_phase('phase1_bfail', phase1_bfail)
 
         traj_p1_bfail.set_time_options(fix_initial=False, fix_duration=True)
@@ -412,8 +411,8 @@ class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
 
         # Second phase, but with motor failure.
 
-        phase1_mfail = Phase(ode_class=BatteryODE, ode_init_kwargs={'num_motor': 2},
-                             transcription=transcription)
+        phase1_mfail = dm.Phase(ode_class=BatteryODE, ode_init_kwargs={'num_motor': 2},
+                                transcription=transcription)
         traj_p1_mfail = traj.add_phase('phase1_mfail', phase1_mfail)
 
         traj_p1_mfail.set_time_options(fix_initial=False, fix_duration=True)
@@ -424,7 +423,7 @@ class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
         traj.link_phases(phases=['phase0', 'phase1_mfail'], vars=['state_of_charge', 'time'])
 
         prob.model.options['assembled_jac_type'] = 'csc'
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
         prob.setup()
 
@@ -455,14 +454,14 @@ class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
         assert_rel_error(self, soc1m[-1], 0.18625395, 1e-4)
 
     def test_single_phase_reverse_propagation_rk(self):
-        prob = Problem()
+        prob = om.Problem()
 
         num_seg = 10
         seg_ends, _ = lgl(num_seg + 1)
 
         # First phase: normal operation.
-        transcription = RungeKutta(num_segments=num_seg)
-        phase0 = Phase(ode_class=BatteryODE, transcription=transcription)
+        transcription = dm.RungeKutta(num_segments=num_seg)
+        phase0 = dm.Phase(ode_class=BatteryODE, transcription=transcription)
         traj_p0 = prob.model.add_subsystem('phase0', phase0)
 
         traj_p0.set_time_options(fix_initial=True, fix_duration=True)
@@ -481,10 +480,10 @@ class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
         assert_rel_error(self, soc0[-1], 1.0, 1e-6)
 
     def test_connected_linkages_rk(self):
-        prob = Problem()
+        prob = om.Problem()
 
         if optimizer == 'SNOPT':
-            opt = prob.driver = pyOptSparseDriver()
+            opt = prob.driver = om.pyOptSparseDriver()
             opt.options['optimizer'] = optimizer
             opt.options['dynamic_simul_derivs'] = True
 
@@ -495,18 +494,18 @@ class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
             opt.opt_settings['iSumm'] = 6
 
         else:
-            opt = prob.driver = ScipyOptimizeDriver()
+            opt = prob.driver = om.ScipyOptimizeDriver()
             opt.options['dynamic_simul_derivs'] = True
 
         num_seg = 20
         seg_ends, _ = lgl(num_seg + 1)
 
-        traj = prob.model.add_subsystem('traj', Trajectory())
+        traj = prob.model.add_subsystem('traj',  dm.Trajectory())
 
         # First phase: normal operation.
 
-        transcription = RungeKutta(num_segments=num_seg)
-        phase0 = Phase(ode_class=BatteryODE, transcription=transcription)
+        transcription = dm.RungeKutta(num_segments=num_seg)
+        phase0 = dm.Phase(ode_class=BatteryODE, transcription=transcription)
         traj_p0 = traj.add_phase('phase0', phase0)
 
         traj_p0.set_time_options(fix_initial=True, fix_duration=True)
@@ -514,7 +513,7 @@ class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
 
         # Second phase: normal operation.
 
-        phase1 = Phase(ode_class=BatteryODE, transcription=transcription)
+        phase1 = dm.Phase(ode_class=BatteryODE, transcription=transcription)
         traj_p1 = traj.add_phase('phase1', phase1)
 
         traj_p1.set_time_options(fix_initial=False, fix_duration=True)
@@ -523,16 +522,16 @@ class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
 
         # Second phase, but with battery failure.
 
-        phase1_bfail = Phase(ode_class=BatteryODE, ode_init_kwargs={'num_battery': 2},
-                             transcription=transcription)
+        phase1_bfail = dm.Phase(ode_class=BatteryODE, ode_init_kwargs={'num_battery': 2},
+                                transcription=transcription)
         traj_p1_bfail = traj.add_phase('phase1_bfail', phase1_bfail)
 
         traj_p1_bfail.set_time_options(fix_initial=False, fix_duration=True)
         traj_p1_bfail.set_state_options('state_of_charge', fix_initial=False, fix_final=False)
 
         # Second phase, but with motor failure.
-        phase1_mfail = Phase(ode_class=BatteryODE, ode_init_kwargs={'num_motor': 2},
-                             transcription=transcription)
+        phase1_mfail = dm.Phase(ode_class=BatteryODE, ode_init_kwargs={'num_motor': 2},
+                                transcription=transcription)
         traj_p1_mfail = traj.add_phase('phase1_mfail', phase1_mfail)
 
         traj_p1_mfail.set_time_options(fix_initial=False, fix_duration=True)
@@ -546,7 +545,7 @@ class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
                          connected=True)
 
         prob.model.options['assembled_jac_type'] = 'csc'
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
         prob.setup()
 

--- a/dymos/examples/battery_multibranch/test/test_multibranch_trajectory.py
+++ b/dymos/examples/battery_multibranch/test/test_multibranch_trajectory.py
@@ -25,7 +25,7 @@ class TestBatteryBranchingPhases(unittest.TestCase):
         if optimizer == 'SNOPT':
             opt = prob.driver = om.pyOptSparseDriver()
             opt.options['optimizer'] = optimizer
-            opt.options['dynamic_simul_derivs'] = True
+            opt.declare_coloring()
 
             opt.opt_settings['Major iterations limit'] = 1000
             opt.opt_settings['Major feasibility tolerance'] = 1.0E-6
@@ -35,7 +35,7 @@ class TestBatteryBranchingPhases(unittest.TestCase):
 
         else:
             opt = prob.driver = om.ScipyOptimizeDriver()
-            opt.options['dynamic_simul_derivs'] = True
+            opt.declare_coloring()
 
         num_seg = 5
         seg_ends, _ = lgl(num_seg + 1)
@@ -272,7 +272,7 @@ class TestBatteryBranchingPhases(unittest.TestCase):
         if optimizer == 'SNOPT':
             opt = prob.driver = om.pyOptSparseDriver()
             opt.options['optimizer'] = optimizer
-            opt.options['dynamic_simul_derivs'] = True
+            opt.declare_coloring()
 
             opt.opt_settings['Major iterations limit'] = 1000
             opt.opt_settings['Major feasibility tolerance'] = 1.0E-6
@@ -282,7 +282,7 @@ class TestBatteryBranchingPhases(unittest.TestCase):
 
         else:
             opt = prob.driver = om.ScipyOptimizeDriver()
-            opt.options['dynamic_simul_derivs'] = True
+            opt.declare_coloring()
 
         num_seg = 5
         seg_ends, _ = lgl(num_seg + 1)
@@ -366,7 +366,7 @@ class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
         if optimizer == 'SNOPT':
             opt = prob.driver = om.pyOptSparseDriver()
             opt.options['optimizer'] = optimizer
-            opt.options['dynamic_simul_derivs'] = True
+            opt.declare_coloring()
 
             opt.opt_settings['Major iterations limit'] = 1000
             opt.opt_settings['Major feasibility tolerance'] = 1.0E-6
@@ -376,7 +376,7 @@ class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
 
         else:
             opt = prob.driver = om.ScipyOptimizeDriver()
-            opt.options['dynamic_simul_derivs'] = True
+            opt.declare_coloring()
 
         num_seg = 20
         seg_ends, _ = lgl(num_seg + 1)
@@ -485,7 +485,7 @@ class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
         if optimizer == 'SNOPT':
             opt = prob.driver = om.pyOptSparseDriver()
             opt.options['optimizer'] = optimizer
-            opt.options['dynamic_simul_derivs'] = True
+            opt.declare_coloring()
 
             opt.opt_settings['Major iterations limit'] = 1000
             opt.opt_settings['Major feasibility tolerance'] = 1.0E-6
@@ -495,7 +495,7 @@ class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
 
         else:
             opt = prob.driver = om.ScipyOptimizeDriver()
-            opt.options['dynamic_simul_derivs'] = True
+            opt.declare_coloring()
 
         num_seg = 20
         seg_ends, _ = lgl(num_seg + 1)

--- a/dymos/examples/battery_multibranch/test/test_multibranch_trajectory_rk_ivp.py
+++ b/dymos/examples/battery_multibranch/test/test_multibranch_trajectory_rk_ivp.py
@@ -6,9 +6,8 @@ from __future__ import division, print_function, absolute_import
 
 import unittest
 
-from openmdao.api import Problem, Group
-
-from dymos import Trajectory, Phase, Radau, RungeKutta
+import openmdao.api as om
+import dymos as dm
 
 from dymos.examples.battery_multibranch.battery_multibranch_ode import BatteryODE
 
@@ -16,16 +15,16 @@ from dymos.examples.battery_multibranch.battery_multibranch_ode import BatteryOD
 class TestBatteryRKIVP(unittest.TestCase):
 
     def test_dynamic_input_params(self):
-        prob = Problem(model=Group())
+        prob = om.Problem(model=om.Group())
 
-        traj = prob.model.add_subsystem('traj', Trajectory())
+        traj = prob.model.add_subsystem('traj',  dm.Trajectory())
 
         # First phase: normal operation.
         # NOTE: using RK4 integration here
 
         P_DEMAND = 2.0
 
-        phase0 = Phase(ode_class=BatteryODE, transcription=RungeKutta(num_segments=200))
+        phase0 = dm.Phase(ode_class=BatteryODE, transcription=dm.RungeKutta(num_segments=200))
         phase0.set_time_options(fix_initial=True, fix_duration=True)
         phase0.set_state_options('state_of_charge', fix_initial=True, fix_final=False)
         phase0.add_timeseries_output('battery.V_oc', output_name='V_oc', units='V')
@@ -36,8 +35,8 @@ class TestBatteryRKIVP(unittest.TestCase):
 
         # Second phase: normal operation.
 
-        transcription = Radau(num_segments=5, order=5, compressed=True)
-        phase1 = Phase(ode_class=BatteryODE, transcription=transcription)
+        transcription = dm.Radau(num_segments=5, order=5, compressed=True)
+        phase1 = dm.Phase(ode_class=BatteryODE, transcription=transcription)
         phase1.set_time_options(fix_initial=False, fix_duration=True)
         phase1.set_state_options('state_of_charge', fix_initial=False, fix_final=False, solve_segments=True)
         phase1.add_timeseries_output('battery.V_oc', output_name='V_oc', units='V')
@@ -48,8 +47,8 @@ class TestBatteryRKIVP(unittest.TestCase):
 
         # Second phase, but with battery failure.
 
-        phase1_bfail = Phase(ode_class=BatteryODE, ode_init_kwargs={'num_battery': 2},
-                             transcription=transcription)
+        phase1_bfail = dm.Phase(ode_class=BatteryODE, ode_init_kwargs={'num_battery': 2},
+                                transcription=transcription)
         phase1_bfail.set_time_options(fix_initial=False, fix_duration=True)
         phase1_bfail.set_state_options('state_of_charge', fix_initial=False, fix_final=False, solve_segments=True)
         phase1_bfail.add_timeseries_output('battery.V_oc', output_name='V_oc', units='V')
@@ -60,8 +59,8 @@ class TestBatteryRKIVP(unittest.TestCase):
 
         # Second phase, but with motor failure.
 
-        phase1_mfail = Phase(ode_class=BatteryODE, ode_init_kwargs={'num_motor': 2},
-                             transcription=transcription)
+        phase1_mfail = dm.Phase(ode_class=BatteryODE, ode_init_kwargs={'num_motor': 2},
+                                transcription=transcription)
         phase1_mfail.set_time_options(fix_initial=False, fix_duration=True)
         phase1_mfail.set_state_options('state_of_charge', fix_initial=False, fix_final=False, solve_segments=True)
         phase1_mfail.add_timeseries_output('battery.V_oc', output_name='V_oc', units='V')
@@ -74,7 +73,7 @@ class TestBatteryRKIVP(unittest.TestCase):
         traj.link_phases(phases=['phase0', 'phase1_bfail'], vars=['state_of_charge', 'time'], connected=True)
         traj.link_phases(phases=['phase0', 'phase1_mfail'], vars=['state_of_charge', 'time'], connected=True)
 
-        # prob.model.linear_solver = DirectSolver(assemble_jac=True)
+        # prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
         prob.setup()
         prob.final_setup()
@@ -159,16 +158,16 @@ class TestBatteryRKIVP(unittest.TestCase):
             plt.show()
 
     def test_static_input_params(self):
-        prob = Problem(model=Group())
+        prob = om.Problem(model=om.Group())
 
-        traj = prob.model.add_subsystem('traj', Trajectory())
+        traj = prob.model.add_subsystem('traj',  dm.Trajectory())
 
         # First phase: normal operation.
         # NOTE: using RK4 integration here
 
         P_DEMAND = 2.0
 
-        phase0 = Phase(ode_class=BatteryODE, transcription=RungeKutta(num_segments=200))
+        phase0 = dm.Phase(ode_class=BatteryODE, transcription=dm.RungeKutta(num_segments=200))
         phase0.set_time_options(fix_initial=True, fix_duration=True)
         phase0.set_state_options('state_of_charge', fix_initial=True, fix_final=False)
         phase0.add_timeseries_output('battery.V_oc', output_name='V_oc', units='V')
@@ -179,8 +178,8 @@ class TestBatteryRKIVP(unittest.TestCase):
 
         # Second phase: normal operation.
 
-        transcription = Radau(num_segments=5, order=5, compressed=True)
-        phase1 = Phase(ode_class=BatteryODE, transcription=transcription)
+        transcription = dm.Radau(num_segments=5, order=5, compressed=True)
+        phase1 = dm.Phase(ode_class=BatteryODE, transcription=transcription)
         phase1.set_time_options(fix_initial=False, fix_duration=True)
         phase1.set_state_options('state_of_charge', fix_initial=False, fix_final=False,
                                  solve_segments=True)
@@ -192,8 +191,8 @@ class TestBatteryRKIVP(unittest.TestCase):
 
         # Second phase, but with battery failure.
 
-        phase1_bfail = Phase(ode_class=BatteryODE, ode_init_kwargs={'num_battery': 2},
-                             transcription=transcription)
+        phase1_bfail = dm.Phase(ode_class=BatteryODE, ode_init_kwargs={'num_battery': 2},
+                                transcription=transcription)
         phase1_bfail.set_time_options(fix_initial=False, fix_duration=True)
         phase1_bfail.set_state_options('state_of_charge', fix_initial=False, fix_final=False,
                                        solve_segments=True)
@@ -205,8 +204,8 @@ class TestBatteryRKIVP(unittest.TestCase):
 
         # Second phase, but with motor failure.
 
-        phase1_mfail = Phase(ode_class=BatteryODE, ode_init_kwargs={'num_motor': 2},
-                             transcription=transcription)
+        phase1_mfail = dm.Phase(ode_class=BatteryODE, ode_init_kwargs={'num_motor': 2},
+                                transcription=transcription)
         phase1_mfail.set_time_options(fix_initial=False, fix_duration=True)
         phase1_mfail.set_state_options('state_of_charge', fix_initial=False, fix_final=False,
                                        solve_segments=True)
@@ -223,7 +222,7 @@ class TestBatteryRKIVP(unittest.TestCase):
         traj.link_phases(phases=['phase0', 'phase1_mfail'], vars=['state_of_charge', 'time'],
                          connected=True)
 
-        # prob.model.linear_solver = DirectSolver(assemble_jac=True)
+        # prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
         prob.setup()
         prob.final_setup()

--- a/dymos/examples/brachistochrone/brachistochrone_ode.py
+++ b/dymos/examples/brachistochrone/brachistochrone_ode.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 import numpy as np
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 import dymos as dm
 
 
@@ -11,7 +11,7 @@ import dymos as dm
 @dm.declare_state('v', rate_source='vdot', targets='v', units='m/s')
 @dm.declare_parameter('theta', targets='theta', units='rad')
 @dm.declare_parameter('g', units='m/s**2', targets='g')
-class BrachistochroneODE(ExplicitComponent):
+class BrachistochroneODE(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)

--- a/dymos/examples/brachistochrone/brachistochrone_vector_states_ode.py
+++ b/dymos/examples/brachistochrone/brachistochrone_vector_states_ode.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 import numpy as np
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 import dymos as dm
 
 
@@ -10,7 +10,7 @@ import dymos as dm
 @dm.declare_state('v', rate_source='vdot', targets=['v'], units='m/s')
 @dm.declare_parameter('theta', targets=['theta'], units='rad')
 @dm.declare_parameter('g', units='m/s**2', targets=['g'])
-class BrachistochroneVectorStatesODE(ExplicitComponent):
+class BrachistochroneVectorStatesODE(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
@@ -12,7 +12,7 @@ plt.style.use('ggplot')
 class TestBrachistochroneForDocs(unittest.TestCase):
 
     def tearDown(self):
-        for filename in ['coloring.json', 'SLSQP.out', 'SNOPT_print.out', 'SNOPT_summary.out']:
+        for filename in ['total_coloring.pkl', 'SLSQP.out', 'SNOPT_print.out', 'SNOPT_summary.out']:
             if os.path.exists(filename):
                 os.remove(filename)
 

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
@@ -17,8 +17,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
                 os.remove(filename)
 
     def test_brachistochrone_for_docs_gauss_lobatto(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver, \
-            SqliteRecorder, CaseReader
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
         import dymos as dm
         from dymos.examples.plotting import plot_results
@@ -27,8 +26,8 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         #
         # Initialize the Problem and the optimization driver
         #
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
         #
@@ -55,7 +54,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         #
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         #
         # Setup the Problem
@@ -94,7 +93,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         plt.show()
 
     def test_brachistochrone_for_docs_radau(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver, SqliteRecorder
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
         import dymos as dm
         from dymos.examples.plotting import plot_results
@@ -103,8 +102,8 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         #
         # Initialize the Problem and the optimization driver
         #
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
         #
@@ -131,7 +130,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         #
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         #
         # Setup the Problem
@@ -171,7 +170,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         plt.show()
 
     def test_brachistochrone_for_docs_runge_kutta(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver, SqliteRecorder
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
         import dymos as dm
         from dymos.examples.plotting import plot_results
@@ -180,8 +179,8 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         #
         # Initialize the Problem and the optimization driver
         #
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
         #
@@ -215,7 +214,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         #
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         #
         # Setup the Problem
@@ -255,7 +254,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         plt.show()
 
     def test_brachistochrone_for_docs_runge_kutta_polynomial_controls(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver, SqliteRecorder
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
         import dymos as dm
         from dymos.examples.plotting import plot_results
@@ -264,8 +263,8 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         #
         # Initialize the Problem and the optimization driver
         #
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
         #
@@ -299,7 +298,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         #
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         #
         # Setup the Problem

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
@@ -28,7 +28,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         #
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         #
         # Create a trajectory and add a phase to it
@@ -104,7 +104,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         #
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         #
         # Create a trajectory and add a phase to it
@@ -181,7 +181,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         #
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         #
         # Create a trajectory and add a phase to it
@@ -265,7 +265,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         #
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         #
         # Create a trajectory and add a phase to it

--- a/dymos/examples/brachistochrone/test/ex_brachistochrone.py
+++ b/dymos/examples/brachistochrone/test/ex_brachistochrone.py
@@ -4,9 +4,9 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
-from openmdao.api import Problem, Group, pyOptSparseDriver, ScipyOptimizeDriver, DirectSolver
+import openmdao.api as om
 
-from dymos import Phase, GaussLobatto, Radau, RungeKutta
+import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
 SHOW_PLOTS = True
@@ -14,27 +14,27 @@ SHOW_PLOTS = True
 
 def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, transcription_order=3,
                              run_driver=True, compressed=True, optimizer='SLSQP'):
-    p = Problem(model=Group())
+    p = om.Problem(model=om.Group())
 
     # if optimizer == 'SNOPT':
-    p.driver = pyOptSparseDriver()
+    p.driver = om.pyOptSparseDriver()
     p.driver.options['optimizer'] = optimizer
     p.driver.options['dynamic_simul_derivs'] = True
 
     if transcription == 'gauss-lobatto':
-        t = GaussLobatto(num_segments=num_segments,
-                         order=transcription_order,
-                         compressed=compressed)
+        t = dm.GaussLobatto(num_segments=num_segments,
+                            order=transcription_order,
+                            compressed=compressed)
     elif transcription == 'radau-ps':
-        t = Radau(num_segments=num_segments,
-                  order=transcription_order,
-                  compressed=compressed)
+        t = dm.Radau(num_segments=num_segments,
+                     order=transcription_order,
+                     compressed=compressed)
     elif transcription == 'runge-kutta':
-        t = RungeKutta(num_segments=num_segments,
-                       order=transcription_order,
-                       compressed=compressed)
+        t = dm.RungeKutta(num_segments=num_segments,
+                          order=transcription_order,
+                          compressed=compressed)
 
-    phase = Phase(ode_class=BrachistochroneODE, transcription=t)
+    phase = dm.Phase(ode_class=BrachistochroneODE, transcription=t)
 
     p.model.add_subsystem('phase0', phase)
 
@@ -54,7 +54,7 @@ def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, tran
     # Minimize time at the end of the phase
     phase.add_objective('time_phase', loc='final', scaler=10)
 
-    p.model.linear_solver = DirectSolver()
+    p.model.linear_solver = om.DirectSolver()
     p.setup(check=True)
 
     p['phase0.t_initial'] = 0.0

--- a/dymos/examples/brachistochrone/test/ex_brachistochrone.py
+++ b/dymos/examples/brachistochrone/test/ex_brachistochrone.py
@@ -16,10 +16,9 @@ def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, tran
                              run_driver=True, compressed=True, optimizer='SLSQP'):
     p = om.Problem(model=om.Group())
 
-    # if optimizer == 'SNOPT':
     p.driver = om.pyOptSparseDriver()
     p.driver.options['optimizer'] = optimizer
-    p.driver.options['dynamic_simul_derivs'] = True
+    p.driver.declare_coloring()
 
     if transcription == 'gauss-lobatto':
         t = dm.GaussLobatto(num_segments=num_segments,

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_control.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_control.py
@@ -6,18 +6,18 @@ import unittest
 import numpy as np
 from scipy.interpolate import interp1d
 
-from openmdao.api import ExplicitComponent
-from dymos import declare_time, declare_state, declare_parameter
+import openmdao.api as om
+import dymos as dm
 
 
-@declare_time(units='s')
-@declare_state('x', rate_source='xdot', units='m')
-@declare_state('y', rate_source='ydot', units='m')
-@declare_state('v', rate_source='vdot', targets=['v'], units='m/s')
-@declare_state('theta', targets=['theta'], rate_source='theta_dot', units='rad')
-@declare_parameter('theta_dot', targets=[], units='rad/s')
-@declare_parameter('g', units='m/s**2', targets=['g'])
-class BrachistochroneODE(ExplicitComponent):
+@dm.declare_time(units='s')
+@dm.declare_state('x', rate_source='xdot', units='m')
+@dm.declare_state('y', rate_source='ydot', units='m')
+@dm.declare_state('v', rate_source='vdot', targets=['v'], units='m/s')
+@dm.declare_state('theta', targets=['theta'], rate_source='theta_dot', units='rad')
+@dm.declare_parameter('theta_dot', targets=[], units='rad/s')
+@dm.declare_parameter('g', units='m/s**2', targets=['g'])
+class BrachistochroneODE(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)
@@ -98,14 +98,14 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
 
     def test_brachistochrone_integrated_control_gauss_lobatto(self):
         import numpy as np
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, GaussLobatto
+        import dymos as dm
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
 
-        phase = Phase(ode_class=BrachistochroneODE, transcription=GaussLobatto(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE, transcription=dm.GaussLobatto(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -123,7 +123,7 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -173,14 +173,14 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
 
     def test_brachistochrone_integrated_control_radau_ps(self):
         import numpy as np
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, Radau
+        import dymos as dm
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
 
-        phase = Phase(ode_class=BrachistochroneODE, transcription=Radau(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE, transcription=dm.Radau(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -198,7 +198,7 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.model.options['assembled_jac_type'] = 'csc'
 
         p.setup()

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_quick_start.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_quick_start.py
@@ -2,10 +2,10 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class BrachistochroneODE(ExplicitComponent):
+class BrachistochroneODE(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)
@@ -65,7 +65,7 @@ class TestBrachistochroneQuickStart(unittest.TestCase):
 
     def test_brachistochrone_quick_start(self):
         import numpy as np
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver
+        import openmdao.api as om
         import dymos as dm
         import matplotlib
         matplotlib.use('Agg')
@@ -74,7 +74,7 @@ class TestBrachistochroneQuickStart(unittest.TestCase):
         #
         # Define the OpenMDAO problem
         #
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         #
         # Define a Trajectory object
@@ -118,7 +118,7 @@ class TestBrachistochroneQuickStart(unittest.TestCase):
         phase.add_objective('time', loc='final')
 
         # Set the driver.
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
 
         # Allow OpenMDAO to automatically determine our sparsity pattern.
         # Doing so can significant speed up the execution of Dymos.

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_quick_start.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_quick_start.py
@@ -122,7 +122,7 @@ class TestBrachistochroneQuickStart(unittest.TestCase):
 
         # Allow OpenMDAO to automatically determine our sparsity pattern.
         # Doing so can significant speed up the execution of Dymos.
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         # Setup the problem
         p.setup(check=True)

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_rk4.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_rk4.py
@@ -13,7 +13,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.RungeKutta(num_segments=20))
@@ -73,7 +73,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.RungeKutta(num_segments=20))
@@ -134,7 +134,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.RungeKutta(num_segments=20))
@@ -195,7 +195,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.RungeKutta(num_segments=20))
@@ -256,7 +256,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.RungeKutta(num_segments=20))
@@ -317,7 +317,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.RungeKutta(num_segments=20))
@@ -378,7 +378,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.RungeKutta(num_segments=20))
@@ -441,7 +441,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.RungeKutta(num_segments=20))
@@ -505,7 +505,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.RungeKutta(num_segments=20))

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_rk4.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_rk4.py
@@ -6,17 +6,17 @@ import unittest
 class TestBrachistochroneRK4Example(unittest.TestCase):
 
     def test_brachistochrone_forward_shooting(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, RungeKutta
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=RungeKutta(num_segments=20))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.RungeKutta(num_segments=20))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -39,7 +39,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time_phase', loc='final', scaler=1)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True)
 
@@ -66,17 +66,17 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
                          tolerance=1.0E-3)
 
     def test_brachistochrone_backward_shooting(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, RungeKutta
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=RungeKutta(num_segments=20))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.RungeKutta(num_segments=20))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -100,7 +100,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=-1)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True)
 
@@ -127,17 +127,17 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
                          tolerance=1.0E-3)
 
     def test_brachistochrone_forward_shooting_path_constrained_state(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, RungeKutta
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=RungeKutta(num_segments=20))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.RungeKutta(num_segments=20))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -161,7 +161,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time_phase', loc='final', scaler=1)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True)
 
@@ -188,17 +188,17 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
                          tolerance=1.0E-3)
 
     def test_brachistochrone_forward_shooting_path_constrained_control(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, RungeKutta
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=RungeKutta(num_segments=20))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.RungeKutta(num_segments=20))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -222,7 +222,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time_phase', loc='final', scaler=1)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True)
 
@@ -249,17 +249,17 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
                          tolerance=1.0E-3)
 
     def test_brachistochrone_forward_shooting_path_constrained_control_rate(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, RungeKutta
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=RungeKutta(num_segments=20))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.RungeKutta(num_segments=20))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -283,7 +283,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time_phase', loc='final', scaler=1)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True)
 
@@ -310,17 +310,17 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
                          tolerance=1.0E-3)
 
     def test_brachistochrone_forward_shooting_path_constrained_ode_output(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, RungeKutta
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=RungeKutta(num_segments=20))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.RungeKutta(num_segments=20))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -344,7 +344,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time_phase', loc='final', scaler=1)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True)
 
@@ -371,17 +371,17 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
                          tolerance=1.0E-3)
 
     def test_brachistochrone_forward_shooting_boundary_constrained_control_rate(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, RungeKutta
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=RungeKutta(num_segments=20))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.RungeKutta(num_segments=20))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -405,7 +405,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time_phase', loc='final', scaler=1)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True)
 
@@ -434,17 +434,17 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
                          tolerance=1.0E-3)
 
     def test_brachistochrone_forward_shooting_boundary_constrained_design_parameter(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, RungeKutta
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=RungeKutta(num_segments=20))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.RungeKutta(num_segments=20))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -466,7 +466,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time_phase', loc='final', scaler=1)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True)
 
@@ -498,17 +498,17 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
                          tolerance=1.0E-3)
 
     def test_brachistochrone_forward_shooting_boundary_constrained_ode_output(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, RungeKutta
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=RungeKutta(num_segments=20))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.RungeKutta(num_segments=20))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -531,7 +531,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time_phase', loc='final', scaler=1)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True)
 
@@ -558,16 +558,16 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
                          tolerance=1.0E-3)
 
     def test_brachistochrone_forward_shooting_path_constrained_time(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, RungeKutta
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=RungeKutta(num_segments=20))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.RungeKutta(num_segments=20))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -593,7 +593,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time_phase', loc='final', scaler=1)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True)
 

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_undecorated_ode.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_undecorated_ode.py
@@ -2,10 +2,10 @@ from __future__ import print_function, division, absolute_import
 
 import unittest
 import numpy as np
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class BrachistochroneODE(ExplicitComponent):
+class BrachistochroneODE(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)
@@ -83,14 +83,14 @@ class TestBrachistochroneUndecoratedODE(unittest.TestCase):
         import matplotlib
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, GaussLobatto
+        import dymos as dm
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
 
-        phase = Phase(ode_class=BrachistochroneODE, transcription=GaussLobatto(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE, transcription=dm.GaussLobatto(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -107,7 +107,7 @@ class TestBrachistochroneUndecoratedODE(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -130,14 +130,14 @@ class TestBrachistochroneUndecoratedODE(unittest.TestCase):
         import matplotlib
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, Radau
+        import dymos as dm
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
 
-        phase = Phase(ode_class=BrachistochroneODE, transcription=Radau(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE, transcription=dm.Radau(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -154,7 +154,7 @@ class TestBrachistochroneUndecoratedODE(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -177,14 +177,14 @@ class TestBrachistochroneUndecoratedODE(unittest.TestCase):
         import matplotlib
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, RungeKutta
+        import dymos as dm
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
 
-        phase = Phase(ode_class=BrachistochroneODE, transcription=RungeKutta(num_segments=20))
+        phase = dm.Phase(ode_class=BrachistochroneODE, transcription=dm.RungeKutta(num_segments=20))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -204,7 +204,7 @@ class TestBrachistochroneUndecoratedODE(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -226,11 +226,11 @@ class TestBrachistochroneUndecoratedODE(unittest.TestCase):
 class TestBrachistochroneBasePhaseClass(unittest.TestCase):
 
     def test_brachistochrone_base_phase_class_gl(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, GaussLobatto
+        import dymos as dm
 
-        class BrachistochronePhase(Phase):
+        class BrachistochronePhase(dm.Phase):
 
             def setup(self):
 
@@ -247,10 +247,10 @@ class TestBrachistochroneBasePhaseClass(unittest.TestCase):
 
                 super(BrachistochronePhase, self).setup()
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
 
-        phase = BrachistochronePhase(transcription=GaussLobatto(num_segments=20, order=3))
+        phase = BrachistochronePhase(transcription=dm.GaussLobatto(num_segments=20, order=3))
         p.model.add_subsystem('phase0', phase)
 
         phase.add_boundary_constraint('x', loc='final', equals=10)
@@ -259,7 +259,7 @@ class TestBrachistochroneBasePhaseClass(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_vector_boundary_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_vector_boundary_constraints.py
@@ -23,7 +23,7 @@ class TestBrachistochroneVectorBoundaryConstraints(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
                          transcription=dm.Radau(num_segments=20, order=3))
@@ -110,7 +110,7 @@ class TestBrachistochroneVectorBoundaryConstraints(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
                          transcription=dm.Radau(num_segments=20, order=3))
@@ -197,7 +197,7 @@ class TestBrachistochroneVectorBoundaryConstraints(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
                          transcription=dm.Radau(num_segments=20, order=3))

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_vector_boundary_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_vector_boundary_constraints.py
@@ -13,7 +13,7 @@ import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_vector_states_ode \
     import BrachistochroneVectorStatesODE
 
-SHOW_PLOTS = True
+SHOW_PLOTS = False
 
 
 class TestBrachistochroneVectorBoundaryConstraints(unittest.TestCase):

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_vector_boundary_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_vector_boundary_constraints.py
@@ -6,10 +6,10 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
-from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
-from dymos import Phase, GaussLobatto, Radau, RungeKutta
+import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_vector_states_ode \
     import BrachistochroneVectorStatesODE
 
@@ -20,13 +20,13 @@ class TestBrachistochroneVectorBoundaryConstraints(unittest.TestCase):
 
     def test_brachistochrone_vector_boundary_constraints_radau_no_indices(self):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneVectorStatesODE,
-                      transcription=Radau(num_segments=20, order=3))
+        phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
+                         transcription=dm.Radau(num_segments=20, order=3))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -45,7 +45,7 @@ class TestBrachistochroneVectorBoundaryConstraints(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True, force_alloc_complex=True)
 
         p['phase0.t_initial'] = 0.0
@@ -108,12 +108,12 @@ class TestBrachistochroneVectorBoundaryConstraints(unittest.TestCase):
 
     def test_brachistochrone_vector_boundary_constraints_radau_full_indices(self):
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneVectorStatesODE,
-                      transcription=Radau(num_segments=20, order=3))
+        phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
+                         transcription=dm.Radau(num_segments=20, order=3))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -132,7 +132,7 @@ class TestBrachistochroneVectorBoundaryConstraints(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True, force_alloc_complex=True)
 
         p['phase0.t_initial'] = 0.0
@@ -195,12 +195,12 @@ class TestBrachistochroneVectorBoundaryConstraints(unittest.TestCase):
 
     def test_brachistochrone_vector_boundary_constraints_radau_partial_indices(self):
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneVectorStatesODE,
-                      transcription=Radau(num_segments=20, order=3))
+        phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
+                         transcription=dm.Radau(num_segments=20, order=3))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -219,7 +219,7 @@ class TestBrachistochroneVectorBoundaryConstraints(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True, force_alloc_complex=True)
 
         p['phase0.t_initial'] = 0.0

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
@@ -25,7 +25,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
                          transcription=dm.Radau(num_segments=20, order=3))
@@ -137,7 +137,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
                          transcription=dm.Radau(num_segments=20, order=3))
@@ -253,7 +253,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
                          transcription=dm.Radau(num_segments=20, order=3))
@@ -369,7 +369,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
                          transcription=dm.GaussLobatto(num_segments=20, order=3))
@@ -481,7 +481,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
                          transcription=dm.GaussLobatto(num_segments=20, order=3))
@@ -597,7 +597,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
                          transcription=dm.GaussLobatto(num_segments=20, order=3))
@@ -712,7 +712,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
                          transcription=dm.RungeKutta(num_segments=50))
@@ -826,7 +826,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
                          transcription=dm.RungeKutta(num_segments=20))
@@ -944,7 +944,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
                          transcription=dm.RungeKutta(num_segments=20))

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
@@ -15,7 +15,7 @@ import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_vector_states_ode \
     import BrachistochroneVectorStatesODE
 
-SHOW_PLOTS = True
+SHOW_PLOTS = False
 
 
 class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
@@ -42,6 +42,8 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
 
+        phase.add_boundary_constraint('theta_rate', loc='final', equals=0.0)
+        phase.add_boundary_constraint('theta_rate2', loc='final', equals=0.0)
         phase.add_path_constraint('pos', indices=[1], lower=5)
 
         phase.add_timeseries_output('pos_dot', shape=(2,), units='m/s')
@@ -65,7 +67,8 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self, p.get_val('phase0.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_rel_error(self, np.min(p.get_val('phase0.timeseries.states:pos')[:, 1]), 5.0,
+                         tolerance=1.0E-3)
 
         # Plot results
         if SHOW_PLOTS:
@@ -409,7 +412,10 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self, p.get_val('phase0.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_rel_error(self,
+                         np.min(p.get_val('phase0.timeseries.states:pos')[:, 1]),
+                         5,
+                         tolerance=1.0E-2)
 
         # Plot results
         if SHOW_PLOTS:
@@ -498,6 +504,8 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         phase.add_design_parameter('g', units='m/s**2', opt=False, val=9.80665)
 
+        phase.add_boundary_constraint('theta_rate', loc='final', equals=0.0)
+        phase.add_boundary_constraint('theta_rate2', loc='final', equals=0.0)
         phase.add_path_constraint('pos_dot', shape=(2,), units='m/s', indices=[1],
                                   lower=-4, upper=4)
 
@@ -522,10 +530,8 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self,
-                         np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
-                         -4,
-                         tolerance=1.0E-2)
+        assert_rel_error(self, np.min(p.get_val('phase0.timeseries.pos_dot')[:, 1]), -4.0,
+                         tolerance=1.0E-3)
 
         # Plot results
         if SHOW_PLOTS:

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
@@ -8,10 +8,10 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
-from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
-from dymos import Phase, GaussLobatto, Radau, RungeKutta
+import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_vector_states_ode \
     import BrachistochroneVectorStatesODE
 
@@ -22,13 +22,13 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
     def test_brachistochrone_vector_state_path_constraints_radau_partial_indices(self):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneVectorStatesODE,
-                      transcription=Radau(num_segments=20, order=3))
+        phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
+                         transcription=dm.Radau(num_segments=20, order=3))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -49,7 +49,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True, force_alloc_complex=True)
 
         p['phase0.t_initial'] = 0.0
@@ -134,13 +134,13 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
     def test_brachistochrone_vector_ode_path_constraints_radau_partial_indices(self):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneVectorStatesODE,
-                      transcription=Radau(num_segments=20, order=3))
+        phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
+                         transcription=dm.Radau(num_segments=20, order=3))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -162,7 +162,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True, force_alloc_complex=True)
 
         p['phase0.t_initial'] = 0.0
@@ -250,13 +250,13 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
     def test_brachistochrone_vector_ode_path_constraints_radau_no_indices(self):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneVectorStatesODE,
-                      transcription=Radau(num_segments=20, order=3))
+        phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
+                         transcription=dm.Radau(num_segments=20, order=3))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -278,7 +278,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True, force_alloc_complex=True)
 
         p['phase0.t_initial'] = 0.0
@@ -366,13 +366,13 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
     def test_brachistochrone_vector_state_path_constraints_gl_partial_indices(self):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneVectorStatesODE,
-                      transcription=GaussLobatto(num_segments=20, order=3))
+        phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
+                         transcription=dm.GaussLobatto(num_segments=20, order=3))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -393,7 +393,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True, force_alloc_complex=True)
 
         p['phase0.t_initial'] = 0.0
@@ -478,13 +478,13 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
     def test_brachistochrone_vector_ode_path_constraints_gl_partial_indices(self):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneVectorStatesODE,
-                      transcription=GaussLobatto(num_segments=20, order=3))
+        phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
+                         transcription=dm.GaussLobatto(num_segments=20, order=3))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -506,7 +506,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True, force_alloc_complex=True)
 
         p['phase0.t_initial'] = 0.0
@@ -594,13 +594,13 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
     def test_brachistochrone_vector_ode_path_constraints_gl_no_indices(self):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneVectorStatesODE,
-                      transcription=GaussLobatto(num_segments=20, order=3))
+        phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
+                         transcription=dm.GaussLobatto(num_segments=20, order=3))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -622,7 +622,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True, force_alloc_complex=True)
 
         p['phase0.t_initial'] = 0.0
@@ -709,13 +709,13 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         return p
 
     def test_brachistochrone_vector_state_path_constraints_rk_partial_indices(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneVectorStatesODE,
-                      transcription=RungeKutta(num_segments=50))
+        phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
+                         transcription=dm.RungeKutta(num_segments=50))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -737,7 +737,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True, force_alloc_complex=True)
 
         p['phase0.t_initial'] = 0.0
@@ -823,13 +823,13 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
     def test_brachistochrone_vector_ode_path_constraints_rk_partial_indices(self):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneVectorStatesODE,
-                      transcription=RungeKutta(num_segments=20))
+        phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
+                         transcription=dm.RungeKutta(num_segments=20))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -853,7 +853,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True, force_alloc_complex=True)
 
         p['phase0.t_initial'] = 0.0
@@ -941,13 +941,13 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
     def test_brachistochrone_vector_ode_path_constraints_rk_no_indices(self):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneVectorStatesODE,
-                      transcription=RungeKutta(num_segments=20))
+        phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
+                         transcription=dm.RungeKutta(num_segments=20))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -971,7 +971,7 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True, force_alloc_complex=True)
 
         p['phase0.t_initial'] = 0.0

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_vector_states_ode.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_vector_states_ode.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from dymos.examples.brachistochrone.brachistochrone_vector_states_ode import \
@@ -17,9 +17,9 @@ class TestBrachistochroneVectorStatesODE(unittest.TestCase):
     def setUpClass(cls):
         nn = 5
 
-        p = cls.p = Problem(model=Group())
+        p = cls.p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
         ivc.add_output('v', val=np.ones((nn,)), units='m/s')
         ivc.add_output('g', val=np.zeros((nn,)), units='m/s**2')
         ivc.add_output('theta', val=np.zeros((nn)), units='rad')

--- a/dymos/examples/brachistochrone/test/test_doc_brachistochrone_polynomial_controls.py
+++ b/dymos/examples/brachistochrone/test/test_doc_brachistochrone_polynomial_controls.py
@@ -9,17 +9,17 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
         import matplotlib
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, DirectSolver, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, GaussLobatto
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -38,7 +38,7 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -95,17 +95,17 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
         import matplotlib
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, DirectSolver, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, Radau
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=Radau(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.Radau(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -123,7 +123,7 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -180,17 +180,17 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
         import matplotlib
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, DirectSolver, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, RungeKutta
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=RungeKutta(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.RungeKutta(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -211,7 +211,7 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -267,21 +267,20 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
 class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase):
 
     def test_brachistochrone_polynomial_control_gauss_lobatto(self):
-        import numpy as np
         import matplotlib
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, DirectSolver, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, GaussLobatto
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -302,7 +301,7 @@ class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase)
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -355,21 +354,20 @@ class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase)
         plt.show()
 
     def test_brachistochrone_polynomial_control_radau(self):
-        import numpy as np
         import matplotlib
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, DirectSolver, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, Radau
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=Radau(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.Radau(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -390,7 +388,7 @@ class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase)
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -447,17 +445,17 @@ class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase)
         import matplotlib
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, DirectSolver, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, RungeKutta
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=RungeKutta(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.RungeKutta(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -481,7 +479,7 @@ class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase)
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -537,21 +535,20 @@ class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase)
 class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
 
     def test_brachistochrone_polynomial_control_gauss_lobatto(self):
-        import numpy as np
         import matplotlib
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, DirectSolver, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, GaussLobatto
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -571,7 +568,7 @@ class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -628,17 +625,17 @@ class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
         import matplotlib
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, DirectSolver, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, Radau
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=Radau(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.Radau(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -658,7 +655,7 @@ class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -715,17 +712,17 @@ class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
         import matplotlib
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, DirectSolver, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, RungeKutta
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=RungeKutta(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.RungeKutta(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -748,7 +745,7 @@ class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -808,17 +805,17 @@ class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase)
         import matplotlib
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, DirectSolver, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, GaussLobatto
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -838,7 +835,7 @@ class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase)
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -895,17 +892,17 @@ class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase)
         import matplotlib
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, DirectSolver, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, Radau
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=Radau(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.Radau(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -925,7 +922,7 @@ class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase)
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -982,17 +979,17 @@ class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase)
         import matplotlib
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, DirectSolver, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, RungeKutta
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=RungeKutta(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.RungeKutta(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -1015,7 +1012,7 @@ class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase)
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -1075,17 +1072,17 @@ class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase
         import matplotlib
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, DirectSolver, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, GaussLobatto
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -1105,7 +1102,7 @@ class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -1162,17 +1159,17 @@ class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase
         import matplotlib
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, DirectSolver, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, Radau
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=Radau(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.Radau(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -1192,7 +1189,7 @@ class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -1249,17 +1246,17 @@ class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase
         import matplotlib
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, DirectSolver, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, RungeKutta
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=RungeKutta(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.RungeKutta(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -1282,7 +1279,7 @@ class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -1338,17 +1335,17 @@ class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase
 class TestBrachistochronePolynomialControlSimulation(unittest.TestCase):
 
     def test_brachistochrone_polynomial_control_gauss_lobatto(self):
-        from openmdao.api import Problem, Group, DirectSolver, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, GaussLobatto
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -1365,7 +1362,7 @@ class TestBrachistochronePolynomialControlSimulation(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -1393,17 +1390,17 @@ class TestBrachistochronePolynomialControlSimulation(unittest.TestCase):
         assert_rel_error(self, theta_exp[-1], theta_imp[-1])
 
     def test_brachistochrone_polynomial_control_radau(self):
-        from openmdao.api import Problem, Group, DirectSolver, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, Radau
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=Radau(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.Radau(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -1421,7 +1418,7 @@ class TestBrachistochronePolynomialControlSimulation(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -1449,17 +1446,17 @@ class TestBrachistochronePolynomialControlSimulation(unittest.TestCase):
         assert_rel_error(self, theta_exp[-1], theta_imp[-1])
 
     def test_brachistochrone_polynomial_control_rungekutta(self):
-        from openmdao.api import Problem, Group, DirectSolver, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, RungeKutta
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=RungeKutta(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.RungeKutta(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -1480,7 +1477,7 @@ class TestBrachistochronePolynomialControlSimulation(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 

--- a/dymos/examples/brachistochrone/test/test_doc_brachistochrone_polynomial_controls.py
+++ b/dymos/examples/brachistochrone/test/test_doc_brachistochrone_polynomial_controls.py
@@ -16,7 +16,7 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=10))
@@ -102,7 +102,7 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.Radau(num_segments=10))
@@ -187,7 +187,7 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.RungeKutta(num_segments=10))
@@ -277,7 +277,7 @@ class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase)
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=10))
@@ -364,7 +364,7 @@ class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase)
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.Radau(num_segments=10))
@@ -452,7 +452,7 @@ class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase)
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.RungeKutta(num_segments=10))
@@ -545,7 +545,7 @@ class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=10))
@@ -632,7 +632,7 @@ class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.Radau(num_segments=10))
@@ -719,7 +719,7 @@ class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.RungeKutta(num_segments=10))
@@ -812,7 +812,7 @@ class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase)
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=10))
@@ -899,7 +899,7 @@ class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase)
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.Radau(num_segments=10))
@@ -986,7 +986,7 @@ class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase)
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.RungeKutta(num_segments=10))
@@ -1079,7 +1079,7 @@ class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=10))
@@ -1166,7 +1166,7 @@ class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.Radau(num_segments=10))
@@ -1253,7 +1253,7 @@ class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.RungeKutta(num_segments=10))
@@ -1342,7 +1342,7 @@ class TestBrachistochronePolynomialControlSimulation(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=10))
@@ -1397,7 +1397,7 @@ class TestBrachistochronePolynomialControlSimulation(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.Radau(num_segments=10))
@@ -1453,7 +1453,7 @@ class TestBrachistochronePolynomialControlSimulation(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.RungeKutta(num_segments=10))

--- a/dymos/examples/brachistochrone/test/test_ex_brachistochrone_vector_states.py
+++ b/dymos/examples/brachistochrone/test/test_ex_brachistochrone_vector_states.py
@@ -108,19 +108,19 @@ class TestBrachistochroneVectorStatesExample(unittest.TestCase):
             os.remove('ex_brachvs_gl_compressed.db')
 
     def test_ex_brachistochrone_vs_rungekutta_compressed(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
-        from dymos import Phase, RungeKutta
+        import openmdao.api as om
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_vector_states_ode import \
             BrachistochroneVectorStatesODE
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
 
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneVectorStatesODE,
-                      transcription=RungeKutta(num_segments=20, compressed=True))
+        phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
+                         transcription=dm.RungeKutta(num_segments=20, compressed=True))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -139,7 +139,7 @@ class TestBrachistochroneVectorStatesExample(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True, force_alloc_complex=True)
 
         p['phase0.t_initial'] = 0.0

--- a/dymos/examples/brachistochrone/test/test_ex_brachistochrone_vector_states.py
+++ b/dymos/examples/brachistochrone/test/test_ex_brachistochrone_vector_states.py
@@ -117,7 +117,7 @@ class TestBrachistochroneVectorStatesExample(unittest.TestCase):
 
         p.driver = om.ScipyOptimizeDriver()
 
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
                          transcription=dm.RungeKutta(num_segments=20, compressed=True))

--- a/dymos/examples/brachistochrone/test/test_path_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_path_constraints.py
@@ -6,16 +6,16 @@ import unittest
 class TestBrachistochronePathConstraints(unittest.TestCase):
 
     def test_control_rate_path_constraint_gl(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, GaussLobatto
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=10))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=10))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -34,7 +34,7 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
 
         phase.add_path_constraint('theta_rate', lower=0, upper=100, units='deg/s')
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -53,16 +53,16 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
         assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
     def test_control_rate2_path_constraint_gl(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, GaussLobatto
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=10, order=5))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=10, order=5))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -81,7 +81,7 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
 
         phase.add_path_constraint('theta_rate2', lower=-200, upper=200, units='rad/s**2')
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.model.options['assembled_jac_type'] = 'csc'
 
         p.setup()
@@ -101,17 +101,17 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
         assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
     def test_control_rate_path_constraint_radau(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, Radau
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=Radau(num_segments=10,
-                                          compressed=False))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.Radau(num_segments=10,
+                                                compressed=False))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -130,7 +130,7 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
 
         phase.add_path_constraint('theta_rate', lower=0, upper=100, units='deg/s')
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 
@@ -149,17 +149,17 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
         assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
     def test_control_rate2_path_constraint_radau(self):
-        from openmdao.api import Problem, Group, ScipyOptimizeDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
-        from dymos import Phase, Radau
+        import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-        p = Problem(model=Group())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=Radau(num_segments=10,
-                                          compressed=False))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.Radau(num_segments=10,
+                                                compressed=False))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -178,7 +178,7 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
 
         phase.add_path_constraint('theta_rate2', lower=-200, upper=200, units='rad/s**2')
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.model.options['assembled_jac_type'] = 'csc'
 
         p.setup()

--- a/dymos/examples/cannonball/cannonball_ode.py
+++ b/dymos/examples/cannonball/cannonball_ode.py
@@ -1,8 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
-from openmdao.api import Group
-
-from dymos import declare_time, declare_state, declare_parameter
+import openmdao.api as om
+import dymos as dm
 from dymos.examples.min_time_climb.aero.dynamic_pressure_comp import DynamicPressureComp
 from dymos.examples.min_time_climb.aero.lift_drag_force_comp import LiftDragForceComp
 from dymos.models.atmosphere import USatm1976Comp
@@ -10,19 +9,19 @@ from dymos.models.eom import FlightPathEOM2D
 from .kinetic_energy_comp import KineticEnergyComp
 
 
-@declare_time(units='s')
-@declare_state(name='r', rate_source='eom.r_dot', units='m')
-@declare_state(name='h', rate_source='eom.h_dot', targets=['atmos.h'], units='m')
-@declare_state(name='gam', rate_source='eom.gam_dot', targets=['eom.gam'], units='rad')
-@declare_state(name='v', rate_source='eom.v_dot',
-               targets=['dynamic_pressure.v', 'eom.v', 'kinetic_energy.v'], units='m/s')
-@declare_parameter(name='CD', targets=['aero.CD'], units=None)
-@declare_parameter(name='CL', targets=['aero.CL'], units=None)
-@declare_parameter(name='T', targets=['eom.T'], units='N')
-@declare_parameter(name='alpha', targets=['eom.alpha'], units='deg')
-@declare_parameter(name='m', targets=['eom.m', 'kinetic_energy.m'], units='kg')
-@declare_parameter(name='S', targets=['aero.S'], units='m**2')
-class CannonballODE(Group):
+@dm.declare_time(units='s')
+@dm.declare_state(name='r', rate_source='eom.r_dot', units='m')
+@dm.declare_state(name='h', rate_source='eom.h_dot', targets=['atmos.h'], units='m')
+@dm.declare_state(name='gam', rate_source='eom.gam_dot', targets=['eom.gam'], units='rad')
+@dm.declare_state(name='v', rate_source='eom.v_dot',
+                  targets=['dynamic_pressure.v', 'eom.v', 'kinetic_energy.v'], units='m/s')
+@dm.declare_parameter(name='CD', targets=['aero.CD'], units=None)
+@dm.declare_parameter(name='CL', targets=['aero.CL'], units=None)
+@dm.declare_parameter(name='T', targets=['eom.T'], units='N')
+@dm.declare_parameter(name='alpha', targets=['eom.alpha'], units='deg')
+@dm.declare_parameter(name='m', targets=['eom.m', 'kinetic_energy.m'], units='kg')
+@dm.declare_parameter(name='S', targets=['aero.S'], units='m**2')
+class CannonballODE(om.Group):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)

--- a/dymos/examples/cannonball/cannonball_undecorated_ode.py
+++ b/dymos/examples/cannonball/cannonball_undecorated_ode.py
@@ -1,8 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
-from openmdao.api import Group
-
-from dymos import declare_time, declare_state, declare_parameter
+import openmdao.api as om
 from dymos.examples.min_time_climb.aero.dynamic_pressure_comp import DynamicPressureComp
 from dymos.examples.min_time_climb.aero.lift_drag_force_comp import LiftDragForceComp
 from dymos.models.atmosphere import USatm1976Comp
@@ -10,7 +8,7 @@ from dymos.models.eom import FlightPathEOM2D
 from .kinetic_energy_comp import KineticEnergyComp
 
 
-class CannonballUndecoratedODE(Group):
+class CannonballUndecoratedODE(om.Group):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)

--- a/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
+++ b/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
@@ -25,7 +25,7 @@ class TestTwoPhaseCannonballForDocs(unittest.TestCase):
 
         p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'SLSQP'
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         external_params = p.model.add_subsystem('external_params', om.IndepVarComp())
 

--- a/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
+++ b/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
@@ -13,22 +13,21 @@ from dymos.utils.testing_utils import use_tempdirs
 class TestTwoPhaseCannonballForDocs(unittest.TestCase):
 
     def test_two_phase_cannonball_for_docs(self):
-        from openmdao.api import Problem, Group, IndepVarComp, DirectSolver, SqliteRecorder, \
-            pyOptSparseDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
 
-        from dymos import Phase, Trajectory, Radau, GaussLobatto
+        import dymos as dm
         from dymos.examples.cannonball.cannonball_ode import CannonballODE
 
         from dymos.examples.cannonball.size_comp import CannonballSizeComp
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = pyOptSparseDriver()
+        p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'SLSQP'
         p.driver.options['dynamic_simul_derivs'] = True
 
-        external_params = p.model.add_subsystem('external_params', IndepVarComp())
+        external_params = p.model.add_subsystem('external_params', om.IndepVarComp())
 
         external_params.add_output('radius', val=0.10, units='m')
         external_params.add_output('dens', val=7.87, units='g/cm**3')
@@ -37,10 +36,10 @@ class TestTwoPhaseCannonballForDocs(unittest.TestCase):
 
         p.model.add_subsystem('size_comp', CannonballSizeComp())
 
-        traj = p.model.add_subsystem('traj', Trajectory())
+        traj = p.model.add_subsystem('traj', dm.Trajectory())
 
-        transcription = Radau(num_segments=5, order=3, compressed=True)
-        ascent = Phase(ode_class=CannonballODE, transcription=transcription)
+        transcription = dm.Radau(num_segments=5, order=3, compressed=True)
+        ascent = dm.Phase(ode_class=CannonballODE, transcription=transcription)
 
         ascent = traj.add_phase('ascent', ascent)
 
@@ -58,8 +57,8 @@ class TestTwoPhaseCannonballForDocs(unittest.TestCase):
                                        upper=400000, lower=0, ref=100000, shape=(1,))
 
         # Second Phase (descent)
-        transcription = GaussLobatto(num_segments=5, order=3, compressed=True)
-        descent = Phase(ode_class=CannonballODE, transcription=transcription)
+        transcription = dm.GaussLobatto(num_segments=5, order=3, compressed=True)
+        descent = dm.Phase(ode_class=CannonballODE, transcription=transcription)
 
         traj.add_phase('descent', descent)
 
@@ -99,9 +98,9 @@ class TestTwoPhaseCannonballForDocs(unittest.TestCase):
         p.model.connect('size_comp.S', 'traj.input_parameters:S')
 
         # Finish Problem Setup
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
-        p.driver.add_recorder(SqliteRecorder('ex_two_phase_cannonball.db'))
+        p.driver.add_recorder(om.SqliteRecorder('ex_two_phase_cannonball.db'))
 
         p.setup(check=True)
 

--- a/dymos/examples/cannonball/kinetic_energy_comp.py
+++ b/dymos/examples/cannonball/kinetic_energy_comp.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class KineticEnergyComp(ExplicitComponent):
+class KineticEnergyComp(om.ExplicitComponent):
     """
     Computes the kinetic energy of a particle based on its speed and mass
 

--- a/dymos/examples/cannonball/size_comp.py
+++ b/dymos/examples/cannonball/size_comp.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class CannonballSizeComp(ExplicitComponent):
+class CannonballSizeComp(om.ExplicitComponent):
     """
     Compute the reference area and mass of a cannonball with a given radius and density.
 

--- a/dymos/examples/cannonball/test/test_two_phase_cannonball_undecorated_ode.py
+++ b/dymos/examples/cannonball/test/test_two_phase_cannonball_undecorated_ode.py
@@ -25,7 +25,7 @@ class TestTwoPhaseCannonball(unittest.TestCase):
 
         p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'SLSQP'
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         external_params = p.model.add_subsystem('external_params', om.IndepVarComp())
 
@@ -251,7 +251,7 @@ class TestTwoPhaseCannonball(unittest.TestCase):
 
         p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'SLSQP'
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         external_params = p.model.add_subsystem('external_params', om.IndepVarComp())
 

--- a/dymos/examples/cannonball/test/test_two_phase_cannonball_undecorated_ode.py
+++ b/dymos/examples/cannonball/test/test_two_phase_cannonball_undecorated_ode.py
@@ -13,22 +13,21 @@ from dymos.utils.testing_utils import use_tempdirs
 class TestTwoPhaseCannonball(unittest.TestCase):
 
     def test_two_phase_cannonball_undecorated_ode(self):
-        from openmdao.api import Problem, Group, IndepVarComp, DirectSolver, SqliteRecorder, \
-            pyOptSparseDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
 
-        from dymos import Phase, Trajectory, Radau, GaussLobatto
+        import dymos as dm
         from dymos.examples.cannonball.cannonball_undecorated_ode import CannonballUndecoratedODE
 
         from dymos.examples.cannonball.size_comp import CannonballSizeComp
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = pyOptSparseDriver()
+        p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'SLSQP'
         p.driver.options['dynamic_simul_derivs'] = True
 
-        external_params = p.model.add_subsystem('external_params', IndepVarComp())
+        external_params = p.model.add_subsystem('external_params', om.IndepVarComp())
 
         external_params.add_output('radius', val=0.10, units='m')
         external_params.add_output('dens', val=7.87, units='g/cm**3')
@@ -37,10 +36,10 @@ class TestTwoPhaseCannonball(unittest.TestCase):
 
         p.model.add_subsystem('size_comp', CannonballSizeComp())
 
-        traj = p.model.add_subsystem('traj', Trajectory())
+        traj = p.model.add_subsystem('traj', dm.Trajectory())
 
-        transcription = Radau(num_segments=5, order=3, compressed=True)
-        ascent = Phase(ode_class=CannonballUndecoratedODE, transcription=transcription)
+        transcription = dm.Radau(num_segments=5, order=3, compressed=True)
+        ascent = dm.Phase(ode_class=CannonballUndecoratedODE, transcription=transcription)
 
         ascent = traj.add_phase('ascent', ascent)
 
@@ -63,8 +62,8 @@ class TestTwoPhaseCannonball(unittest.TestCase):
                                        upper=400000, lower=0, ref=100000, shape=(1,))
 
         # Second Phase (descent)
-        transcription = GaussLobatto(num_segments=5, order=3, compressed=True)
-        descent = Phase(ode_class=CannonballUndecoratedODE, transcription=transcription)
+        transcription = dm.GaussLobatto(num_segments=5, order=3, compressed=True)
+        descent = dm.Phase(ode_class=CannonballUndecoratedODE, transcription=transcription)
 
         traj.add_phase('descent', descent)
 
@@ -122,9 +121,9 @@ class TestTwoPhaseCannonball(unittest.TestCase):
         p.model.connect('size_comp.S', 'traj.input_parameters:S')
 
         # Finish Problem Setup
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
-        p.driver.add_recorder(SqliteRecorder('ex_two_phase_cannonball.db'))
+        p.driver.add_recorder(om.SqliteRecorder('ex_two_phase_cannonball.db'))
 
         p.setup(check=True)
 
@@ -239,8 +238,7 @@ class TestTwoPhaseCannonball(unittest.TestCase):
         plt.show()
 
     def test_two_phase_cannonball_mixed_odes(self):
-        from openmdao.api import Problem, Group, IndepVarComp, DirectSolver, SqliteRecorder, \
-            pyOptSparseDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
 
         import dymos as dm
@@ -249,13 +247,13 @@ class TestTwoPhaseCannonball(unittest.TestCase):
 
         from dymos.examples.cannonball.size_comp import CannonballSizeComp
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = pyOptSparseDriver()
+        p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'SLSQP'
         p.driver.options['dynamic_simul_derivs'] = True
 
-        external_params = p.model.add_subsystem('external_params', IndepVarComp())
+        external_params = p.model.add_subsystem('external_params', om.IndepVarComp())
 
         external_params.add_output('radius', val=0.10, units='m')
         external_params.add_output('dens', val=7.87, units='g/cm**3')
@@ -343,9 +341,9 @@ class TestTwoPhaseCannonball(unittest.TestCase):
         p.model.connect('size_comp.S', 'traj.input_parameters:S')
 
         # Finish Problem Setup
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
-        p.driver.add_recorder(SqliteRecorder('ex_two_phase_cannonball.db'))
+        p.driver.add_recorder(om.SqliteRecorder('ex_two_phase_cannonball.db'))
 
         p.setup(check=True)
 

--- a/dymos/examples/double_integrator/doc/test_doc_double_integrator.py
+++ b/dymos/examples/double_integrator/doc/test_doc_double_integrator.py
@@ -13,7 +13,7 @@ class TestDoubleIntegratorForDocs(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        for filename in ['coloring.json', 'SLSQP.out', 'SNOPT_print.out']:
+        for filename in ['total_coloring.pkl', 'SLSQP.out', 'SNOPT_print.out']:
             if os.path.exists(filename):
                 os.remove(filename)
 

--- a/dymos/examples/double_integrator/doc/test_doc_double_integrator.py
+++ b/dymos/examples/double_integrator/doc/test_doc_double_integrator.py
@@ -29,7 +29,7 @@ class TestDoubleIntegratorForDocs(unittest.TestCase):
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'SLSQP'
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         # Setup the trajectory and its phase
         traj = p.model.add_subsystem('traj', dm.Trajectory())

--- a/dymos/examples/double_integrator/doc/test_doc_double_integrator.py
+++ b/dymos/examples/double_integrator/doc/test_doc_double_integrator.py
@@ -19,15 +19,15 @@ class TestDoubleIntegratorForDocs(unittest.TestCase):
 
     def test_double_integrator_for_docs(self):
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, pyOptSparseDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
         import dymos as dm
         from dymos.examples.plotting import plot_results
         from dymos.examples.double_integrator.double_integrator_ode import DoubleIntegratorODE
 
         # Initialize the problem and assign the driver
-        p = Problem(model=Group())
-        p.driver = pyOptSparseDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'SLSQP'
         p.driver.options['dynamic_simul_derivs'] = True
 
@@ -54,7 +54,7 @@ class TestDoubleIntegratorForDocs(unittest.TestCase):
         #
         phase.add_objective('x', loc='final', scaler=-1)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         #
         # Setup the problem and set our initial values.

--- a/dymos/examples/double_integrator/double_integrator_ode.py
+++ b/dymos/examples/double_integrator/double_integrator_ode.py
@@ -1,9 +1,9 @@
 from __future__ import print_function, division, absolute_import
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class DoubleIntegratorODE(ExplicitComponent):
+class DoubleIntegratorODE(om.ExplicitComponent):
     """
     The double integrator is a special case where the state rates are all set to other states
     or parameters.  Since we aren't computing any other outputs, the ODE doesn't actually

--- a/dymos/examples/double_integrator/test/test_double_integrator.py
+++ b/dymos/examples/double_integrator/test/test_double_integrator.py
@@ -17,7 +17,7 @@ def double_integrator_direct_collocation(transcription='gauss-lobatto', compress
 
     p = om.Problem(model=om.Group())
     p.driver = om.pyOptSparseDriver()
-    p.driver.options['dynamic_simul_derivs'] = True
+    p.driver.declare_coloring()
 
     if transcription == 'gauss-lobatto':
         t = dm.GaussLobatto(num_segments=30, order=3, compressed=compressed)
@@ -92,7 +92,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         times_ivc = p.model.add_subsystem('times_ivc', om.IndepVarComp(),
                                           promotes_outputs=['t0', 'tp'])
@@ -134,7 +134,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         t = dm.RungeKutta(num_segments=30, order=3, compressed=compressed)
 

--- a/dymos/examples/double_integrator/test/test_double_integrator.py
+++ b/dymos/examples/double_integrator/test/test_double_integrator.py
@@ -61,7 +61,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        for filename in ['coloring.json', 'SLSQP.out', 'SNOPT_print.out']:
+        for filename in ['total_coloring.pkl', 'SLSQP.out', 'SNOPT_print.out']:
             if os.path.exists(filename):
                 os.remove(filename)
 

--- a/dymos/examples/double_integrator/test/test_double_integrator.py
+++ b/dymos/examples/double_integrator/test/test_double_integrator.py
@@ -6,7 +6,7 @@ import unittest
 
 from parameterized import parameterized
 
-from openmdao.api import Problem, Group, pyOptSparseDriver, DirectSolver, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 import dymos as dm
@@ -15,8 +15,8 @@ from dymos.examples.double_integrator.double_integrator_ode import DoubleIntegra
 
 def double_integrator_direct_collocation(transcription='gauss-lobatto', compressed=True):
 
-    p = Problem(model=Group())
-    p.driver = pyOptSparseDriver()
+    p = om.Problem(model=om.Group())
+    p.driver = om.pyOptSparseDriver()
     p.driver.options['dynamic_simul_derivs'] = True
 
     if transcription == 'gauss-lobatto':
@@ -41,7 +41,7 @@ def double_integrator_direct_collocation(transcription='gauss-lobatto', compress
     # Maximize distance travelled in one second.
     phase.add_objective('x', loc='final', scaler=-1)
 
-    p.model.linear_solver = DirectSolver()
+    p.model.linear_solver = om.DirectSolver()
 
     p.setup(check=True)
 
@@ -90,11 +90,11 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         Tests that externally connected t_initial and t_duration function as expected.
         """
 
-        p = Problem(model=Group())
-        p.driver = pyOptSparseDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.pyOptSparseDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        times_ivc = p.model.add_subsystem('times_ivc', IndepVarComp(),
+        times_ivc = p.model.add_subsystem('times_ivc', om.IndepVarComp(),
                                           promotes_outputs=['t0', 'tp'])
         times_ivc.add_output(name='t0', val=0.0, units='s')
         times_ivc.add_output(name='tp', val=1.0, units='s')
@@ -117,7 +117,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         # Maximize distance travelled in one second.
         phase.add_objective('x', loc='final', scaler=-1)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True)
 
@@ -132,8 +132,8 @@ class TestDoubleIntegratorExample(unittest.TestCase):
 
     def test_double_integrator_rk4(self, compressed=True):
 
-        p = Problem(model=Group())
-        p.driver = pyOptSparseDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.pyOptSparseDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
         t = dm.RungeKutta(num_segments=30, order=3, compressed=compressed)
@@ -155,7 +155,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         # Maximize distance travelled in one second.
         phase.add_objective('x', loc='final', scaler=-1)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True)
 

--- a/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
@@ -33,7 +33,7 @@ class TestFiniteBurnOrbitRaise(unittest.TestCase):
         #
         p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'SLSQP'
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         #
         # The trajectory controls the design parameter governing exhaust velocity

--- a/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
@@ -15,7 +15,7 @@ class TestFiniteBurnOrbitRaise(unittest.TestCase):
 
         import matplotlib.pyplot as plt
 
-        from openmdao.api import Problem, Group, pyOptSparseDriver, DirectSolver, SqliteRecorder
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
 
         import dymos as dm
@@ -24,14 +24,14 @@ class TestFiniteBurnOrbitRaise(unittest.TestCase):
         #
         # Instantiate the problem and trajectory
         #
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
         traj = dm.Trajectory()
         p.model.add_subsystem('traj', traj)
 
         #
         # Setup the optimization driver
         #
-        p.driver = pyOptSparseDriver()
+        p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'SLSQP'
         p.driver.options['dynamic_simul_derivs'] = True
 
@@ -116,9 +116,9 @@ class TestFiniteBurnOrbitRaise(unittest.TestCase):
         #
         # Finish Problem Setup
         #
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
-        p.driver.add_recorder(SqliteRecorder('two_burn_orbit_raise_example_for_docs.db'))
+        p.driver.add_recorder(om.SqliteRecorder('two_burn_orbit_raise_example_for_docs.db'))
 
         p.setup(check=True)
 

--- a/dymos/examples/finite_burn_orbit_raise/finite_burn_eom.py
+++ b/dymos/examples/finite_burn_orbit_raise/finite_burn_eom.py
@@ -1,11 +1,10 @@
 from __future__ import print_function, division, absolute_import
 
 import numpy as np
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 import openmdao.utils.units as units
 
-from dymos import declare_time, declare_state, declare_parameter
-
+import dymos as dm
 # Add canonical units to OpenMDAO
 MU_earth = 3.986592936294783e14
 R_earth = 6378137.0
@@ -17,16 +16,16 @@ units.add_unit('TU', '{0}*s'.format(period))
 units.add_unit('DU', '{0}*m'.format(R_earth))
 
 
-@declare_time(units='TU')
-@declare_state('r', rate_source='r_dot', targets=['r'], units='DU')
-@declare_state('theta', rate_source='theta_dot', targets=['theta'], units='rad')
-@declare_state('vr', rate_source='vr_dot', targets=['vr'], units='DU/TU')
-@declare_state('vt', rate_source='vt_dot', targets=['vt'], units='DU/TU')
-@declare_state('accel', rate_source='at_dot', targets=['accel'], units='DU/TU**2')
-@declare_state('deltav', rate_source='deltav_dot', units='DU/TU')
-@declare_parameter('u1', targets=['u1'], units='rad')
-@declare_parameter('c', targets=['c'], units='DU/TU')
-class FiniteBurnODE(ExplicitComponent):
+@dm.declare_time(units='TU')
+@dm.declare_state('r', rate_source='r_dot', targets=['r'], units='DU')
+@dm.declare_state('theta', rate_source='theta_dot', targets=['theta'], units='rad')
+@dm.declare_state('vr', rate_source='vr_dot', targets=['vr'], units='DU/TU')
+@dm.declare_state('vt', rate_source='vt_dot', targets=['vt'], units='DU/TU')
+@dm.declare_state('accel', rate_source='at_dot', targets=['accel'], units='DU/TU**2')
+@dm.declare_state('deltav', rate_source='deltav_dot', units='DU/TU')
+@dm.declare_parameter('u1', targets=['u1'], units='rad')
+@dm.declare_parameter('c', targets=['c'], units='DU/TU')
+class FiniteBurnODE(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)

--- a/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise.py
@@ -132,14 +132,14 @@ def two_burn_orbit_raise_problem(transcription='gauss-lobatto', optimizer='SLSQP
     p.driver = om.pyOptSparseDriver()
     p.driver.options['optimizer'] = optimizer
     if optimizer == 'SNOPT':
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
         p.driver.opt_settings['Major iterations limit'] = 100
         p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
         p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
         if show_output:
             p.driver.opt_settings['iSumm'] = 6
     else:
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
     traj = make_traj(transcription=transcription, transcription_order=transcription_order,
                      compressed=compressed, connected=connected)

--- a/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, pyOptSparseDriver, SqliteRecorder
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 
@@ -127,9 +127,9 @@ def two_burn_orbit_raise_problem(transcription='gauss-lobatto', optimizer='SLSQP
                                  transcription_order=3, compressed=False,
                                  show_output=True, connected=False):
 
-    p = Problem(model=Group())
+    p = om.Problem(model=om.Group())
 
-    p.driver = pyOptSparseDriver()
+    p.driver = om.pyOptSparseDriver()
     p.driver.options['optimizer'] = optimizer
     if optimizer == 'SNOPT':
         p.driver.options['dynamic_simul_derivs'] = True
@@ -150,7 +150,7 @@ def two_burn_orbit_raise_problem(transcription='gauss-lobatto', optimizer='SLSQP
     # Needed to move the direct solver down into the phases for use with MPI.
     #  - After moving down, used fewer iterations (about 30 less)
 
-    p.driver.add_recorder(SqliteRecorder('two_burn_orbit_raise_example.db'))
+    p.driver.add_recorder(om.SqliteRecorder('two_burn_orbit_raise_example.db'))
 
     p.setup(check=True)
 

--- a/dymos/examples/finite_burn_orbit_raise/test/test_finite_burn_eom.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_finite_burn_eom.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 
 from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
 
@@ -17,9 +17,9 @@ class TestFiniteBurnEOM(unittest.TestCase):
     def setUpClass(cls):
         nn = 2
 
-        p = cls.p = Problem(model=Group())
+        p = cls.p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         p.model.add_subsystem('ode', subsys=FiniteBurnODE(num_nodes=nn), promotes_inputs=['*'],
                               promotes_outputs=['*'])

--- a/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
@@ -16,18 +16,18 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         import matplotlib.pyplot as plt
 
-        from openmdao.api import Problem, Group, pyOptSparseDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
         from openmdao.utils.general_utils import set_pyoptsparse_opt
 
-        from dymos import Phase, GaussLobatto, RungeKutta, Trajectory
+        import dymos as dm
         from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
 
-        traj = Trajectory()
-        p = Problem(model=Group())
+        traj = dm.Trajectory()
+        p = om.Problem(model=om.Group())
         p.model.add_subsystem('traj', traj)
 
-        p.driver = pyOptSparseDriver()
+        p.driver = om.pyOptSparseDriver()
         _, optimizer = set_pyoptsparse_opt('SNOPT', fallback=True)
         p.driver.options['optimizer'] = optimizer
 
@@ -37,8 +37,8 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         # First Phase (burn)
 
-        burn1 = Phase(ode_class=FiniteBurnODE,
-                      transcription=GaussLobatto(num_segments=10, order=3, compressed=True))
+        burn1 = dm.Phase(ode_class=FiniteBurnODE,
+                         transcription=dm.GaussLobatto(num_segments=10, order=3, compressed=True))
 
         burn1 = traj.add_phase('burn1', burn1)
 
@@ -53,8 +53,8 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
                           scaler=0.01, lower=-30, upper=30)
 
         # Second Phase (Coast)
-        coast = Phase(ode_class=FiniteBurnODE,
-                      transcription=RungeKutta(num_segments=20, compressed=True))
+        coast = dm.Phase(ode_class=FiniteBurnODE,
+                         transcription=dm.RungeKutta(num_segments=20, compressed=True))
 
         traj.add_phase('coast', coast)
 
@@ -69,8 +69,8 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         # Third Phase (burn)
 
-        burn2 = Phase(ode_class=FiniteBurnODE,
-                      transcription=GaussLobatto(num_segments=10, order=3, compressed=True))
+        burn2 = dm.Phase(ode_class=FiniteBurnODE,
+                         transcription=dm.GaussLobatto(num_segments=10, order=3, compressed=True))
 
         traj.add_phase('burn2', burn2)
 
@@ -100,7 +100,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
         traj.link_phases(phases=['burn1', 'burn2'], vars=['accel'])
 
         # Finish Problem Setup
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True, force_alloc_complex=True)
 

--- a/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
@@ -31,7 +31,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
         _, optimizer = set_pyoptsparse_opt('SNOPT', fallback=True)
         p.driver.options['optimizer'] = optimizer
 
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         traj.add_design_parameter('c', opt=False, val=1.5, units='DU/TU')
 

--- a/dymos/examples/min_time_climb/aero/aero.py
+++ b/dymos/examples/min_time_climb/aero/aero.py
@@ -2,8 +2,7 @@ from __future__ import absolute_import
 
 import numpy as np
 
-from openmdao.api import Group
-
+import openmdao.api as om
 from .dynamic_pressure_comp import DynamicPressureComp
 from .lift_drag_force_comp import LiftDragForceComp
 from .cd0_comp import CD0Comp
@@ -14,7 +13,7 @@ from .cd_comp import CDComp
 from .mach_comp import MachComp
 
 
-class AeroGroup(Group):
+class AeroGroup(om.Group):
     """
     The purpose of the AeroGroup is to compute the aerodynamic forces on the
     aircraft in the body frame.

--- a/dymos/examples/min_time_climb/aero/cd0_comp.py
+++ b/dymos/examples/min_time_climb/aero/cd0_comp.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class CD0Comp(ExplicitComponent):
+class CD0Comp(om.ExplicitComponent):
     """ Computes the zero-lift drag coefficient
     """
     def initialize(self):

--- a/dymos/examples/min_time_climb/aero/cd_comp.py
+++ b/dymos/examples/min_time_climb/aero/cd_comp.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class CDComp(ExplicitComponent):
+class CDComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)

--- a/dymos/examples/min_time_climb/aero/cl_comp.py
+++ b/dymos/examples/min_time_climb/aero/cl_comp.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class CLComp(ExplicitComponent):
+class CLComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)

--- a/dymos/examples/min_time_climb/aero/cla_comp.py
+++ b/dymos/examples/min_time_climb/aero/cla_comp.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class CLaComp(ExplicitComponent):
+class CLaComp(om.ExplicitComponent):
     """ Computes the alpha lift coefficient for induced drag
 
     """

--- a/dymos/examples/min_time_climb/aero/dynamic_pressure_comp.py
+++ b/dymos/examples/min_time_climb/aero/dynamic_pressure_comp.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class DynamicPressureComp(ExplicitComponent):
+class DynamicPressureComp(om.ExplicitComponent):
     def initialize(self):
         self.options.declare('num_nodes', types=int)
 

--- a/dymos/examples/min_time_climb/aero/kappa_comp.py
+++ b/dymos/examples/min_time_climb/aero/kappa_comp.py
@@ -1,10 +1,10 @@
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class KappaComp(ExplicitComponent):
-    """ Computes the term kappa in the drag equation:
+class KappaComp(om.ExplicitComponent):
+    r""" Computes the term kappa in the drag equation:
 
     .. math::
 

--- a/dymos/examples/min_time_climb/aero/lift_drag_force_comp.py
+++ b/dymos/examples/min_time_climb/aero/lift_drag_force_comp.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class LiftDragForceComp(ExplicitComponent):
+class LiftDragForceComp(om.ExplicitComponent):
     """
     Compute the aerodynamic forces on the vehicle in the wind axis frame
     (lift, drag, cross) force.

--- a/dymos/examples/min_time_climb/aero/mach_comp.py
+++ b/dymos/examples/min_time_climb/aero/mach_comp.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class MachComp(ExplicitComponent):
+class MachComp(om.ExplicitComponent):
     """ Compute the Mach number based on vehicle airspeed and local speed
     of sound.
     """

--- a/dymos/examples/min_time_climb/aero/test/test_aerodynamics.py
+++ b/dymos/examples/min_time_climb/aero/test/test_aerodynamics.py
@@ -6,7 +6,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 
 from dymos.examples.min_time_climb.aero import AeroGroup
 
@@ -14,10 +14,10 @@ from dymos.examples.min_time_climb.aero import AeroGroup
 class TestAeroGroup(unittest.TestCase):
 
     def setUp(self):
-        self.prob = Problem(model=Group())
+        self.prob = om.Problem(model=om.Group())
         nn = 5
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
 
         ivc.add_output('rho', val=0.0001 * np.ones(nn), units='kg/m**3')
         ivc.add_output('v', val=0.0001 * np.ones(nn), units='m/s')

--- a/dymos/examples/min_time_climb/aero/test/test_cd0_comp.py
+++ b/dymos/examples/min_time_climb/aero/test/test_cd0_comp.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from dymos.examples.min_time_climb.aero.cd0_comp import CD0Comp
@@ -22,9 +22,9 @@ class TestCD0Comp(unittest.TestCase):
     def test_visual_inspection(self):
         n = 500
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
 
         ivc.add_output(name='mach', units=None, val=np.zeros(n))
 
@@ -48,9 +48,9 @@ class TestCD0Comp(unittest.TestCase):
 
         n = 10
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
 
         ivc.add_output(name='mach', units=None, val=np.zeros(n))
 

--- a/dymos/examples/min_time_climb/aero/test/test_cla_comp.py
+++ b/dymos/examples/min_time_climb/aero/test/test_cla_comp.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from dymos.examples.min_time_climb.aero.cla_comp import CLaComp
@@ -23,9 +23,9 @@ class TestCLaComp(unittest.TestCase):
     def test_visual_inspection(self):
         n = 500
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
 
         ivc.add_output(name='mach', units=None, val=np.zeros(n))
 
@@ -49,9 +49,9 @@ class TestCLaComp(unittest.TestCase):
 
         n = 10
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
 
         ivc.add_output(name='mach', units=None, val=np.zeros(n))
 

--- a/dymos/examples/min_time_climb/aero/test/test_kappa_comp.py
+++ b/dymos/examples/min_time_climb/aero/test/test_kappa_comp.py
@@ -14,7 +14,7 @@ assert_almost_equal = np.testing.assert_almost_equal
 import matplotlib
 matplotlib.use('Agg')
 
-SHOW_PLOTS = True
+SHOW_PLOTS = False
 
 
 class TestCLaComp(unittest.TestCase):

--- a/dymos/examples/min_time_climb/aero/test/test_kappa_comp.py
+++ b/dymos/examples/min_time_climb/aero/test/test_kappa_comp.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from dymos.examples.min_time_climb.aero.kappa_comp import KappaComp
@@ -22,9 +22,9 @@ class TestCLaComp(unittest.TestCase):
     def test_visual_inspection(self):
         n = 500
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
 
         ivc.add_output(name='mach', units=None, val=np.zeros(n))
 
@@ -48,9 +48,9 @@ class TestCLaComp(unittest.TestCase):
 
         n = 10
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
 
         ivc.add_output(name='mach', units=None, val=np.zeros(n))
 

--- a/dymos/examples/min_time_climb/doc/test_doc_min_time_climb.py
+++ b/dymos/examples/min_time_climb/doc/test_doc_min_time_climb.py
@@ -3,7 +3,7 @@ from __future__ import print_function, absolute_import, division
 import unittest
 
 import matplotlib
-matplotlib.use('Agg')
+# matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
@@ -26,8 +26,14 @@ class TestMinTimeClimbForDocs(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.pyOptSparseDriver()
-        p.driver.options['optimizer'] = 'SLSQP'
-        p.driver.declare_coloring()
+        p.driver.options['optimizer'] = 'SNOPT'
+        p.driver.opt_settings['iSumm'] = 6
+
+        # Note this problem can be problematic for the coloring algorithm since the DirectSolver
+        # introduces a some noise when solving.  Here we just specify the acceptable tolerance
+        # and set orders=None to prevent the coloring algorithm from trying to find the tolerance
+        # automatically.
+        p.driver.declare_coloring(tol=1.0E-9, orders=None)
 
         #
         # Instantiate the trajectory and phase
@@ -35,7 +41,7 @@ class TestMinTimeClimbForDocs(unittest.TestCase):
         traj = dm.Trajectory()
 
         phase = dm.Phase(ode_class=MinTimeClimbODE,
-                         transcription=dm.GaussLobatto(num_segments=20, compressed=True))
+                         transcription=dm.GaussLobatto(num_segments=15, compressed=True))
 
         traj.add_phase('phase0', phase)
 

--- a/dymos/examples/min_time_climb/doc/test_doc_min_time_climb.py
+++ b/dymos/examples/min_time_climb/doc/test_doc_min_time_climb.py
@@ -13,7 +13,7 @@ class TestMinTimeClimbForDocs(unittest.TestCase):
     def test_min_time_climb_for_docs_gauss_lobatto(self):
         import matplotlib.pyplot as plt
 
-        from openmdao.api import Problem, Group, pyOptSparseDriver, DirectSolver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
 
         import dymos as dm
@@ -23,9 +23,9 @@ class TestMinTimeClimbForDocs(unittest.TestCase):
         #
         # Instantiate the problem and configure the optimization driver
         #
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = pyOptSparseDriver()
+        p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'SLSQP'
         p.driver.options['dynamic_simul_derivs'] = True
 
@@ -83,7 +83,7 @@ class TestMinTimeClimbForDocs(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', ref=1.0)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         #
         # Setup the problem and set the initial guess

--- a/dymos/examples/min_time_climb/doc/test_doc_min_time_climb.py
+++ b/dymos/examples/min_time_climb/doc/test_doc_min_time_climb.py
@@ -3,7 +3,7 @@ from __future__ import print_function, absolute_import, division
 import unittest
 
 import matplotlib
-# matplotlib.use('Agg')
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
@@ -26,8 +26,7 @@ class TestMinTimeClimbForDocs(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.pyOptSparseDriver()
-        p.driver.options['optimizer'] = 'SNOPT'
-        p.driver.opt_settings['iSumm'] = 6
+        p.driver.options['optimizer'] = 'SLSQP'
 
         # Note this problem can be problematic for the coloring algorithm since the DirectSolver
         # introduces a some noise when solving.  Here we just specify the acceptable tolerance

--- a/dymos/examples/min_time_climb/doc/test_doc_min_time_climb.py
+++ b/dymos/examples/min_time_climb/doc/test_doc_min_time_climb.py
@@ -27,7 +27,7 @@ class TestMinTimeClimbForDocs(unittest.TestCase):
 
         p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'SLSQP'
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         #
         # Instantiate the trajectory and phase

--- a/dymos/examples/min_time_climb/min_time_climb_ode.py
+++ b/dymos/examples/min_time_climb/min_time_climb_ode.py
@@ -1,26 +1,24 @@
 from __future__ import print_function, division, absolute_import
 
-from openmdao.api import Group
-
-from dymos import declare_time, declare_state, declare_parameter
-
+import openmdao.api as om
+import dymos as dm
 from ...models.atmosphere import USatm1976Comp
 from .aero import AeroGroup
 from .prop import PropGroup
 from ...models.eom import FlightPathEOM2D
 
 
-@declare_time(units='s')
-@declare_state('r', units='m', rate_source='flight_dynamics.r_dot')
-@declare_state('h', units='m', rate_source='flight_dynamics.h_dot', targets=['h'])
-@declare_state('v', units='m/s', rate_source='flight_dynamics.v_dot', targets=['v'])
-@declare_state('gam', units='rad', rate_source='flight_dynamics.gam_dot', targets=['gam'])
-@declare_state('m', units='kg', rate_source='prop.m_dot', targets=['m'])
-@declare_parameter('alpha', targets=['alpha'], units='rad')
-@declare_parameter('Isp', targets=['Isp'], units='s')
-@declare_parameter('S', targets=['S'], units='m**2')
-@declare_parameter('throttle', targets=['throttle'], units=None)
-class MinTimeClimbODE(Group):
+@dm.declare_time(units='s')
+@dm.declare_state('r', units='m', rate_source='flight_dynamics.r_dot')
+@dm.declare_state('h', units='m', rate_source='flight_dynamics.h_dot', targets=['h'])
+@dm.declare_state('v', units='m/s', rate_source='flight_dynamics.v_dot', targets=['v'])
+@dm.declare_state('gam', units='rad', rate_source='flight_dynamics.gam_dot', targets=['gam'])
+@dm.declare_state('m', units='kg', rate_source='prop.m_dot', targets=['m'])
+@dm.declare_parameter('alpha', targets=['alpha'], units='rad')
+@dm.declare_parameter('Isp', targets=['Isp'], units='s')
+@dm.declare_parameter('S', targets=['S'], units='m**2')
+@dm.declare_parameter('throttle', targets=['throttle'], units=None)
+class MinTimeClimbODE(om.Group):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)

--- a/dymos/examples/min_time_climb/prop/max_thrust_comp.py
+++ b/dymos/examples/min_time_climb/prop/max_thrust_comp.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division, absolute_import
 import numpy as np
-from openmdao.api import MetaModelStructuredComp
+import openmdao.api as om
 
 _FT2M = 0.3048
 
@@ -62,7 +62,7 @@ THR_DATA = {'mach': np.array([0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8],
                                 ]).reshape((10, 10))}
 
 
-class MaxThrustComp(MetaModelStructuredComp):
+class MaxThrustComp(om.MetaModelStructuredComp):
     """ Interpolates max thrust for 2 J79 jet engines. """
 
     def setup(self):

--- a/dymos/examples/min_time_climb/prop/mdot_comp.py
+++ b/dymos/examples/min_time_climb/prop/mdot_comp.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class MassFlowRateComp(ExplicitComponent):
+class MassFlowRateComp(om.ExplicitComponent):
     """ Computes mass flow rate for the F4's 2 J79 engines at full throttle. """
 
     def initialize(self):

--- a/dymos/examples/min_time_climb/prop/prop.py
+++ b/dymos/examples/min_time_climb/prop/prop.py
@@ -1,13 +1,12 @@
 from __future__ import absolute_import
 
-from openmdao.api import Group
-
+import openmdao.api as om
 from .mdot_comp import MassFlowRateComp
 from .max_thrust_comp import MaxThrustComp
 from .thrust_comp import ThrustComp
 
 
-class PropGroup(Group):
+class PropGroup(om.Group):
     """
     The purpose of the PropGroup is to compute the propulsive forces on the
     aircraft in the body frame.

--- a/dymos/examples/min_time_climb/prop/test/test_max_thrust_comp.py
+++ b/dymos/examples/min_time_climb/prop/test/test_max_thrust_comp.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 
 from dymos.examples.min_time_climb.prop.max_thrust_comp import MaxThrustComp, THR_DATA, _LBF2N
 
@@ -15,9 +15,9 @@ class TestBrysonThrustComp(unittest.TestCase):
     def test_grid_values(self):
         n = 10
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='h', val=np.zeros(n), units='ft')
         ivc.add_output(name='mach', val=np.zeros(n), units=None)
 

--- a/dymos/examples/min_time_climb/prop/thrust_comp.py
+++ b/dymos/examples/min_time_climb/prop/thrust_comp.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class ThrustComp(ExplicitComponent):
+class ThrustComp(om.ExplicitComponent):
     """ Computes mass flow rate for the F4's 2 J79 engines at full throttle. """
 
     def initialize(self):

--- a/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
+++ b/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
@@ -17,7 +17,7 @@ def min_time_climb(optimizer='SLSQP', num_seg=3, transcription='gauss-lobatto',
 
     p.driver = om.pyOptSparseDriver()
     p.driver.options['optimizer'] = optimizer
-    p.driver.declare_coloring()
+    p.driver.declare_coloring(tol=1.0E-9, orders=None)
 
     if optimizer == 'SNOPT':
         p.driver.opt_settings['Major iterations limit'] = 1000
@@ -27,7 +27,6 @@ def min_time_climb(optimizer='SLSQP', num_seg=3, transcription='gauss-lobatto',
         p.driver.opt_settings['Function precision'] = 1.0E-12
         p.driver.opt_settings['Linesearch tolerance'] = 0.1
         p.driver.opt_settings['Major step limit'] = 0.5
-        # p.driver.opt_settings['Verify level'] = 3
 
     t = {'gauss-lobatto': dm.GaussLobatto(num_segments=num_seg, order=transcription_order),
          'radau-ps': dm.Radau(num_segments=num_seg, order=transcription_order),

--- a/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
+++ b/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 
 import unittest
 
-from openmdao.api import Problem, Group, pyOptSparseDriver, DirectSolver
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 import dymos as dm
 from dymos.examples.min_time_climb.min_time_climb_ode import MinTimeClimbODE
@@ -13,9 +13,9 @@ from dymos.utils.testing_utils import use_tempdirs
 def min_time_climb(optimizer='SLSQP', num_seg=3, transcription='gauss-lobatto',
                    transcription_order=3, force_alloc_complex=False):
 
-    p = Problem(model=Group())
+    p = om.Problem(model=om.Group())
 
-    p.driver = pyOptSparseDriver()
+    p.driver = om.pyOptSparseDriver()
     p.driver.options['optimizer'] = optimizer
     p.driver.options['dynamic_simul_derivs'] = True
 
@@ -81,7 +81,7 @@ def min_time_climb(optimizer='SLSQP', num_seg=3, transcription='gauss-lobatto',
     # Minimize time at the end of the phase
     phase.add_objective('time', loc='final', ref=1.0)
 
-    p.model.linear_solver = DirectSolver()
+    p.model.linear_solver = om.DirectSolver()
 
     p.setup(check=True, force_alloc_complex=force_alloc_complex)
 

--- a/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
+++ b/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
@@ -17,7 +17,7 @@ def min_time_climb(optimizer='SLSQP', num_seg=3, transcription='gauss-lobatto',
 
     p.driver = om.pyOptSparseDriver()
     p.driver.options['optimizer'] = optimizer
-    p.driver.options['dynamic_simul_derivs'] = True
+    p.driver.declare_coloring()
 
     if optimizer == 'SNOPT':
         p.driver.opt_settings['Major iterations limit'] = 1000

--- a/dymos/examples/ssto/doc/test_doc_ssto_earth.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_earth.py
@@ -21,7 +21,7 @@ class TestDocSSTOEarth(unittest.TestCase):
         #
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         from dymos.examples.ssto.launch_vehicle_ode import LaunchVehicleODE
 

--- a/dymos/examples/ssto/doc/test_doc_ssto_earth.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_earth.py
@@ -12,16 +12,15 @@ class TestDocSSTOEarth(unittest.TestCase):
 
     def test_doc_ssto_earth(self):
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, DirectSolver, \
-            pyOptSparseDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
         import dymos as dm
 
         #
         # Setup and solve the optimal control problem
         #
-        p = Problem(model=Group())
-        p.driver = pyOptSparseDriver()
+        p = om.Problem(model=om.Group())
+        p.driver = om.pyOptSparseDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
         from dymos.examples.ssto.launch_vehicle_ode import LaunchVehicleODE
@@ -61,7 +60,7 @@ class TestDocSSTOEarth(unittest.TestCase):
 
         phase.add_objective('time', loc='final', scaler=0.01)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         #
         # Setup and set initial values

--- a/dymos/examples/ssto/doc/test_doc_ssto_linear_tangent_guidance.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_linear_tangent_guidance.py
@@ -13,15 +13,14 @@ class TestDocSSTOLinearTangentGuidance(unittest.TestCase):
     def test_doc_ssto_linear_tangent_guidance(self):
         import numpy as np
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, ExplicitComponent, DirectSolver, \
-            pyOptSparseDriver
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
         import dymos as dm
         from dymos.examples.plotting import plot_results
 
         g = 1.61544  # lunar gravity, m/s**2
 
-        class LaunchVehicle2DEOM(ExplicitComponent):
+        class LaunchVehicle2DEOM(om.ExplicitComponent):
             """
             Simple 2D Cartesian Equations of Motion for a launch vehicle subject to thrust and drag.
             """
@@ -144,7 +143,7 @@ class TestDocSSTOLinearTangentGuidance(unittest.TestCase):
                 jacobian['mdot', 'thrust'] = -1.0 / (g * Isp)
                 jacobian['mdot', 'Isp'] = F_T / (g * Isp ** 2)
 
-        class LinearTangentGuidanceComp(ExplicitComponent):
+        class LinearTangentGuidanceComp(om.ExplicitComponent):
             """ Compute pitch angle from static controls governing linear expression for
                 pitch angle tangent as function of time.
             """
@@ -210,7 +209,7 @@ class TestDocSSTOLinearTangentGuidance(unittest.TestCase):
         @dm.declare_parameter('a_ctrl', targets=['guidance.a_ctrl'], units='1/s')
         @dm.declare_parameter('b_ctrl', targets=['guidance.b_ctrl'], units=None)
         @dm.declare_parameter('Isp', targets=['eom.Isp'], units='s')
-        class LaunchVehicleLinearTangentODE(Group):
+        class LaunchVehicleLinearTangentODE(om.Group):
             """
             The LaunchVehicleLinearTangentODE for this case consists of a guidance component and
             the EOM.  Guidance is simply an OpenMDAO ExecComp which computes the arctangent of the
@@ -229,9 +228,9 @@ class TestDocSSTOLinearTangentGuidance(unittest.TestCase):
         #
         # Setup and solve the optimal control problem
         #
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = pyOptSparseDriver()
+        p.driver = om.pyOptSparseDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
         traj = dm.Trajectory()
@@ -261,7 +260,7 @@ class TestDocSSTOLinearTangentGuidance(unittest.TestCase):
 
         phase.add_objective('time', index=-1, scaler=0.01)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         phase.add_timeseries_output('guidance.theta', units='deg')
 

--- a/dymos/examples/ssto/doc/test_doc_ssto_linear_tangent_guidance.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_linear_tangent_guidance.py
@@ -231,7 +231,7 @@ class TestDocSSTOLinearTangentGuidance(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.pyOptSparseDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         traj = dm.Trajectory()
         p.model.add_subsystem('traj', traj)

--- a/dymos/examples/ssto/doc/test_doc_ssto_polynomial_control.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_polynomial_control.py
@@ -226,7 +226,7 @@ class TestDocSSTOPolynomialControl(unittest.TestCase):
         #
         p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'SLSQP'
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         #
         # We don't strictly need to define a linear solver here since our problem is entirely

--- a/dymos/examples/ssto/launch_vehicle_2d_eom_comp.py
+++ b/dymos/examples/ssto/launch_vehicle_2d_eom_comp.py
@@ -2,13 +2,12 @@ from __future__ import print_function, division
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
-
+import openmdao.api as om
 _g = {'earth': 9.80665,
       'moon': 1.61544}
 
 
-class LaunchVehicle2DEOM(ExplicitComponent):
+class LaunchVehicle2DEOM(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)

--- a/dymos/examples/ssto/launch_vehicle_ode.py
+++ b/dymos/examples/ssto/launch_vehicle_ode.py
@@ -1,23 +1,22 @@
 from __future__ import print_function, division, absolute_import
 
-from openmdao.api import Group
+import openmdao.api as om
 
-from dymos import declare_time, declare_state, declare_parameter
-
+import dymos as dm
 from .log_atmosphere_comp import LogAtmosphereComp
 from .launch_vehicle_2d_eom_comp import LaunchVehicle2DEOM
 
 
-@declare_time(units='s')
-@declare_state('x', rate_source='eom.xdot', units='m')
-@declare_state('y', rate_source='eom.ydot', targets=['atmos.y'], units='m')
-@declare_state('vx', rate_source='eom.vxdot', targets=['eom.vx'], units='m/s')
-@declare_state('vy', rate_source='eom.vydot', targets=['eom.vy'], units='m/s')
-@declare_state('m', rate_source='eom.mdot', targets=['eom.m'], units='kg')
-@declare_parameter('thrust', targets=['eom.thrust'], units='N')
-@declare_parameter('theta', targets=['eom.theta'], units='rad')
-@declare_parameter('Isp', targets=['eom.Isp'], units='s')
-class LaunchVehicleODE(Group):
+@dm.declare_time(units='s')
+@dm.declare_state('x', rate_source='eom.xdot', units='m')
+@dm.declare_state('y', rate_source='eom.ydot', targets=['atmos.y'], units='m')
+@dm.declare_state('vx', rate_source='eom.vxdot', targets=['eom.vx'], units='m/s')
+@dm.declare_state('vy', rate_source='eom.vydot', targets=['eom.vy'], units='m/s')
+@dm.declare_state('m', rate_source='eom.mdot', targets=['eom.m'], units='kg')
+@dm.declare_parameter('thrust', targets=['eom.thrust'], units='N')
+@dm.declare_parameter('theta', targets=['eom.theta'], units='rad')
+@dm.declare_parameter('Isp', targets=['eom.Isp'], units='s')
+class LaunchVehicleODE(om.Group):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int,

--- a/dymos/examples/ssto/log_atmosphere_comp.py
+++ b/dymos/examples/ssto/log_atmosphere_comp.py
@@ -2,10 +2,10 @@ from __future__ import print_function, division, absolute_import
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class LogAtmosphereComp(ExplicitComponent):
+class LogAtmosphereComp(om.ExplicitComponent):
     def initialize(self):
         self.options.declare('num_nodes', types=int)
         self.options.declare('rho_ref', types=float, default=1.225,

--- a/dymos/examples/ssto/test/test_simulate_root_trajectory.py
+++ b/dymos/examples/ssto/test/test_simulate_root_trajectory.py
@@ -18,14 +18,13 @@ class TestSSTOSimulateRootTrajectory(unittest.TestCase):
         """
         import numpy as np
         import matplotlib.pyplot as plt
-        from openmdao.api import Problem, Group, ExplicitComponent, DirectSolver, \
-            pyOptSparseDriver, ExecComp
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
         import dymos as dm
 
         g = 1.61544  # lunar gravity, m/s**2
 
-        class LaunchVehicle2DEOM(ExplicitComponent):
+        class LaunchVehicle2DEOM(om.ExplicitComponent):
             """
             Simple 2D Cartesian Equations of Motion for a launch vehicle subject to thrust and drag.
             """
@@ -148,7 +147,7 @@ class TestSSTOSimulateRootTrajectory(unittest.TestCase):
                 jacobian['mdot', 'thrust'] = -1.0 / (g * Isp)
                 jacobian['mdot', 'Isp'] = F_T / (g * Isp ** 2)
 
-        class LaunchVehicleLinearTangentODE(Group):
+        class LaunchVehicleLinearTangentODE(om.Group):
             """
             The LaunchVehicleLinearTangentODE for this case consists of a guidance component and
             the EOM.  Guidance is simply an OpenMDAO ExecComp which computes the arctangent of the
@@ -162,10 +161,10 @@ class TestSSTOSimulateRootTrajectory(unittest.TestCase):
             def setup(self):
                 nn = self.options['num_nodes']
 
-                self.add_subsystem('guidance', ExecComp('theta=arctan(tan_theta)',
-                                                        theta={'value': np.ones(nn),
-                                                               'units': 'rad'},
-                                                        tan_theta={'value': np.ones(nn)}))
+                self.add_subsystem('guidance', om.ExecComp('theta=arctan(tan_theta)',
+                                                           theta={'value': np.ones(nn),
+                                                                  'units': 'rad'},
+                                                           tan_theta={'value': np.ones(nn)}))
 
                 self.add_subsystem('eom', LaunchVehicle2DEOM(num_nodes=nn))
 
@@ -176,7 +175,7 @@ class TestSSTOSimulateRootTrajectory(unittest.TestCase):
         #
         traj = dm.Trajectory()
 
-        p = Problem(model=traj)
+        p = om.Problem(model=traj)
 
         phase = dm.Phase(ode_class=LaunchVehicleLinearTangentODE,
                          transcription=dm.Radau(num_segments=20, order=3, compressed=False))
@@ -230,7 +229,7 @@ class TestSSTOSimulateRootTrajectory(unittest.TestCase):
         #
         # Set the optimizer
         #
-        p.driver = pyOptSparseDriver()
+        p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'SLSQP'
         p.driver.options['dynamic_simul_derivs'] = True
 
@@ -240,7 +239,7 @@ class TestSSTOSimulateRootTrajectory(unittest.TestCase):
         # failing to do so can cause incorrect derivatives if iterative processes are ever
         # introduced to the system.
         #
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True)
 

--- a/dymos/examples/ssto/test/test_simulate_root_trajectory.py
+++ b/dymos/examples/ssto/test/test_simulate_root_trajectory.py
@@ -231,7 +231,7 @@ class TestSSTOSimulateRootTrajectory(unittest.TestCase):
         #
         p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'SLSQP'
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         #
         # We don't strictly need to define a linear solver here since our problem is entirely

--- a/dymos/models/atmosphere/atmos_1976.py
+++ b/dymos/models/atmosphere/atmos_1976.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 import numpy as np
 from scipy.interpolate import Akima1DInterpolator as Akima
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 """United States standard atmosphere 1976 tables, data
 obtained from http://www.digitaldutch.com/atmoscalc/index.htm"""
@@ -133,7 +133,7 @@ visc_interp_deriv = visc_interp.derivative(1)
 drho_dh_interp_deriv = rho_interp_deriv.derivative(1)
 
 
-class USatm1976Comp(ExplicitComponent):
+class USatm1976Comp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int,

--- a/dymos/models/atmosphere/test/test_atmos.py
+++ b/dymos/models/atmosphere/test/test_atmos.py
@@ -10,7 +10,7 @@ from dymos.models.atmosphere.atmos_1976 import USatm1976Comp
 
 assert_almost_equal = np.testing.assert_almost_equal
 
-SHOW_PLOTS = True
+SHOW_PLOTS = False
 
 if SHOW_PLOTS:
     import matplotlib

--- a/dymos/models/atmosphere/test/test_atmos.py
+++ b/dymos/models/atmosphere/test/test_atmos.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division, absolute_import
 import unittest
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 from dymos.models.atmosphere.atmos_1976 import USatm1976Comp
@@ -46,9 +46,9 @@ class TestAtmosphere(unittest.TestCase):
     def test_temperature_comp(self):
         n = reference.shape[0]
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', subsys=IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', subsys=om.IndepVarComp(), promotes_outputs=['*'])
         ivc.add_output(name='alt_m', val=reference[:, 0], units='m')
 
         p.model.add_subsystem('atmos', subsys=USatm1976Comp(num_nodes=n))

--- a/dymos/models/eom/flight_path_eom_2d.py
+++ b/dymos/models/eom/flight_path_eom_2d.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class FlightPathEOM2D(ExplicitComponent):
+class FlightPathEOM2D(om.ExplicitComponent):
     """
     Computes the position and velocity equations of motion using a 2D flight path
     parameterization of states per equations 4.42 - 4.46 of _[1].
@@ -159,8 +159,8 @@ class FlightPathEOM2D(ExplicitComponent):
 
 if __name__ == "__main__":
 
-    from openmdao.api import Problem
-    p = Problem()
+    import openmdao.api as om
+    p = om.Problem()
     p.model = FlightPathEOM2D(num_nodes=2)
 
     p.setup(force_alloc_complex=True)

--- a/dymos/models/eom/test/test_flight_path_eom_2d.py
+++ b/dymos/models/eom/test/test_flight_path_eom_2d.py
@@ -5,21 +5,21 @@ import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from openmdao.api import Problem, Group, pyOptSparseDriver
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
-from dymos import Phase, GaussLobatto, declare_time, declare_state
+import dymos as dm
 from dymos.models.eom import FlightPathEOM2D
 
 OPTIMIZER = 'SLSQP'
 SHOW_PLOTS = False
 
 
-@declare_time(units='s')
-@declare_state(name='r', rate_source='r_dot', units='m')
-@declare_state(name='h', rate_source='h_dot', units='m')
-@declare_state(name='gam', rate_source='gam_dot', targets='gam', units='rad')
-@declare_state(name='v', rate_source='v_dot', targets='v', units='m/s')
+@dm.declare_time(units='s')
+@dm.declare_state(name='r', rate_source='r_dot', units='m')
+@dm.declare_state(name='h', rate_source='h_dot', units='m')
+@dm.declare_state(name='gam', rate_source='gam_dot', targets='gam', units='rad')
+@dm.declare_state(name='v', rate_source='v_dot', targets='v', units='m/s')
 class _CannonballODE(FlightPathEOM2D):
     pass
 
@@ -27,17 +27,17 @@ class _CannonballODE(FlightPathEOM2D):
 class TestFlightPathEOM2D(unittest.TestCase):
 
     def setUp(self):
-        self.p = Problem(model=Group())
+        self.p = om.Problem(model=om.Group())
 
-        self.p.driver = pyOptSparseDriver()
+        self.p.driver = om.pyOptSparseDriver()
         self.p.driver.options['optimizer'] = OPTIMIZER
         if OPTIMIZER == 'SNOPT':
             self.p.driver.opt_settings['Major iterations limit'] = 50
             self.p.driver.opt_settings['iSumm'] = 6
             self.p.driver.opt_settings['Verify level'] = 3
 
-        phase = Phase(ode_class=_CannonballODE,
-                      transcription=GaussLobatto(num_segments=15, order=3, compressed=False))
+        phase = dm.Phase(ode_class=_CannonballODE,
+                         transcription=dm.GaussLobatto(num_segments=15, order=3, compressed=False))
 
         self.p.model.add_subsystem('phase0', phase)
 

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -4,10 +4,10 @@ from six import string_types
 
 import numpy as np
 
-from openmdao.api import OptionsDictionary
+import openmdao.api as om
 
 
-class ControlOptionsDictionary(OptionsDictionary):
+class ControlOptionsDictionary(om.OptionsDictionary):
     """
     An OptionsDictionary specific to controls.
     """
@@ -118,7 +118,7 @@ class ControlOptionsDictionary(OptionsDictionary):
                           'to the default value of True.')
 
 
-class PolynomialControlOptionsDictionary(OptionsDictionary):
+class PolynomialControlOptionsDictionary(om.OptionsDictionary):
     """
     An OptionsDictionary specific to controls.
     """
@@ -211,7 +211,7 @@ class PolynomialControlOptionsDictionary(OptionsDictionary):
                           'to the default value of True.')
 
 
-class DesignParameterOptionsDictionary(OptionsDictionary):
+class DesignParameterOptionsDictionary(om.OptionsDictionary):
     """
     An OptionsDictionary specific to design parameters.
     """
@@ -291,7 +291,7 @@ class TrajDesignParameterOptionsDictionary(DesignParameterOptionsDictionary):
         self._dict.pop('targets')
 
 
-class InputParameterOptionsDictionary(OptionsDictionary):
+class InputParameterOptionsDictionary(om.OptionsDictionary):
     """
     An OptionsDictionary specific to input parameters.
     """
@@ -338,7 +338,7 @@ class TrajInputParameterOptionsDictionary(InputParameterOptionsDictionary):
         self._dict.pop('targets')
 
 
-class StateOptionsDictionary(OptionsDictionary):
+class StateOptionsDictionary(om.OptionsDictionary):
     """
     An OptionsDictionary specific to controls.
     """
@@ -458,7 +458,7 @@ class StateOptionsDictionary(OptionsDictionary):
                           'set by a trajectory that links phases.')
 
 
-class TimeOptionsDictionary(OptionsDictionary):
+class TimeOptionsDictionary(om.OptionsDictionary):
     """
     An OptionsDictionary for time options
     """

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -925,7 +925,6 @@ class Phase(om.Group):
         transcription.setup_ode(self)
         transcription.setup_defects(self)
 
-        # self._setup_endpoint_conditions()
         transcription.setup_boundary_constraints('initial', self)
         transcription.setup_boundary_constraints('final', self)
         transcription.setup_path_constraints(self)
@@ -1082,8 +1081,6 @@ class Phase(om.Group):
 
         gd = self.options['transcription'].grid_data
         node_locations = gd.node_ptau[gd.subset_node_indices[nodes]]
-        # if self.options['compressed']:
-        #     node_locations = np.array(sorted(list(set(node_locations))))
         # Affine transform xs into tau space [-1, 1]
         _xs = np.asarray(xs).ravel()
         m = 2.0 / (_xs[-1] - _xs[0])

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
-from collections import Iterable
+from collections import Iterable, Sequence
 import inspect
 import warnings
 
@@ -10,8 +10,9 @@ import numpy as np
 
 from scipy import interpolate
 
-from openmdao.api import Problem, Group, SqliteRecorder
+import openmdao.api as om
 from openmdao.core.system import System
+import dymos as dm
 
 from .options import ControlOptionsDictionary, DesignParameterOptionsDictionary, \
     InputParameterOptionsDictionary, StateOptionsDictionary, TimeOptionsDictionary, \
@@ -23,7 +24,7 @@ from ..transcriptions.transcription_base import TranscriptionBase
 _unspecified = object()
 
 
-class Phase(Group):
+class Phase(om.Group):
     """
     The Phase object in Dymos.
 
@@ -115,7 +116,7 @@ class Phase(Group):
             Units in which the state variable is defined.  Internally components may use different
             units for the state variable, but the IndepVarComp which provides its value will provide
             it in these units, and collocation defects will use these units.  If units is not
-            specified here then the value as defined in the ODEOptions (@declare_state) will be
+            specified here then the value as defined in the ODEOptions (@dm.declare_state) will be
             used.
         val :  ndarray
             The default value of the state at the state discretization nodes of the phase.
@@ -619,8 +620,7 @@ class Phase(Group):
         self._path_constraints[name]['indices'] = indices
         self._path_constraints[name]['shape'] = shape
         self._path_constraints[name]['linear'] = linear
-        self._path_constraints[name]['units'] = units\
-
+        self._path_constraints[name]['units'] = units
         self.add_timeseries_output(name, output_name=constraint_name, units=units, shape=shape)
 
     def add_timeseries_output(self, name, output_name=None, units=None, shape=(1,)):
@@ -800,13 +800,13 @@ class Phase(Group):
         elif var in self.traj_parameter_options:
             return 'traj_parameter'
         elif var.endswith('_rate') and var[:-5] in self.control_options:
-                return 'control_rate'
+            return 'control_rate'
         elif var.endswith('_rate2') and var[:-6] in self.control_options:
-                return 'control_rate2'
+            return 'control_rate2'
         elif var.endswith('_rate') and var[:-5] in self.polynomial_control_options:
-                return 'polynomial_control_rate'
+            return 'polynomial_control_rate'
         elif var.endswith('_rate2') and var[:-6] in self.polynomial_control_options:
-                return 'polynomial_control_rate2'
+            return 'polynomial_control_rate2'
         else:
             return 'ode'
 
@@ -1043,9 +1043,9 @@ class Phase(Group):
 
         Parameters
         ----------
-        xs :  ndarray
+        xs :  ndarray or Sequence or None
             Array of integration variable values.
-        ys :  ndarray
+        ys :  ndarray or Sequence or None
             Array of control/state/parameter values.
         nodes : str or None
             The name of the node subset or None (default).
@@ -1123,12 +1123,12 @@ class Phase(Group):
 
         t = self.options['transcription']
 
-        sim_phase = Phase(from_phase=self,
-                          transcription=SolveIVP(grid_data=t.grid_data,
-                                                 method=method,
-                                                 atol=atol,
-                                                 rtol=rtol,
-                                                 output_nodes_per_seg=times_per_seg))
+        sim_phase = dm.Phase(from_phase=self,
+                             transcription=SolveIVP(grid_data=t.grid_data,
+                                                    method=method,
+                                                    atol=atol,
+                                                    rtol=rtol,
+                                                    output_nodes_per_seg=times_per_seg))
 
         return sim_phase
 
@@ -1231,14 +1231,14 @@ class Phase(Group):
 
         """
 
-        sim_prob = Problem(model=Group())
+        sim_prob = om.Problem(model=om.Group())
 
         sim_phase = self.get_simulation_phase(times_per_seg, method=method, atol=atol, rtol=rtol)
 
         sim_prob.model.add_subsystem(self.name, sim_phase)
 
         if record_file is not None:
-            rec = SqliteRecorder(record_file)
+            rec = om.SqliteRecorder(record_file)
             sim_prob.model.recording_options['includes'] = ['*.timeseries.*']
 
             sim_prob.model.add_recorder(rec)

--- a/dymos/phase/test/test_input_parameter_connections.py
+++ b/dymos/phase/test/test_input_parameter_connections.py
@@ -1,14 +1,14 @@
 import numpy as np
 
 import unittest
-from openmdao.api import ExplicitComponent, Group, Problem
-from dymos import ODEOptions, Phase, Radau, GaussLobatto
+import openmdao.api as om
+import dymos as dm
 
 
 n_traj = 4
 
 
-class MyComp(ExplicitComponent):
+class MyComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('n_traj', types=int)
@@ -28,8 +28,8 @@ class MyComp(ExplicitComponent):
         pass
 
 
-class MyODE(Group):
-    ode_options = ODEOptions()
+class MyODE(om.Group):
+    ode_options = dm.ODEOptions()
     ode_options.declare_time(units='s', targets=['comp.time'])
     ode_options.declare_state(name='F', rate_source='comp.y')
     ode_options.declare_parameter(name='alpha', shape=(n_traj, 2), targets='comp.alpha',
@@ -52,13 +52,13 @@ class TestStaticInputParameters(unittest.TestCase):
 
     def test_radau(self):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        phase = Phase(ode_class=MyODE,
-                      ode_init_kwargs={'n_traj': n_traj},
-                      transcription=Radau(num_segments=25,
-                                          order=3,
-                                          compressed=True))
+        phase = dm.Phase(ode_class=MyODE,
+                         ode_init_kwargs={'n_traj': n_traj},
+                         transcription=dm.Radau(num_segments=25,
+                                                order=3,
+                                                compressed=True))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -71,13 +71,13 @@ class TestStaticInputParameters(unittest.TestCase):
 
     def test_gauss_lobatto(self):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        phase = Phase(ode_class=MyODE,
-                      ode_init_kwargs={'n_traj': n_traj},
-                      transcription=GaussLobatto(num_segments=25,
-                                                 order=3,
-                                                 compressed=True))
+        phase = dm.Phase(ode_class=MyODE,
+                         ode_init_kwargs={'n_traj': n_traj},
+                         transcription=dm.GaussLobatto(num_segments=25,
+                                                       order=3,
+                                                       compressed=True))
 
         p.model.add_subsystem('phase0', phase)
 

--- a/dymos/phase/test/test_phase.py
+++ b/dymos/phase/test/test_phase.py
@@ -43,7 +43,7 @@ class TestPhaseBase(unittest.TestCase):
 
         p.driver = om.ScipyOptimizeDriver()
 
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=_A,
                          transcription=dm.GaussLobatto(num_segments=20, order=3, compressed=True))
@@ -76,7 +76,7 @@ class TestPhaseBase(unittest.TestCase):
 
         p.driver = om.ScipyOptimizeDriver()
 
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=_A(),
                          transcription=dm.GaussLobatto(num_segments=20, order=3, compressed=True))
@@ -147,7 +147,7 @@ class TestPhaseBase(unittest.TestCase):
 
         p.driver = om.ScipyOptimizeDriver()
 
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=16, order=3, compressed=True))
 
@@ -223,7 +223,7 @@ class TestPhaseBase(unittest.TestCase):
 
         p.driver = om.ScipyOptimizeDriver()
 
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=8, order=3, compressed=True))
@@ -271,7 +271,7 @@ class TestPhaseBase(unittest.TestCase):
 
         p.driver = om.ScipyOptimizeDriver()
 
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=8, order=3, compressed=True))
@@ -313,7 +313,7 @@ class TestPhaseBase(unittest.TestCase):
 
         p.driver = om.ScipyOptimizeDriver()
 
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.Radau(num_segments=20, order=3, compressed=True))
@@ -356,7 +356,7 @@ class TestPhaseBase(unittest.TestCase):
 
         p.driver = om.ScipyOptimizeDriver()
 
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=20,
@@ -402,7 +402,7 @@ class TestPhaseBase(unittest.TestCase):
 
         p.driver = om.ScipyOptimizeDriver()
 
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=20,
@@ -466,7 +466,7 @@ class TestPhaseBase(unittest.TestCase):
 
         p.driver = om.ScipyOptimizeDriver()
 
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=20,
@@ -527,7 +527,7 @@ class TestPhaseBase(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=20,

--- a/dymos/phase/test/test_phase.py
+++ b/dymos/phase/test/test_phase.py
@@ -3,9 +3,9 @@ from __future__ import print_function, division, absolute_import
 import unittest
 import warnings
 
-from openmdao.api import ExplicitComponent, Group, Problem, ScipyOptimizeDriver, DirectSolver
+import openmdao.api as om
 
-from dymos import Phase, GaussLobatto, Radau
+import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
 from openmdao.utils.assert_utils import assert_rel_error
@@ -23,15 +23,15 @@ class _A(object):
     pass
 
 
-class _B(Group):
+class _B(om.Group):
     pass
 
 
-class _C(ExplicitComponent):
+class _C(om.ExplicitComponent):
     pass
 
 
-class _D(ExplicitComponent):
+class _D(om.ExplicitComponent):
     ode_options = None
 
 
@@ -39,14 +39,14 @@ class TestPhaseBase(unittest.TestCase):
 
     def test_invalid_ode_wrong_class(self):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
 
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=_A,
-                      transcription=GaussLobatto(num_segments=20, order=3, compressed=True))
+        phase = dm.Phase(ode_class=_A,
+                         transcription=dm.GaussLobatto(num_segments=20, order=3, compressed=True))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -63,7 +63,7 @@ class TestPhaseBase(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('g')
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         with self.assertRaises(ValueError) as e:
             p.setup(check=True)
@@ -72,14 +72,14 @@ class TestPhaseBase(unittest.TestCase):
 
     def test_invalid_ode_instance(self):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
 
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=_A(),
-                      transcription=GaussLobatto(num_segments=20, order=3, compressed=True))
+        phase = dm.Phase(ode_class=_A(),
+                         transcription=dm.GaussLobatto(num_segments=20, order=3, compressed=True))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -96,7 +96,7 @@ class TestPhaseBase(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('g')
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         with self.assertRaises(ValueError) as e:
             p.setup(check=True)
@@ -105,8 +105,8 @@ class TestPhaseBase(unittest.TestCase):
 
     def test_add_existing_design_parameter_as_design_parameter(self):
 
-        p = Phase(ode_class=_A,
-                  transcription=GaussLobatto(num_segments=8, order=3, compressed=True))
+        p = dm.Phase(ode_class=_A,
+                     transcription=dm.GaussLobatto(num_segments=8, order=3, compressed=True))
 
         p.add_design_parameter('theta')
 
@@ -118,8 +118,8 @@ class TestPhaseBase(unittest.TestCase):
 
     def test_add_existing_control_as_design_parameter(self):
 
-        p = Phase(ode_class=BrachistochroneODE,
-                  transcription=GaussLobatto(num_segments=8, order=3))
+        p = dm.Phase(ode_class=BrachistochroneODE,
+                     transcription=dm.GaussLobatto(num_segments=8, order=3))
 
         p.add_control('theta')
 
@@ -131,8 +131,8 @@ class TestPhaseBase(unittest.TestCase):
 
     def test_add_existing_input_parameter_as_design_parameter(self):
 
-        p = Phase(ode_class=_A,
-                  transcription=GaussLobatto(num_segments=8, order=3, compressed=True))
+        p = dm.Phase(ode_class=_A,
+                     transcription=dm.GaussLobatto(num_segments=8, order=3, compressed=True))
 
         p.add_input_parameter('theta')
 
@@ -143,13 +143,13 @@ class TestPhaseBase(unittest.TestCase):
         self.assertEqual(str(e.exception), expected)
 
     def test_invalid_options_nonoptimal_design_param(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
 
         p.driver.options['dynamic_simul_derivs'] = True
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=16, order=3, compressed=True))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=16, order=3, compressed=True))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -167,7 +167,7 @@ class TestPhaseBase(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('g')
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
@@ -181,8 +181,8 @@ class TestPhaseBase(unittest.TestCase):
         self.assertIn(expected, [str(ww.message) for ww in w])
 
     def test_add_existing_design_parameter_as_input_parameter(self):
-        p = Phase(ode_class=_A,
-                  transcription=GaussLobatto(num_segments=14, order=3, compressed=True))
+        p = dm.Phase(ode_class=_A,
+                     transcription=dm.GaussLobatto(num_segments=14, order=3, compressed=True))
 
         p.add_design_parameter('theta')
 
@@ -194,8 +194,8 @@ class TestPhaseBase(unittest.TestCase):
 
     def test_add_existing_control_as_input_parameter(self):
 
-        p = Phase(ode_class=_A,
-                  transcription=GaussLobatto(num_segments=8, order=3, compressed=True))
+        p = dm.Phase(ode_class=_A,
+                     transcription=dm.GaussLobatto(num_segments=8, order=3, compressed=True))
 
         p.add_control('theta')
 
@@ -207,8 +207,8 @@ class TestPhaseBase(unittest.TestCase):
 
     def test_add_existing_input_parameter_as_input_parameter(self):
 
-        p = Phase(ode_class=_A,
-                  transcription=GaussLobatto(num_segments=8, order=3, compressed=True))
+        p = dm.Phase(ode_class=_A,
+                     transcription=dm.GaussLobatto(num_segments=8, order=3, compressed=True))
 
         p.add_input_parameter('theta')
 
@@ -219,14 +219,14 @@ class TestPhaseBase(unittest.TestCase):
         self.assertEqual(str(e.exception), expected)
 
     def test_invalid_options_nonoptimal_control(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
 
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=8, order=3, compressed=True))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=8, order=3, compressed=True))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -244,7 +244,7 @@ class TestPhaseBase(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('g')
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
@@ -257,8 +257,8 @@ class TestPhaseBase(unittest.TestCase):
 
     def test_invalid_boundary_loc(self):
 
-        p = Phase(ode_class=BrachistochroneODE,
-                  transcription=GaussLobatto(num_segments=8, order=3, compressed=True))
+        p = dm.Phase(ode_class=BrachistochroneODE,
+                     transcription=dm.GaussLobatto(num_segments=8, order=3, compressed=True))
 
         with self.assertRaises(ValueError) as e:
             p.add_boundary_constraint('x', loc='foo')
@@ -267,14 +267,14 @@ class TestPhaseBase(unittest.TestCase):
         self.assertEqual(str(e.exception), expected)
 
     def test_objective_design_parameter_gl(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
 
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=8, order=3, compressed=True))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=8, order=3, compressed=True))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -292,7 +292,7 @@ class TestPhaseBase(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('g')
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0
@@ -309,14 +309,14 @@ class TestPhaseBase(unittest.TestCase):
         assert_rel_error(self, p['phase0.t_duration'], 10, tolerance=1.0E-3)
 
     def test_objective_design_parameter_radau(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
 
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=Radau(num_segments=20, order=3, compressed=True))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.Radau(num_segments=20, order=3, compressed=True))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -335,7 +335,7 @@ class TestPhaseBase(unittest.TestCase):
         phase.add_objective('g')
 
         p.model.options['assembled_jac_type'] = 'csc'
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0
@@ -352,16 +352,16 @@ class TestPhaseBase(unittest.TestCase):
         assert_rel_error(self, p['phase0.t_duration'], 10, tolerance=1.0E-3)
 
     def test_control_boundary_constraint_gl(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
 
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=20,
-                                                 order=3,
-                                                 compressed=True))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=20,
+                                                       order=3,
+                                                       compressed=True))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -381,7 +381,7 @@ class TestPhaseBase(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time')
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0
@@ -398,16 +398,16 @@ class TestPhaseBase(unittest.TestCase):
         assert_rel_error(self, p.get_val('phase0.timeseries.controls:theta', units='deg')[-1], 90.0)
 
     def test_control_rate_boundary_constraint_gl(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
 
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=20,
-                                                 order=3,
-                                                 compressed=True))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=20,
+                                                       order=3,
+                                                       compressed=True))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -427,7 +427,7 @@ class TestPhaseBase(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time')
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0
@@ -462,16 +462,16 @@ class TestPhaseBase(unittest.TestCase):
                          tolerance=1.0E-6)
 
     def test_control_rate2_boundary_constraint_gl(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
 
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=20,
-                                                 order=3,
-                                                 compressed=True))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=20,
+                                                       order=3,
+                                                       compressed=True))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -491,7 +491,7 @@ class TestPhaseBase(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time')
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0
@@ -524,15 +524,15 @@ class TestPhaseBase(unittest.TestCase):
                          tolerance=1.0E-6)
 
     def test_design_parameter_boundary_constraint(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=20,
-                                                 order=3,
-                                                 compressed=True))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=20,
+                                                       order=3,
+                                                       compressed=True))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -558,7 +558,7 @@ class TestPhaseBase(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time_phase', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0

--- a/dymos/phase/test/test_set_time_options.py
+++ b/dymos/phase/test/test_set_time_options.py
@@ -4,12 +4,11 @@ import os
 import unittest
 import warnings
 
-from openmdao.api import Problem, Group, IndepVarComp, ScipyOptimizeDriver, DirectSolver
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
-from dymos import Phase, GaussLobatto
+import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
-from dymos.examples.double_integrator.double_integrator_ode import DoubleIntegratorODE
 
 
 class TestPhaseTimeOptions(unittest.TestCase):
@@ -21,13 +20,13 @@ class TestPhaseTimeOptions(unittest.TestCase):
                 os.remove(filename)
 
     def test_fixed_time_invalid_options(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=8, order=3))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=8, order=3))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -52,7 +51,7 @@ class TestPhaseTimeOptions(unittest.TestCase):
 
         phase.add_boundary_constraint('time', loc='initial', equals=0)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         expected_msg0 = 'Phase time options have no effect because fix_initial=True for ' \
                         'phase \'phase0\': initial_bounds, initial_scaler, initial_adder, ' \
@@ -70,13 +69,13 @@ class TestPhaseTimeOptions(unittest.TestCase):
         self.assertIn(expected_msg1, [str(w.message) for w in ctx])
 
     def test_initial_val_and_final_val_stick(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=8, order=3))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=8, order=3))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -97,7 +96,7 @@ class TestPhaseTimeOptions(unittest.TestCase):
 
         phase.add_boundary_constraint('time', loc='initial', equals=0)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True)
 
         assert_rel_error(self, p['phase0.t_initial'], 0.01)
@@ -108,13 +107,13 @@ class TestPhaseTimeOptions(unittest.TestCase):
         Tests that time optimization options cause a ValueError to be raised when t_initial and
         t_duration are connected to external sources.
         """
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=8, order=3))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=8, order=3))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -135,7 +134,7 @@ class TestPhaseTimeOptions(unittest.TestCase):
 
         phase.add_boundary_constraint('time', loc='initial', equals=0)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         with warnings.catch_warnings(record=True) as ctx:
             warnings.simplefilter('always')
@@ -151,13 +150,13 @@ class TestPhaseTimeOptions(unittest.TestCase):
         self.assertIn(expected_msg1, [str(w.message) for w in ctx])
 
     def test_input_time_invalid_options(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=8, order=3))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=8, order=3))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -182,7 +181,7 @@ class TestPhaseTimeOptions(unittest.TestCase):
 
         phase.add_boundary_constraint('time', loc='initial', equals=0)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         expected_msg0 = 'Phase time options have no effect because fix_initial=True for ' \
                         'phase \'phase0\': initial_bounds, initial_scaler, initial_adder, ' \
@@ -200,13 +199,13 @@ class TestPhaseTimeOptions(unittest.TestCase):
         self.assertIn(expected_msg1, [str(w.message) for w in ctx])
 
     def test_unbounded_time(self):
-            p = Problem(model=Group())
+            p = om.Problem(model=om.Group())
 
-            p.driver = ScipyOptimizeDriver()
+            p.driver = om.ScipyOptimizeDriver()
             p.driver.options['dynamic_simul_derivs'] = True
 
-            phase = Phase(ode_class=BrachistochroneODE,
-                          transcription=GaussLobatto(num_segments=8, order=3))
+            phase = dm.Phase(ode_class=BrachistochroneODE,
+                             transcription=dm.GaussLobatto(num_segments=8, order=3))
 
             p.model.add_subsystem('phase0', phase)
 
@@ -226,7 +225,7 @@ class TestPhaseTimeOptions(unittest.TestCase):
 
             phase.add_boundary_constraint('time', loc='initial', equals=0)
 
-            p.model.linear_solver = DirectSolver()
+            p.model.linear_solver = om.DirectSolver()
             p.setup(check=True)
 
             p['phase0.t_initial'] = 0.0

--- a/dymos/phase/test/test_set_time_options.py
+++ b/dymos/phase/test/test_set_time_options.py
@@ -23,7 +23,7 @@ class TestPhaseTimeOptions(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=8, order=3))
@@ -72,7 +72,7 @@ class TestPhaseTimeOptions(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=8, order=3))
@@ -110,7 +110,7 @@ class TestPhaseTimeOptions(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=8, order=3))
@@ -153,7 +153,7 @@ class TestPhaseTimeOptions(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=8, order=3))
@@ -202,7 +202,7 @@ class TestPhaseTimeOptions(unittest.TestCase):
             p = om.Problem(model=om.Group())
 
             p.driver = om.ScipyOptimizeDriver()
-            p.driver.options['dynamic_simul_derivs'] = True
+            p.driver.declare_coloring()
 
             phase = dm.Phase(ode_class=BrachistochroneODE,
                              transcription=dm.GaussLobatto(num_segments=8, order=3))

--- a/dymos/phase/test/test_sized_input_parameters.py
+++ b/dymos/phase/test/test_sized_input_parameters.py
@@ -41,7 +41,7 @@ class TestInputParameterConnections(unittest.TestCase):
 
         p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = optimizer
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         seg_ends, _ = lgl(num_segments + 1)
 
@@ -103,7 +103,7 @@ class TestInputParameterConnections(unittest.TestCase):
 
         p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = optimizer
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         seg_ends, _ = lgl(num_segments + 1)
 
@@ -165,7 +165,7 @@ class TestInputParameterConnections(unittest.TestCase):
 
         p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = optimizer
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         seg_ends, _ = lgl(num_segments + 1)
 
@@ -234,7 +234,7 @@ class TestInputParameterConnections(unittest.TestCase):
 
         p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = optimizer
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         seg_ends, _ = lgl(num_segments + 1)
 

--- a/dymos/phase/test/test_time_targets.py
+++ b/dymos/phase/test/test_time_targets.py
@@ -263,20 +263,16 @@ class TestPhaseTimeTargets(unittest.TestCase):
 
         # Test the iteration ODE
 
-        assert_rel_error(self, p['phase0.rk_solve_group.k_iter_group.ode.time_phase'][-1], 1.8016,
+        assert_rel_error(self, p['phase0.rk_solve_group.ode.time_phase'][-1], 1.8016,
                          tolerance=1.0E-3)
 
-        assert_rel_error(self, p['phase0.rk_solve_group.k_iter_group.ode.t_initial'],
-                         p['phase0.t_initial'])
+        assert_rel_error(self, p['phase0.rk_solve_group.ode.t_initial'], p['phase0.t_initial'])
 
-        assert_rel_error(self, p['phase0.rk_solve_group.k_iter_group.ode.t_duration'],
-                         p['phase0.t_duration'])
+        assert_rel_error(self, p['phase0.rk_solve_group.ode.t_duration'], p['phase0.t_duration'])
 
-        assert_rel_error(self, p['phase0.rk_solve_group.k_iter_group.ode.time_phase'],
-                         time_phase_all)
+        assert_rel_error(self, p['phase0.rk_solve_group.ode.time_phase'], time_phase_all)
 
-        assert_rel_error(self, p['phase0.rk_solve_group.k_iter_group.ode.time'],
-                         time_all)
+        assert_rel_error(self, p['phase0.rk_solve_group.ode.time'], time_all)
 
         # Now test the final ODE
 

--- a/dymos/phase/test/test_time_targets.py
+++ b/dymos/phase/test/test_time_targets.py
@@ -106,7 +106,7 @@ class TestPhaseTimeTargets(unittest.TestCase):
         p.driver = om.ScipyOptimizeDriver()
 
         # Compute sparsity/coloring when run_driver is called
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         t = {'gauss-lobatto': dm.GaussLobatto(num_segments=num_seg, order=transcription_order),
              'radau-ps': dm.Radau(num_segments=num_seg, order=transcription_order),

--- a/dymos/phase/test/test_time_targets.py
+++ b/dymos/phase/test/test_time_targets.py
@@ -1,32 +1,25 @@
 from __future__ import print_function, absolute_import, division
 
-import itertools
 import unittest
-
-from numpy.testing import assert_almost_equal
 
 import matplotlib
 matplotlib.use('Agg')
 
-from parameterized import parameterized
-
-from openmdao.api import Problem, Group, pyOptSparseDriver, ScipyOptimizeDriver, DirectSolver
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 import numpy as np
-from openmdao.api import ExplicitComponent
-from dymos import declare_time, declare_state, declare_parameter, Phase, \
-    GaussLobatto, Radau, RungeKutta
+import dymos as dm
 
 
-@declare_time(units='s', time_phase_targets=['time_phase'], t_duration_targets=['t_duration'],
-              t_initial_targets=['t_initial'], targets=['time'])
-@declare_state('x', rate_source='xdot', units='m')
-@declare_state('y', rate_source='ydot', units='m')
-@declare_state('v', rate_source='vdot', targets=['v'], units='m/s')
-@declare_parameter('theta', targets=['theta'], units='rad')
-@declare_parameter('g', units='m/s**2', targets=['g'])
-class _BrachistochroneTestODE(ExplicitComponent):
+@dm.declare_time(units='s', time_phase_targets=['time_phase'], t_duration_targets=['t_duration'],
+                 t_initial_targets=['t_initial'], targets=['time'])
+@dm.declare_state('x', rate_source='xdot', units='m')
+@dm.declare_state('y', rate_source='ydot', units='m')
+@dm.declare_state('v', rate_source='vdot', targets=['v'], units='m/s')
+@dm.declare_parameter('theta', targets=['theta'], units='rad')
+@dm.declare_parameter('g', units='m/s**2', targets=['g'])
+class _BrachistochroneTestODE(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)
@@ -108,18 +101,18 @@ class _BrachistochroneTestODE(ExplicitComponent):
 class TestPhaseTimeTargets(unittest.TestCase):
 
     def _make_problem(self, transcription, num_seg, transcription_order=3):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
 
         # Compute sparsity/coloring when run_driver is called
         p.driver.options['dynamic_simul_derivs'] = True
 
-        t = {'gauss-lobatto': GaussLobatto(num_segments=num_seg, order=transcription_order),
-             'radau-ps': Radau(num_segments=num_seg, order=transcription_order),
-             'runge-kutta': RungeKutta(num_segments=num_seg)}
+        t = {'gauss-lobatto': dm.GaussLobatto(num_segments=num_seg, order=transcription_order),
+             'radau-ps': dm.Radau(num_segments=num_seg, order=transcription_order),
+             'runge-kutta': dm.RungeKutta(num_segments=num_seg)}
 
-        phase = Phase(ode_class=_BrachistochroneTestODE, transcription=t[transcription])
+        phase = dm.Phase(ode_class=_BrachistochroneTestODE, transcription=t[transcription])
 
         p.model.add_subsystem('phase0', phase)
 
@@ -139,7 +132,7 @@ class TestPhaseTimeTargets(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup()
 

--- a/dymos/phase/test/test_timeseries.py
+++ b/dymos/phase/test/test_timeseries.py
@@ -22,7 +22,7 @@ class TestTimeseriesOutput(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=8, order=3, compressed=True))
@@ -97,7 +97,7 @@ class TestTimeseriesOutput(unittest.TestCase):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
-        p.driver.options['dynamic_simul_derivs'] = True
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.Radau(num_segments=8, order=3, compressed=True))

--- a/dymos/phase/test/test_timeseries.py
+++ b/dymos/phase/test/test_timeseries.py
@@ -7,10 +7,10 @@ matplotlib.use('Agg')
 
 import numpy as np
 
-from openmdao.api import Problem, Group, pyOptSparseDriver, ScipyOptimizeDriver, DirectSolver
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
-from dymos import Phase, GaussLobatto, Radau, RungeKutta
+import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
 SHOW_PLOTS = True
@@ -19,13 +19,13 @@ SHOW_PLOTS = True
 class TestTimeseriesOutput(unittest.TestCase):
 
     def test_timeseries_gl(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=GaussLobatto(num_segments=8, order=3, compressed=True))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=8, order=3, compressed=True))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -43,7 +43,7 @@ class TestTimeseriesOutput(unittest.TestCase):
         # Minimize time at the end of the phase
         phase.add_objective('time_phase', loc='final', scaler=10)
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0
@@ -94,13 +94,13 @@ class TestTimeseriesOutput(unittest.TestCase):
                                  p.get_val('phase0.timeseries.design_parameters:{0}'.format(dp))[i])
 
     def test_timeseries_radau(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['dynamic_simul_derivs'] = True
 
-        phase = Phase(ode_class=BrachistochroneODE,
-                      transcription=Radau(num_segments=8, order=3, compressed=True))
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.Radau(num_segments=8, order=3, compressed=True))
 
         p.model.add_subsystem('phase0', phase)
 
@@ -119,7 +119,7 @@ class TestTimeseriesOutput(unittest.TestCase):
         phase.add_objective('time_phase', loc='final', scaler=10)
 
         p.model.options['assembled_jac_type'] = 'csc'
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0

--- a/dymos/phase/test/test_timeseries.py
+++ b/dymos/phase/test/test_timeseries.py
@@ -13,7 +13,7 @@ from openmdao.utils.assert_utils import assert_rel_error
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-SHOW_PLOTS = True
+SHOW_PLOTS = False
 
 
 class TestTimeseriesOutput(unittest.TestCase):

--- a/dymos/test/test_ode_options.py
+++ b/dymos/test/test_ode_options.py
@@ -1,14 +1,12 @@
 from __future__ import print_function, division, absolute_import
 
-import numpy as np
 import unittest
 
-from dymos import declare_time, declare_state, declare_parameter
+import openmdao.api as om
+import dymos as dm
 
-from openmdao.api import ExplicitComponent
 
-
-class _BrachistochroneODE(ExplicitComponent):
+class _BrachistochroneODE(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)
@@ -18,7 +16,7 @@ class TestODEOptions(unittest.TestCase):
 
     def test_declare_time(self):
 
-        @declare_time(units='s', targets=['foo', 'bar'])
+        @dm.declare_time(units='s', targets=['foo', 'bar'])
         class B(_BrachistochroneODE):
             pass
 
@@ -28,9 +26,9 @@ class TestODEOptions(unittest.TestCase):
 
     def test_declare_state(self):
 
-        @declare_state('x', rate_source='xdot', units='m')
-        @declare_state('y', rate_source='ydot', units='m')
-        @declare_state('v', rate_source='vdot', targets='v', units='m/s')
+        @dm.declare_state('x', rate_source='xdot', units='m')
+        @dm.declare_state('y', rate_source='ydot', units='m')
+        @dm.declare_state('v', rate_source='vdot', targets='v', units='m/s')
         class B(_BrachistochroneODE):
             pass
 
@@ -45,17 +43,17 @@ class TestODEOptions(unittest.TestCase):
 
     def test_invalid_state_name(self):
         with self.assertRaises(NameError) as e:
-            @declare_state('x', rate_source='xdot', units='m')
-            @declare_state('foo.x', rate_source='foox_dot', units='m')
-            @declare_state('v', rate_source='vdot', targets='v', units='m/s')
+            @dm.declare_state('x', rate_source='xdot', units='m')
+            @dm.declare_state('foo.x', rate_source='foox_dot', units='m')
+            @dm.declare_state('v', rate_source='vdot', targets='v', units='m/s')
             class B(_BrachistochroneODE):
                 pass
         self.assertEqual(str(e.exception), "'foo.x' is not a valid OpenMDAO variable name.")
 
     def test_declare_parameters(self):
 
-        @declare_parameter('theta', targets='theta', units='rad')
-        @declare_parameter('g', units='m/s**2', targets=['g'], dynamic=False)
+        @dm.declare_parameter('theta', targets='theta', units='rad')
+        @dm.declare_parameter('g', units='m/s**2', targets=['g'], dynamic=False)
         class B(_BrachistochroneODE):
             pass
 
@@ -65,20 +63,20 @@ class TestODEOptions(unittest.TestCase):
 
     def test_invalid_parameter_name(self):
         with self.assertRaises(NameError) as e:
-            @declare_parameter('theta', targets='theta', units='rad')
-            @declare_parameter('g?', units='m/s**2', targets=['g'], dynamic=False)
+            @dm.declare_parameter('theta', targets='theta', units='rad')
+            @dm.declare_parameter('g?', units='m/s**2', targets=['g'], dynamic=False)
             class B(_BrachistochroneODE):
                 pass
         self.assertEqual(str(e.exception), "'g?' is not a valid OpenMDAO variable name.")
 
     def test_all(self):
 
-        @declare_time(units='s', targets=['foo', 'bar'])
-        @declare_state('x', rate_source='xdot', units='m')
-        @declare_state('y', rate_source='ydot', units='m')
-        @declare_state('v', rate_source='vdot', targets=['v'], units='m/s')
-        @declare_parameter('theta', targets=['theta'], units='rad')
-        @declare_parameter('g', units='m/s**2', targets=['g'], dynamic=False)
+        @dm.declare_time(units='s', targets=['foo', 'bar'])
+        @dm.declare_state('x', rate_source='xdot', units='m')
+        @dm.declare_state('y', rate_source='ydot', units='m')
+        @dm.declare_state('v', rate_source='vdot', targets=['v'], units='m/s')
+        @dm.declare_parameter('theta', targets=['theta'], units='rad')
+        @dm.declare_parameter('g', units='m/s**2', targets=['g'], dynamic=False)
         class B(_BrachistochroneODE):
             pass
 
@@ -97,12 +95,12 @@ class TestODEOptions(unittest.TestCase):
 
     def test_str(self):
 
-        @declare_time(units='s', targets=['foo', 'bar'])
-        @declare_state('x', rate_source='xdot', units='m')
-        @declare_state('y', rate_source='ydot', units='m')
-        @declare_state('v', rate_source='vdot', targets=['v'], units='m/s')
-        @declare_parameter('theta', targets=['theta'], units='rad')
-        @declare_parameter('g', units='m/s**2', targets=['g'], dynamic=False)
+        @dm.declare_time(units='s', targets=['foo', 'bar'])
+        @dm.declare_state('x', rate_source='xdot', units='m')
+        @dm.declare_state('y', rate_source='ydot', units='m')
+        @dm.declare_state('v', rate_source='vdot', targets=['v'], units='m/s')
+        @dm.declare_parameter('theta', targets=['theta'], units='rad')
+        @dm.declare_parameter('g', units='m/s**2', targets=['g'], dynamic=False)
         class B(_BrachistochroneODE):
             pass
 

--- a/dymos/trajectory/test/test_trajectory.py
+++ b/dymos/trajectory/test/test_trajectory.py
@@ -5,10 +5,10 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, DirectSolver, SqliteRecorder, Group
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
-from dymos import Phase, Trajectory, GaussLobatto
+import dymos as dm
 from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
 
 
@@ -23,15 +23,15 @@ class TestTrajectory(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
 
-        cls.traj = Trajectory()
-        p = cls.p = Problem(model=cls.traj)
+        cls.traj = dm.Trajectory()
+        p = cls.p = om.Problem(model=cls.traj)
 
         # Since we're only testing features like get_values that don't rely on a converged
         # solution, no driver is attached.  We'll just invoke run_model.
 
         # First Phase (burn)
 
-        burn1 = Phase(ode_class=FiniteBurnODE, transcription=GaussLobatto(num_segments=4, order=3))
+        burn1 = dm.Phase(ode_class=FiniteBurnODE, transcription=dm.GaussLobatto(num_segments=4, order=3))
 
         cls.traj.add_phase('burn1', burn1)
 
@@ -47,7 +47,7 @@ class TestTrajectory(unittest.TestCase):
 
         # Second Phase (Coast)
 
-        coast = Phase(ode_class=FiniteBurnODE, transcription=GaussLobatto(num_segments=10, order=3))
+        coast = dm.Phase(ode_class=FiniteBurnODE, transcription=dm.GaussLobatto(num_segments=10, order=3))
 
         cls.traj.add_phase('coast', coast)
 
@@ -63,7 +63,7 @@ class TestTrajectory(unittest.TestCase):
 
         # Third Phase (burn)
 
-        burn2 = Phase(ode_class=FiniteBurnODE, transcription=GaussLobatto(num_segments=3, order=3))
+        burn2 = dm.Phase(ode_class=FiniteBurnODE, transcription=dm.GaussLobatto(num_segments=3, order=3))
 
         cls.traj.add_phase('burn2', burn2)
 
@@ -86,9 +86,9 @@ class TestTrajectory(unittest.TestCase):
         cls.traj.link_phases(phases=['burn1', 'burn2'], vars=['accel'])
 
         # Finish Problem Setup
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
-        p.model.add_recorder(SqliteRecorder('test_trajectory_rec.db'))
+        p.model.add_recorder(om.SqliteRecorder('test_trajectory_rec.db'))
 
         p.setup(check=True)
 
@@ -145,15 +145,15 @@ class TestTrajectory(unittest.TestCase):
 class TestInvalidLinkages(unittest.TestCase):
 
     def test_invalid_linkage_variable(self):
-        traj = Trajectory()
-        p = Problem(model=traj)
+        traj = dm.Trajectory()
+        p = om.Problem(model=traj)
 
         # Since we're only testing features like get_values that don't rely on a converged
         # solution, no driver is attached.  We'll just invoke run_model.
 
         # First Phase (burn)
 
-        burn1 = Phase(ode_class=FiniteBurnODE, transcription=GaussLobatto(num_segments=4, order=3))
+        burn1 = dm.Phase(ode_class=FiniteBurnODE, transcription=dm.GaussLobatto(num_segments=4, order=3))
 
         traj.add_phase('burn1', burn1)
 
@@ -169,7 +169,7 @@ class TestInvalidLinkages(unittest.TestCase):
 
         # Second Phase (Coast)
 
-        coast = Phase(ode_class=FiniteBurnODE, transcription=GaussLobatto(num_segments=10, order=3))
+        coast = dm.Phase(ode_class=FiniteBurnODE, transcription=dm.GaussLobatto(num_segments=10, order=3))
 
         traj.add_phase('coast', coast)
 
@@ -185,7 +185,7 @@ class TestInvalidLinkages(unittest.TestCase):
 
         # Third Phase (burn)
 
-        burn2 = Phase(ode_class=FiniteBurnODE, transcription=GaussLobatto(num_segments=3, order=3))
+        burn2 = dm.Phase(ode_class=FiniteBurnODE, transcription=dm.GaussLobatto(num_segments=3, order=3))
 
         traj.add_phase('burn2', burn2)
 
@@ -209,9 +209,9 @@ class TestInvalidLinkages(unittest.TestCase):
         traj.link_phases(phases=['burn1', 'burn2'], vars=['u1', 'bar'])
 
         # Finish Problem Setup
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
-        p.model.add_recorder(SqliteRecorder('test_trajectory_rec.db'))
+        p.model.add_recorder(om.SqliteRecorder('test_trajectory_rec.db'))
 
         with self.assertRaises(ValueError) as e:
             p.setup(check=True)
@@ -221,16 +221,16 @@ class TestInvalidLinkages(unittest.TestCase):
                                            'or parameters may be linked via link_phases.')
 
     def test_invalid_linkage_phase(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        traj = Trajectory()
+        traj = dm.Trajectory()
         p.model.add_subsystem('traj', subsys=traj)
 
         # Since we're only testing features like get_values that don't rely on a converged
         # solution, no driver is attached.  We'll just invoke run_model.
 
         # First Phase (burn)
-        burn1 = Phase(ode_class=FiniteBurnODE, transcription=GaussLobatto(num_segments=4, order=3))
+        burn1 = dm.Phase(ode_class=FiniteBurnODE, transcription=dm.GaussLobatto(num_segments=4, order=3))
 
         traj.add_phase('burn1', burn1)
 
@@ -246,7 +246,7 @@ class TestInvalidLinkages(unittest.TestCase):
 
         # Second Phase (Coast)
 
-        coast = Phase(ode_class=FiniteBurnODE, transcription=GaussLobatto(num_segments=10, order=3))
+        coast = dm.Phase(ode_class=FiniteBurnODE, transcription=dm.GaussLobatto(num_segments=10, order=3))
 
         traj.add_phase('coast', coast)
 
@@ -262,7 +262,7 @@ class TestInvalidLinkages(unittest.TestCase):
 
         # Third Phase (burn)
 
-        burn2 = Phase(ode_class=FiniteBurnODE, transcription=GaussLobatto(num_segments=3, order=3))
+        burn2 = dm.Phase(ode_class=FiniteBurnODE, transcription=dm.GaussLobatto(num_segments=3, order=3))
 
         traj.add_phase('burn2', burn2)
 
@@ -286,9 +286,9 @@ class TestInvalidLinkages(unittest.TestCase):
         traj.link_phases(phases=['burn1', 'foo'], vars=['u1', 'u1'])
 
         # Finish Problem Setup
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
-        p.model.add_recorder(SqliteRecorder('test_trajectory_rec.db'))
+        p.model.add_recorder(om.SqliteRecorder('test_trajectory_rec.db'))
 
         with self.assertRaises(ValueError) as e:
             p.setup(check=True)

--- a/dymos/trajectory/test/test_trajectory.py
+++ b/dymos/trajectory/test/test_trajectory.py
@@ -16,7 +16,7 @@ class TestTrajectory(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        for filename in ['test_trajectory_rec.db', 'coloring.json']:
+        for filename in ['test_trajectory_rec.db', 'total_coloring.pkl']:
             if os.path.exists(filename):
                 os.remove(filename)
 

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -351,7 +351,7 @@ class Trajectory(Group):
                         path = 'initial_states:{0}'.format(var)
 
                         self.connect('{0}.{1}'.format(phase_name1, source1),
-                                     'phases.{0}.{1}'.format(phase_name2, path))
+                                     '{0}.{1}'.format(phase_name2, path))
 
                     print('       {0:<{2}s} --> {1:<{2}s}'.format(source1, source2,
                                                                   max_varname_length + 9))
@@ -381,28 +381,14 @@ class Trajectory(Group):
         if self.input_parameter_options:
             self._setup_input_parameters()
 
-        phases_group = ParallelGroup()
-
-        promoted_inputs = []
+        phases_group = self.add_subsystem('phases', subsys=ParallelGroup(), promotes_inputs=['*'],
+                                          promotes_outputs=['*'])
 
         for name, phs in iteritems(self._phases):
             g = phases_group.add_subsystem(name, phs, **self._phase_add_kwargs[name])
-            phs.finalize_variables()
-            promoted_inputs.append('{0}.t_initial'.format(name))
-            promoted_inputs.append('{0}.t_duration'.format(name))
-            if phs.input_parameter_options:
-                promoted_inputs.append('{0}.input_parameters:*'.format(name))
-            if phs.traj_parameter_options:
-                promoted_inputs.append('{0}.traj_parameters:*'.format(name))
-            input_controls = [cname for cname, opts in iteritems(phs.control_options) if not opts['opt']]
-            if input_controls:
-                promoted_inputs.append('{0}.controls:*'.format(name))
             # DirectSolvers were moved down into the phases for use with MPI
             g.linear_solver = DirectSolver()
-
-        self.add_subsystem('phases', phases_group,
-                           promotes_inputs=promoted_inputs,
-                           promotes_outputs=['*'])
+            phs.finalize_variables()
 
         if self._linkages:
             self._setup_linkages()

--- a/dymos/transcriptions/common/boundary_constraint_comp.py
+++ b/dymos/transcriptions/common/boundary_constraint_comp.py
@@ -3,12 +3,12 @@ from __future__ import division, print_function
 import numpy as np
 from six import iteritems
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 from dymos.utils.constants import INF_BOUND
 
 
-class BoundaryConstraintComp(ExplicitComponent):
+class BoundaryConstraintComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('loc', values=('initial', 'final'),

--- a/dymos/transcriptions/common/continuity_comp.py
+++ b/dymos/transcriptions/common/continuity_comp.py
@@ -1,14 +1,14 @@
 from __future__ import print_function, division
 
 import numpy as np
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 from six import iteritems, string_types
 
 from ..grid_data import GridData
 from ...utils.misc import get_rate_units
 
 
-class ContinuityCompBase(ExplicitComponent):
+class ContinuityCompBase(om.ExplicitComponent):
     """
     ContinuityComp defines constraints to ensure continuity between adjacent segments.
     """

--- a/dymos/transcriptions/common/control_group.py
+++ b/dymos/transcriptions/common/control_group.py
@@ -4,14 +4,14 @@ from six import string_types, iteritems
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent, Group, IndepVarComp
+import openmdao.api as om
 
 from ..grid_data import GridData
 from ...utils.misc import get_rate_units, CoerceDesvar
 from ...utils.constants import INF_BOUND
 
 
-class ControlInterpComp(ExplicitComponent):
+class ControlInterpComp(om.ExplicitComponent):
     """
     Compute the approximated control values and rates given the values of a control at all nodes,
     given values at the control discretization nodes.
@@ -231,7 +231,7 @@ class ControlInterpComp(ExplicitComponent):
                 (self.rate2_jacs[name] / dt_dstau_x_size ** 2)[r_nz, c_nz]
 
 
-class ControlGroup(Group):
+class ControlGroup(om.Group):
 
     def initialize(self):
         self.options.declare('control_options', types=dict,
@@ -242,7 +242,7 @@ class ControlGroup(Group):
 
     def setup(self):
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
 
         # opts = self.options
         gd = self.options['grid_data']
@@ -255,7 +255,7 @@ class ControlGroup(Group):
         opt_controls = [name for (name, opts) in iteritems(control_options) if opts['opt']]
 
         if len(opt_controls) > 0:
-            ivc = self.add_subsystem('indep_controls', subsys=IndepVarComp(),
+            ivc = self.add_subsystem('indep_controls', subsys=om.IndepVarComp(),
                                      promotes_outputs=['*'])
 
         self.add_subsystem(

--- a/dymos/transcriptions/common/endpoint_conditions_comp.py
+++ b/dymos/transcriptions/common/endpoint_conditions_comp.py
@@ -2,10 +2,10 @@ from __future__ import print_function, division, absolute_import
 
 from six import iteritems
 import numpy as np
-from openmdao.api import ExplicitComponent, OptionsDictionary
+import openmdao.api as om
 
 
-class EndpointConditionsComp(ExplicitComponent):
+class EndpointConditionsComp(om.ExplicitComponent):
     """
     Provides values of time, states, and controls at the start/end of each
     phase to make it simpler to link phases together.
@@ -14,7 +14,7 @@ class EndpointConditionsComp(ExplicitComponent):
         self.options.declare('loc', values=('initial', 'final'),
                              desc='Whether the instance of the component provides conditions at '
                                   'the start (initial) or end (final) of the phase')
-        self.options.declare('time_options', types=OptionsDictionary)
+        self.options.declare('time_options', types=om.OptionsDictionary)
         self.options.declare('state_options', types=dict)
         self.options.declare('control_options', types=dict)
 

--- a/dymos/transcriptions/common/input_parameter_comp.py
+++ b/dymos/transcriptions/common/input_parameter_comp.py
@@ -3,10 +3,10 @@ from __future__ import division, print_function
 import numpy as np
 from six import iteritems
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class InputParameterComp(ExplicitComponent):
+class InputParameterComp(om.ExplicitComponent):
     """
     The InputParameterComp handles input parameters for phases and trajectories.
 

--- a/dymos/transcriptions/common/path_constraint_comp.py
+++ b/dymos/transcriptions/common/path_constraint_comp.py
@@ -1,13 +1,13 @@
 from __future__ import division, print_function
 
 import numpy as np
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 from dymos.transcriptions.grid_data import GridData
 from dymos.utils.constants import INF_BOUND
 
 
-class PathConstraintCompBase(ExplicitComponent):
+class PathConstraintCompBase(om.ExplicitComponent):
 
     def initialize(self):
         self._path_constraints = []

--- a/dymos/transcriptions/common/phase_linkage_comp.py
+++ b/dymos/transcriptions/common/phase_linkage_comp.py
@@ -2,10 +2,10 @@ from __future__ import print_function, division, absolute_import
 
 from six import string_types
 import numpy as np
-from openmdao.api import ExplicitComponent, OptionsDictionary
+import openmdao.api as om
 
 
-class PhaseLinkageComp(ExplicitComponent):
+class PhaseLinkageComp(om.ExplicitComponent):
     """
     Provides a 'linkage' capability between two phases to provide
     continuity in states, time, and other variables between two
@@ -118,7 +118,7 @@ class PhaseLinkageComp(ExplicitComponent):
 
         for var in _vars:
 
-            lnk = OptionsDictionary()
+            lnk = om.OptionsDictionary()
 
             lnk.declare('name', types=(string_types,))
             lnk.declare('equals', types=(float, np.ndarray), allow_none=True)

--- a/dymos/transcriptions/common/polynomial_control_group.py
+++ b/dymos/transcriptions/common/polynomial_control_group.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from six import iteritems, string_types
 
-from openmdao.api import Group, ExplicitComponent, IndepVarComp
+import openmdao.api as om
 
 from ..grid_data import GridData
 from ...utils.lgl import lgl
@@ -12,7 +12,7 @@ from ...utils.misc import get_rate_units
 from ...utils.constants import INF_BOUND
 
 
-class LGLPolynomialControlComp(ExplicitComponent):
+class LGLPolynomialControlComp(om.ExplicitComponent):
     """
     Component which interpolates controls as a single polynomial across the entire phase.
     """
@@ -180,7 +180,7 @@ class LGLPolynomialControlComp(ExplicitComponent):
                 (self.rate2_jacs[name] / (0.5 * t_duration_x_size) ** 2)[r_nz, c_nz]
 
 
-class PolynomialControlGroup(Group):
+class PolynomialControlGroup(om.Group):
 
     def initialize(self):
         self.options.declare('polynomial_control_options', types=dict,
@@ -191,7 +191,7 @@ class PolynomialControlGroup(Group):
 
     def setup(self):
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
 
         opts = self.options
 

--- a/dymos/transcriptions/common/test/test_boundary_constraint_comp.py
+++ b/dymos/transcriptions/common/test/test_boundary_constraint_comp.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from dymos.transcriptions.common.boundary_constraint_comp import BoundaryConstraintComp
@@ -15,9 +15,9 @@ class TestInitialScalarBoundaryValue(unittest.TestCase):
 
     def setUp(self):
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem(model=om.Group())
 
-        ivp = self.p.model.add_subsystem('ivc', subsys=IndepVarComp(), promotes_outputs=['*'])
+        ivp = self.p.model.add_subsystem('ivc', subsys=om.IndepVarComp(), promotes_outputs=['*'])
 
         ivp.add_output('x', val=np.arange(100))
         self.p.model.add_design_var('x', lower=0, upper=100)
@@ -44,9 +44,9 @@ class TestFinalScalarBoundaryValue(unittest.TestCase):
 
     def setUp(self):
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem(model=om.Group())
 
-        ivp = self.p.model.add_subsystem('ivc', subsys=IndepVarComp(), promotes_outputs=['*'])
+        ivp = self.p.model.add_subsystem('ivc', subsys=om.IndepVarComp(), promotes_outputs=['*'])
 
         ivp.add_output('x', val=np.arange(100))
         self.p.model.add_design_var('x', lower=0, upper=100)
@@ -73,9 +73,9 @@ class TestVectorInitialBoundaryValue(unittest.TestCase):
 
     def setUp(self):
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem(model=om.Group())
 
-        ivp = self.p.model.add_subsystem('ivc', subsys=IndepVarComp(), promotes_outputs=['*'])
+        ivp = self.p.model.add_subsystem('ivc', subsys=om.IndepVarComp(), promotes_outputs=['*'])
 
         ivp.add_output('pos', val=np.zeros((100, 3)))
         self.p.model.add_design_var('pos', lower=0, upper=100)
@@ -109,9 +109,9 @@ class TestVectorFinalBoundaryValue(unittest.TestCase):
 
     def setUp(self):
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem(model=om.Group())
 
-        ivp = self.p.model.add_subsystem('ivc', subsys=IndepVarComp(), promotes_outputs=['*'])
+        ivp = self.p.model.add_subsystem('ivc', subsys=om.IndepVarComp(), promotes_outputs=['*'])
 
         ivp.add_output('pos', val=np.zeros((100, 3)))
         self.p.model.add_design_var('pos', lower=0, upper=100)
@@ -146,9 +146,9 @@ class TestMatrixInitialBoundaryValue(unittest.TestCase):
 
     def setUp(self):
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem(model=om.Group())
 
-        ivp = self.p.model.add_subsystem('ivc', subsys=IndepVarComp(), promotes_outputs=['*'])
+        ivp = self.p.model.add_subsystem('ivc', subsys=om.IndepVarComp(), promotes_outputs=['*'])
 
         ivp.add_output('M', val=np.zeros((100, 3, 3)))
         self.p.model.add_design_var('M', lower=0, upper=100)
@@ -191,9 +191,9 @@ class TestMatrixFinalBoundaryValue(unittest.TestCase):
 
     def setUp(self):
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem(model=om.Group())
 
-        ivp = self.p.model.add_subsystem('ivc', subsys=IndepVarComp(), promotes_outputs=['*'])
+        ivp = self.p.model.add_subsystem('ivc', subsys=om.IndepVarComp(), promotes_outputs=['*'])
 
         ivp.add_output('M', val=np.zeros((100, 3, 3)))
         self.p.model.add_design_var('M', lower=0, upper=100)
@@ -236,9 +236,9 @@ class TestMultipleConstraints(unittest.TestCase):
 
     def setUp(self):
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem(model=om.Group())
 
-        ivp = self.p.model.add_subsystem('ivc', subsys=IndepVarComp(), promotes_outputs=['*'])
+        ivp = self.p.model.add_subsystem('ivc', subsys=om.IndepVarComp(), promotes_outputs=['*'])
 
         ivp.add_output('M', val=np.zeros((100, 3, 3)))
         ivp.add_output('pos', val=np.zeros((100, 3)))

--- a/dymos/transcriptions/common/test/test_continuity_comp.py
+++ b/dymos/transcriptions/common/test/test_continuity_comp.py
@@ -7,7 +7,7 @@ from parameterized import parameterized
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_rel_error
 
 from dymos.transcriptions.grid_data import GridData
@@ -34,9 +34,9 @@ class TestContinuityComp(unittest.TestCase):
                       transcription=transcription,
                       compressed=compressed == 'compressed')
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem(model=om.Group())
 
-        ivp = self.p.model.add_subsystem('ivc', subsys=IndepVarComp(), promotes_outputs=['*'])
+        ivp = self.p.model.add_subsystem('ivc', subsys=om.IndepVarComp(), promotes_outputs=['*'])
 
         nn = gd.subset_num_nodes['all']
 

--- a/dymos/transcriptions/common/test/test_control_interp_comp.py
+++ b/dymos/transcriptions/common/test/test_control_interp_comp.py
@@ -7,7 +7,7 @@ from parameterized import parameterized
 
 import numpy as np
 from numpy.testing import assert_almost_equal
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from dymos.transcriptions.common import TimeComp
@@ -83,12 +83,12 @@ class TestControlRateComp(unittest.TestCase):
                       transcription=transcription,
                       compressed=compressed)
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         controls = {'a': {'units': 'm', 'shape': (1,), 'dynamic': True},
                     'b': {'units': 'm', 'shape': (1,), 'dynamic': True}}
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
         ivc.add_output('controls:a',
@@ -174,12 +174,12 @@ class TestControlRateComp(unittest.TestCase):
                       transcription_order='RK4',
                       compressed=compressed)
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         controls = {'a': {'units': 'm', 'shape': (1,), 'dynamic': True},
                     'b': {'units': 'm', 'shape': (1,), 'dynamic': True}}
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
         ivc.add_output('controls:a',
@@ -258,11 +258,11 @@ class TestControlRateComp(unittest.TestCase):
                       transcription=transcription,
                       compressed=compressed)
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         controls = {'a': {'units': 'm', 'shape': (3,), 'dynamic': True}}
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
         ivc.add_output('controls:a', val=np.zeros((gd.subset_num_nodes['control_input'], 3)),
@@ -360,11 +360,11 @@ class TestControlRateComp(unittest.TestCase):
                       transcription=transcription,
                       compressed=compressed)
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         controls = {'a': {'units': 'm', 'shape': (3, 1), 'dynamic': True}}
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
         ivc.add_output('controls:a', val=np.zeros((gd.subset_num_nodes['control_input'], 3, 1)),
@@ -461,11 +461,11 @@ class TestControlRateComp(unittest.TestCase):
                       transcription=transcription,
                       compressed=compressed)
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         controls = {'a': {'units': 'm', 'shape': (2, 2), 'dynamic': True}}
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
         ivc.add_output('controls:a', val=np.zeros((gd.subset_num_nodes['control_input'], 2, 2)),

--- a/dymos/transcriptions/common/test/test_endpoint_conditions_comp.py
+++ b/dymos/transcriptions/common/test/test_endpoint_conditions_comp.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from openmdao.api import Problem, Group, IndepVarComp, DirectSolver
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from dymos.phase.options import TimeOptionsDictionary, StateOptionsDictionary, \
@@ -18,7 +18,7 @@ class TestEndpointConditionComp(unittest.TestCase):
     def test_scalar_state_and_control(self):
         n = 101
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         time_options = TimeOptionsDictionary()
         time_options['units'] = 's'
@@ -33,7 +33,7 @@ class TestEndpointConditionComp(unittest.TestCase):
         control_options['theta']['units'] = 'rad'
         control_options['theta']['shape'] = (1,)
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='phase:time', val=np.zeros(n), units='s')
         ivc.add_output(name='phase:initial_jump:time', val=100.0 * np.ones(1), units='s')
         ivc.add_output(name='phase:final_jump:time', val=1.0 * np.ones(1), units='s')
@@ -96,7 +96,7 @@ class TestEndpointConditionComp(unittest.TestCase):
         p.model.connect('phase:initial_jump:theta', 'initial_conditions.initial_jump:theta')
         p.model.connect('phase:final_jump:theta', 'final_conditions.final_jump:theta')
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(force_alloc_complex=True)
 
@@ -147,7 +147,7 @@ class TestEndpointConditionComp(unittest.TestCase):
     def test_vector_state_and_control(self):
         n = 101
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         time_options = TimeOptionsDictionary()
         time_options['units'] = 's'
@@ -162,7 +162,7 @@ class TestEndpointConditionComp(unittest.TestCase):
         control_options['cmd']['units'] = 'rad'
         control_options['cmd']['shape'] = (3,)
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='phase:time', val=np.zeros(n), units='s')
         ivc.add_output(name='phase:initial_jump:time', val=100.0 * np.ones(1), units='s')
 
@@ -221,7 +221,7 @@ class TestEndpointConditionComp(unittest.TestCase):
         p.model.connect('phase:initial_jump:cmd', 'initial_conditions.initial_jump:cmd')
         p.model.connect('phase:final_jump:cmd', 'final_conditions.final_jump:cmd')
 
-        p.model.linear_solver = DirectSolver()
+        p.model.linear_solver = om.DirectSolver()
         p.model.options['assembled_jac_type'] = 'csc'
 
         p.setup(force_alloc_complex=True)

--- a/dymos/transcriptions/common/test/test_path_constraint_comp.py
+++ b/dymos/transcriptions/common/test/test_path_constraint_comp.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 from numpy.testing import assert_almost_equal
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from dymos.transcriptions.common import GaussLobattoPathConstraintComp, RadauPathConstraintComp
@@ -27,7 +27,7 @@ class TestPathConstraintCompGL(unittest.TestCase):
         ncn = gd.subset_num_nodes['col']
         nn = ndn + ncn
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem(model=om.Group())
 
         controls = {'a': ControlOptionsDictionary(),
                     'b': ControlOptionsDictionary(),
@@ -38,7 +38,7 @@ class TestPathConstraintCompGL(unittest.TestCase):
         controls['b'].update({'units': 's', 'shape': (3,), 'opt': False})
         controls['c'].update({'units': 'kg', 'shape': (3, 3), 'opt': False})
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         self.p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
         ivc.add_output('a_disc', val=np.zeros((ndn, 1)), units='m')
@@ -148,7 +148,7 @@ class TestPathConstraintCompRadau(unittest.TestCase):
 
         ndn = gd.subset_num_nodes['state_disc']
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem(model=om.Group())
 
         controls = {'a': ControlOptionsDictionary(),
                     'b': ControlOptionsDictionary(),
@@ -159,7 +159,7 @@ class TestPathConstraintCompRadau(unittest.TestCase):
         controls['b'].update({'units': 's', 'shape': (3,), 'opt': False})
         controls['c'].update({'units': 'kg', 'shape': (3, 3), 'opt': False})
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         self.p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
         ivc.add_output('a_disc', val=np.zeros((ndn, 1)), units='m')

--- a/dymos/transcriptions/common/test/test_phase_linkage_comp.py
+++ b/dymos/transcriptions/common/test/test_phase_linkage_comp.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from dymos.transcriptions.common import PhaseLinkageComp
@@ -15,9 +15,9 @@ class TestPhaseLinkageComp(unittest.TestCase):
 
     def setUp(self):
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem(model=om.Group())
 
-        ivp = self.p.model.add_subsystem('ivc', subsys=IndepVarComp(), promotes_outputs=['*'])
+        ivp = self.p.model.add_subsystem('ivc', subsys=om.IndepVarComp(), promotes_outputs=['*'])
 
         ndn = 20
         nn = 30

--- a/dymos/transcriptions/common/test/test_polynomial_control_group.py
+++ b/dymos/transcriptions/common/test/test_polynomial_control_group.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 from numpy.testing import assert_almost_equal
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from dymos.transcriptions.common import TimeComp, PolynomialControlGroup
@@ -77,7 +77,7 @@ class TestInterpolatedControLGroup(unittest.TestCase):
                       transcription=transcription,
                       compressed=compressed)
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         controls = {'a': PolynomialControlOptionsDictionary(),
                     'b': PolynomialControlOptionsDictionary()}
@@ -90,7 +90,7 @@ class TestInterpolatedControLGroup(unittest.TestCase):
         controls['b']['order'] = 3
         controls['b']['opt'] = True
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
         ivc.add_output('t_initial', val=0.0, units='s')
@@ -171,7 +171,7 @@ class TestInterpolatedControLGroup(unittest.TestCase):
                       transcription=transcription,
                       compressed=compressed)
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         controls = {'a': PolynomialControlOptionsDictionary(),
                     'b': PolynomialControlOptionsDictionary()}
@@ -184,7 +184,7 @@ class TestInterpolatedControLGroup(unittest.TestCase):
         controls['b']['order'] = 3
         controls['b']['opt'] = True
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
         ivc.add_output('t_initial', val=0.0, units='s')
@@ -267,7 +267,7 @@ class TestInterpolatedControLGroup(unittest.TestCase):
                       transcription=transcription,
                       compressed=compressed)
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         controls = {'a': PolynomialControlOptionsDictionary(),
                     'b': PolynomialControlOptionsDictionary()}
@@ -280,7 +280,7 @@ class TestInterpolatedControLGroup(unittest.TestCase):
         controls['b']['order'] = 3
         controls['b']['opt'] = True
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
         ivc.add_output('t_initial', val=0.0, units='s')
@@ -361,7 +361,7 @@ class TestInterpolatedControLGroup(unittest.TestCase):
                       transcription=transcription,
                       compressed=compressed)
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         controls = {'a': PolynomialControlOptionsDictionary()}
 
@@ -370,7 +370,7 @@ class TestInterpolatedControLGroup(unittest.TestCase):
         controls['a']['opt'] = True
         controls['a']['shape'] = (3,)
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
         ivc.add_output('t_initial', val=0.0, units='s')
@@ -467,7 +467,7 @@ class TestInterpolatedControLGroup(unittest.TestCase):
                       transcription=transcription,
                       compressed=compressed)
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         controls = {'a': PolynomialControlOptionsDictionary()}
 
@@ -476,7 +476,7 @@ class TestInterpolatedControLGroup(unittest.TestCase):
         controls['a']['opt'] = True
         controls['a']['shape'] = (3,)
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
         ivc.add_output('t_initial', val=0.0, units='s')
@@ -573,7 +573,7 @@ class TestInterpolatedControLGroup(unittest.TestCase):
                       transcription=transcription,
                       compressed=compressed)
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         controls = {'a': PolynomialControlOptionsDictionary()}
 
@@ -582,7 +582,7 @@ class TestInterpolatedControLGroup(unittest.TestCase):
         controls['a']['opt'] = True
         controls['a']['shape'] = (3,)
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
         ivc.add_output('t_initial', val=0.0, units='s')
@@ -679,7 +679,7 @@ class TestInterpolatedControLGroup(unittest.TestCase):
                       transcription=transcription,
                       compressed=compressed)
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         controls = {'a': PolynomialControlOptionsDictionary()}
 
@@ -688,7 +688,7 @@ class TestInterpolatedControLGroup(unittest.TestCase):
         controls['a']['opt'] = True
         controls['a']['shape'] = (3, 1)
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
         ivc.add_output('t_initial', val=0.0, units='s')
@@ -785,7 +785,7 @@ class TestInterpolatedControLGroup(unittest.TestCase):
                       transcription=transcription,
                       compressed=compressed)
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         controls = {'a': PolynomialControlOptionsDictionary()}
 
@@ -794,7 +794,7 @@ class TestInterpolatedControLGroup(unittest.TestCase):
         controls['a']['opt'] = True
         controls['a']['shape'] = (3, 1)
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
         ivc.add_output('t_initial', val=0.0, units='s')
@@ -891,7 +891,7 @@ class TestInterpolatedControLGroup(unittest.TestCase):
                       transcription=transcription,
                       compressed=compressed)
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         controls = {'a': PolynomialControlOptionsDictionary()}
 
@@ -900,7 +900,7 @@ class TestInterpolatedControLGroup(unittest.TestCase):
         controls['a']['opt'] = True
         controls['a']['shape'] = (3, 1)
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
         ivc.add_output('t_initial', val=0.0, units='s')

--- a/dymos/transcriptions/common/test/test_time_comp.py
+++ b/dymos/transcriptions/common/test/test_time_comp.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 
 from dymos.transcriptions.grid_data import GridData
 from dymos.transcriptions.common import TimeComp
@@ -30,9 +30,9 @@ class TestTimeComp(unittest.TestCase):
                       segment_ends=_segends,
                       transcription='gauss-lobatto')
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem(name='ivc', subsys=IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem(name='ivc', subsys=om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('t_initial', val=0.0, units='s')
         ivc.add_output('t_duration', val=100.0, units='s')
@@ -85,9 +85,9 @@ class TestTimeComp(unittest.TestCase):
                       segment_ends=_segends,
                       transcription='radau-ps')
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem(name='ivc', subsys=IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem(name='ivc', subsys=om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('t_initial', val=0.0, units='s')
         ivc.add_output('t_duration', val=100.0, units='s')

--- a/dymos/transcriptions/common/time_comp.py
+++ b/dymos/transcriptions/common/time_comp.py
@@ -1,11 +1,11 @@
 from __future__ import print_function, division, absolute_import
 
 import numpy as np
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 from six import string_types
 
 
-class TimeComp(ExplicitComponent):
+class TimeComp(om.ExplicitComponent):
 
     def initialize(self):
         # Required

--- a/dymos/transcriptions/common/timeseries_output_comp.py
+++ b/dymos/transcriptions/common/timeseries_output_comp.py
@@ -3,12 +3,12 @@ from __future__ import division, print_function
 from six import iteritems
 
 import numpy as np
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 from dymos.transcriptions.grid_data import GridData
 
 
-class TimeseriesOutputCompBase(ExplicitComponent):
+class TimeseriesOutputCompBase(om.ExplicitComponent):
     """
     TimeseriesOutputComp collects variable values from the phase and provides them in chronological
     order as outputs.  Some phase types don't internally have access to a contiguous array of all

--- a/dymos/transcriptions/pseudospectral/components/collocation_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/collocation_comp.py
@@ -4,13 +4,13 @@ from six import string_types, iteritems
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 from ...grid_data import GridData
 from ....utils.misc import get_rate_units
 
 
-class CollocationComp(ExplicitComponent):
+class CollocationComp(om.ExplicitComponent):
     """
     CollocationComp computes the generalized defect of a segment for implicit collocation.
     The defect is the interpolated state derivative at the collocation nodes minus

--- a/dymos/transcriptions/pseudospectral/components/control_endpoint_defect_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/control_endpoint_defect_comp.py
@@ -1,13 +1,13 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 from six import iteritems
 
 from ...grid_data import GridData
 
 
-class ControlEndpointDefectComp(ExplicitComponent):
+class ControlEndpointDefectComp(om.ExplicitComponent):
     r""" Compute/enforce the control endpoint defect when using the Radau Pseudospectral method.
 
     For each dynamic control, take the control values at all nodes.  Use a Radau interpolation

--- a/dymos/transcriptions/pseudospectral/components/state_independents.py
+++ b/dymos/transcriptions/pseudospectral/components/state_independents.py
@@ -6,12 +6,12 @@ from six import iteritems
 
 import numpy as np
 
-from openmdao.api import ImplicitComponent
+import openmdao.api as om
 
 from dymos.transcriptions.grid_data import GridData
 
 
-class StateIndependentsComp(ImplicitComponent):
+class StateIndependentsComp(om.ImplicitComponent):
     """
     A simple component that replaces the state indepvarcomps whenver the solver needs to solve for
     the state or whenever the initial state is connected to an external source.

--- a/dymos/transcriptions/pseudospectral/components/state_interp_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/state_interp_comp.py
@@ -1,14 +1,14 @@
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 from six import string_types, iteritems
 
 from ...grid_data import GridData
 from ....utils.misc import get_rate_units
 
 
-class StateInterpComp(ExplicitComponent):
+class StateInterpComp(om.ExplicitComponent):
     r""" Provide interpolated state values and/or rates for pseudospectral transcriptions.
 
     When the transcription is *gauss-lobatto* it accepts the state values and derivatives

--- a/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_opt.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_opt.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from dymos.transcriptions.pseudospectral.components import CollocationComp
@@ -21,7 +21,7 @@ class TestCollocationComp(unittest.TestCase):
             num_segments=4, segment_ends=np.array([0., 2., 4., 5., 12.]),
             transcription=transcription, transcription_order=3)
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem(model=om.Group())
 
         state_options = {'x': {'units': 'm', 'shape': (1,), 'fix_initial': True,
                                'fix_final': False, 'solve_segments': False,
@@ -30,7 +30,7 @@ class TestCollocationComp(unittest.TestCase):
                                'fix_final': True, 'solve_segments': False,
                                'connected_initial': False, 'connected_final': False}}
 
-        indep_comp = IndepVarComp()
+        indep_comp = om.IndepVarComp()
         self.p.model.add_subsystem('indep', indep_comp, promotes_outputs=['*'])
 
         indep_comp.add_output(

--- a/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_sol_opt.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_sol_opt.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 
 from dymos.transcriptions.grid_data import GridData
 from dymos.transcriptions.pseudospectral.components import CollocationComp
@@ -17,7 +17,7 @@ class TestCollocationCompSolOpt(unittest.TestCase):
     # def setUp(self):
     def make_prob(self, transcription, n_segs, order, compressed):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         gd = GridData(num_segments=n_segs, segment_ends=np.arange(n_segs+1),
                       transcription=transcription, transcription_order=order, compressed=compressed)
@@ -29,7 +29,7 @@ class TestCollocationCompSolOpt(unittest.TestCase):
                                'fix_final': True, 'solve_segments': True,
                                'connected_initial': False}}
 
-        indep_comp = IndepVarComp()
+        indep_comp = om.IndepVarComp()
         p.model.add_subsystem('indep', indep_comp, promotes_outputs=['*'])
 
         indep_comp.add_output(

--- a/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_solver.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_solver.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 
 from dymos.transcriptions.grid_data import GridData
 from dymos.transcriptions.pseudospectral.components.collocation_comp import CollocationComp
@@ -16,7 +16,7 @@ class TestCollocationBalanceIndex(unittest.TestCase):
 
     def make_prob(self, transcription, n_segs, order, compressed):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         gd = GridData(num_segments=n_segs, segment_ends=np.arange(n_segs+1),
                       transcription=transcription, transcription_order=order, compressed=compressed)
@@ -126,9 +126,9 @@ class TestCollocationBalanceApplyNL(unittest.TestCase):
         num_col_nodes = gd.subset_num_nodes['col']
         num_col_nodes_per_seg = gd.subset_num_nodes_per_segment['col']
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        indep_comp = IndepVarComp()
+        indep_comp = om.IndepVarComp()
         p.model.add_subsystem('indep', indep_comp, promotes_outputs=['*'])
 
         indep_comp.add_output(

--- a/dymos/transcriptions/pseudospectral/components/test/test_control_endpoint_defect_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_control_endpoint_defect_comp.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_rel_error
 
 from dymos.transcriptions.pseudospectral.components import ControlEndpointDefectComp
@@ -19,12 +19,12 @@ class TestControlEndpointDefectComp(unittest.TestCase):
 
         self.gd = gd
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem(model=om.Group())
 
         control_opts = {'u': {'units': 'm', 'shape': (1,), 'dynamic': True, 'opt': True},
                         'v': {'units': 'm', 'shape': (3, 2), 'dynamic': True, 'opt': True}}
 
-        indep_comp = IndepVarComp()
+        indep_comp = om.IndepVarComp()
         self.p.model.add_subsystem('indep', indep_comp, promotes=['*'])
 
         indep_comp.add_output('controls:u',

--- a/dymos/transcriptions/pseudospectral/components/test/test_state_interp_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_state_interp_comp.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 from numpy.testing import assert_almost_equal
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from dymos.transcriptions.pseudospectral.components import StateInterpComp
@@ -46,12 +46,12 @@ class TestStateInterpComp(unittest.TestCase):
                       segment_ends=segends,
                       transcription='gauss-lobatto')
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         states = {'x': {'units': 'm', 'shape': (1,)},
                   'v': {'units': 'm/s', 'shape': (1,)}}
 
-        X_ivc = IndepVarComp()
+        X_ivc = om.IndepVarComp()
         p.model.add_subsystem('X_ivc', X_ivc, promotes=['state_disc:x', 'state_disc:v'])
 
         X_ivc.add_output('state_disc:x', val=np.zeros(gd.subset_num_nodes['state_disc']),
@@ -60,7 +60,7 @@ class TestStateInterpComp(unittest.TestCase):
         X_ivc.add_output('state_disc:v', val=np.zeros(gd.subset_num_nodes['state_disc']),
                          units='m/s')
 
-        F_ivc = IndepVarComp()
+        F_ivc = om.IndepVarComp()
         p.model.add_subsystem('F_ivc', F_ivc, promotes=['staterate_disc:x', 'staterate_disc:v'])
 
         F_ivc.add_output('staterate_disc:x',
@@ -71,7 +71,7 @@ class TestStateInterpComp(unittest.TestCase):
                          val=np.zeros(gd.subset_num_nodes['state_disc']),
                          units='m/s**2')
 
-        dt_dtau_ivc = IndepVarComp()
+        dt_dtau_ivc = om.IndepVarComp()
         p.model.add_subsystem('dt_dstau_ivc', dt_dtau_ivc, promotes=['dt_dstau'])
 
         dt_dtau_ivc.add_output('dt_dstau', val=0.0*np.zeros(gd.subset_num_nodes['col']), units='s')
@@ -158,24 +158,24 @@ class TestStateInterpComp(unittest.TestCase):
                       segment_ends=segends,
                       transcription='gauss-lobatto')
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         states = {'pos': {'units': 'm', 'shape': (2,)}}
 
-        X_ivc = IndepVarComp()
+        X_ivc = om.IndepVarComp()
         p.model.add_subsystem('X_ivc', X_ivc, promotes=['state_disc:pos'])
 
         X_ivc.add_output('state_disc:pos',
                          val=np.zeros((gd.subset_num_nodes['state_disc'], 2)), units='m')
 
-        F_ivc = IndepVarComp()
+        F_ivc = om.IndepVarComp()
         p.model.add_subsystem('F_ivc', F_ivc, promotes=['staterate_disc:pos'])
 
         F_ivc.add_output('staterate_disc:pos',
                          val=np.zeros((gd.subset_num_nodes['state_disc'], 2)),
                          units='m/s')
 
-        dt_dtau_ivc = IndepVarComp()
+        dt_dtau_ivc = om.IndepVarComp()
         p.model.add_subsystem('dt_dstau_ivc', dt_dtau_ivc, promotes=['dt_dstau'])
 
         dt_dtau_ivc.add_output('dt_dstau', val=0.0*np.zeros(gd.subset_num_nodes['col']), units='s')
@@ -268,24 +268,24 @@ class TestStateInterpComp(unittest.TestCase):
                       segment_ends=segends,
                       transcription='gauss-lobatto')
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         states = {'pos': {'units': 'm', 'shape': (2,)}}
 
-        X_ivc = IndepVarComp()
+        X_ivc = om.IndepVarComp()
         p.model.add_subsystem('X_ivc', X_ivc, promotes=['state_disc:pos'])
 
         X_ivc.add_output('state_disc:pos',
                          val=np.zeros((gd.subset_num_nodes['state_disc'], 2)), units='m')
 
-        F_ivc = IndepVarComp()
+        F_ivc = om.IndepVarComp()
         p.model.add_subsystem('F_ivc', F_ivc, promotes=['staterate_disc:pos'])
 
         F_ivc.add_output('staterate_disc:pos',
                          val=np.zeros((gd.subset_num_nodes['state_disc'], 2)),
                          units='m/s')
 
-        dt_dtau_ivc = IndepVarComp()
+        dt_dtau_ivc = om.IndepVarComp()
         p.model.add_subsystem('dt_dstau_ivc', dt_dtau_ivc, promotes=['dt_dstau'])
 
         dt_dtau_ivc.add_output('dt_dstau', val=0.0*np.zeros(gd.subset_num_nodes['col']), units='s')
@@ -324,12 +324,12 @@ class TestStateInterpComp(unittest.TestCase):
                       segment_ends=np.array([0, 10]),
                       transcription='radau-ps')
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         states = {'x': {'units': 'm', 'shape': (1,)},
                   'v': {'units': 'm/s', 'shape': (1,)}}
 
-        X_ivc = IndepVarComp()
+        X_ivc = om.IndepVarComp()
         p.model.add_subsystem('X_ivc', X_ivc, promotes=['state_disc:x', 'state_disc:v'])
 
         X_ivc.add_output('state_disc:x', val=np.zeros(gd.subset_num_nodes['state_disc']),
@@ -338,7 +338,7 @@ class TestStateInterpComp(unittest.TestCase):
         X_ivc.add_output('state_disc:v', val=np.zeros(gd.subset_num_nodes['state_disc']),
                          units='m/s')
 
-        dt_dtau_ivc = IndepVarComp()
+        dt_dtau_ivc = om.IndepVarComp()
         dt_dtau_ivc.add_output('dt_dstau', val=0.0*np.zeros(gd.subset_num_nodes['col']), units='s')
 
         p.model.add_subsystem('dt_dstau_ivc', dt_dtau_ivc, promotes=['dt_dstau'])

--- a/dymos/transcriptions/pseudospectral/pseudospectral_base.py
+++ b/dymos/transcriptions/pseudospectral/pseudospectral_base.py
@@ -1,13 +1,11 @@
 from __future__ import division, print_function, absolute_import
 
 from collections import Iterable
-import warnings
 
 import numpy as np
 from dymos.transcriptions.common import EndpointConditionsComp
 
-from openmdao.api import IndepVarComp, NonlinearRunOnce, NonlinearBlockGS, \
-    NewtonSolver, BoundsEnforceLS, DirectSolver
+import openmdao.api as om
 from six import iteritems
 
 from ..transcription_base import TranscriptionBase
@@ -65,7 +63,7 @@ class PseudospectralBase(TranscriptionBase):
                                   'indep_states.defects:{0}'.format(name))
 
         else:
-            indep = IndepVarComp()
+            indep = om.IndepVarComp()
 
             for name, options in iteritems(phase.state_options):
                 if not options['solve_segments'] and not options['connected_initial']:
@@ -223,7 +221,7 @@ class PseudospectralBase(TranscriptionBase):
                               src_indices=src_idxs, flat_src_indices=True)
 
     def setup_endpoint_conditions(self, phase):
-        jump_comp = phase.add_subsystem('indep_jumps', subsys=IndepVarComp(),
+        jump_comp = phase.add_subsystem('indep_jumps', subsys=om.IndepVarComp(),
                                         promotes_outputs=['*'])
 
         jump_comp.add_output('initial_jump:time', val=0.0, units=phase.time_options['units'],
@@ -316,11 +314,11 @@ class PseudospectralBase(TranscriptionBase):
 
     def setup_solvers(self, phase):
         if self.any_solved_segs:
-            newton = phase.nonlinear_solver = NewtonSolver()
+            newton = phase.nonlinear_solver = om.NewtonSolver()
             newton.options['solve_subsystems'] = True
             newton.options['iprint'] = -1
-            newton.linesearch = BoundsEnforceLS()
-            phase.linear_solver = DirectSolver()
+            newton.linesearch = om.BoundsEnforceLS()
+            phase.linear_solver = om.DirectSolver()
 
     def _get_boundary_constraint_src(self, var, loc, phase):
         # Determine the path to the variable which we will be constraining

--- a/dymos/transcriptions/runge_kutta/components/runge_kutta_k_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/runge_kutta_k_comp.py
@@ -4,13 +4,12 @@ from six import string_types, iteritems
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
-
+import openmdao.api as om
 from dymos.utils.rk_methods import rk_methods
 from dymos.utils.misc import get_rate_units
 
 
-class RungeKuttaKComp(ExplicitComponent):
+class RungeKuttaKComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_segments', types=int,

--- a/dymos/transcriptions/runge_kutta/components/runge_kutta_k_iter_group.py
+++ b/dymos/transcriptions/runge_kutta/components/runge_kutta_k_iter_group.py
@@ -65,7 +65,8 @@ class RungeKuttaKIterGroup(Group):
                            subsys=RungeKuttaKComp(method=self.options['method'],
                                                   num_segments=num_seg,
                                                   state_options=state_options,
-                                                  time_units=self.options['time_units']))
+                                                  time_units=self.options['time_units']),
+                           promotes_inputs=['h'])
 
         for state_name, options in iteritems(self.options['state_options']):
             # Connect the state predicted (assumed) value to its targets in the ode

--- a/dymos/transcriptions/runge_kutta/components/runge_kutta_k_iter_group.py
+++ b/dymos/transcriptions/runge_kutta/components/runge_kutta_k_iter_group.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 from six import string_types, iteritems
 
-from openmdao.api import Group, DirectSolver, NonlinearBlockGS, NewtonSolver, NonlinearRunOnce
+import openmdao.api as om
 
 from ....utils.rk_methods import rk_methods
 
@@ -10,7 +10,7 @@ from .runge_kutta_state_predict_comp import RungeKuttaStatePredictComp
 from .runge_kutta_k_comp import RungeKuttaKComp
 
 
-class RungeKuttaKIterGroup(Group):
+class RungeKuttaKIterGroup(om.Group):
     """
     This Group contains the state prediction component, the ODE, and the k-calculation component.
     Given the initial values of the states, the times at the ODE evaluations, and the stepsize
@@ -36,8 +36,8 @@ class RungeKuttaKIterGroup(Group):
         self.options.declare('ode_init_kwargs', types=dict, default={},
                              desc='Keyword arguments provided when initializing the ODE System')
 
-        self.options.declare('solver_class', default=NonlinearBlockGS,
-                             values=(NonlinearBlockGS, NewtonSolver, NonlinearRunOnce),
+        self.options.declare('solver_class', default=om.NonlinearBlockGS,
+                             values=(om.NonlinearBlockGS, om.NewtonSolver, om.NonlinearRunOnce),
                              allow_none=True,
                              desc='The nonlinear solver class used to converge the numerical '
                                   'integration of the segment.')
@@ -78,6 +78,6 @@ class RungeKuttaKIterGroup(Group):
             self.connect('k_comp.k:{0}'.format(state_name),
                          'state_predict_comp.k:{0}'.format(state_name))
 
-        self.linear_solver = DirectSolver()
+        self.linear_solver = om.DirectSolver()
         if self.options['solver_class']:
             self.nonlinear_solver = self.options['solver_class'](**self.options['solver_options'])

--- a/dymos/transcriptions/runge_kutta/components/runge_kutta_state_advance_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/runge_kutta_state_advance_comp.py
@@ -1,16 +1,16 @@
 from __future__ import print_function, division, absolute_import
 
-from six import string_types, iteritems
+from six import iteritems
 
 import numpy as np
 from scipy.linalg import block_diag
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 from dymos.utils.rk_methods import rk_methods
 
 
-class RungeKuttaStateAdvanceComp(ExplicitComponent):
+class RungeKuttaStateAdvanceComp(om.ExplicitComponent):
     """
     Given the initial value of each state at the start of each segment and the weight factors k
     for each state in each segment, compute the final value of each state at the end of each

--- a/dymos/transcriptions/runge_kutta/components/runge_kutta_state_continuity_iter_group.py
+++ b/dymos/transcriptions/runge_kutta/components/runge_kutta_state_continuity_iter_group.py
@@ -3,8 +3,7 @@ from __future__ import print_function, division, absolute_import
 import numpy as np
 from six import string_types, iteritems
 
-from openmdao.api import Group, IndepVarComp, DirectSolver, NonlinearBlockGS, NewtonSolver, \
-    NonlinearRunOnce
+import openmdao.api as om
 
 from .runge_kutta_k_iter_group import RungeKuttaKIterGroup
 from .runge_kutta_state_advance_comp import RungeKuttaStateAdvanceComp
@@ -12,7 +11,7 @@ from .runge_kutta_state_continuity_comp import RungeKuttaStateContinuityComp
 from ....utils.indexing import get_src_indices_by_row
 
 
-class RungeKuttaStateContinuityIterGroup(Group):
+class RungeKuttaStateContinuityIterGroup(om.Group):
     """
     This Group contains the k-iteration subgroup, the state advance component, continuity defect
     component.  Given the initial value of each state at the beginning of the first segment,
@@ -41,8 +40,8 @@ class RungeKuttaStateContinuityIterGroup(Group):
         self.options.declare('ode_init_kwargs', types=dict, default={},
                              desc='Keyword arguments provided when initializing the ODE System')
 
-        self.options.declare('k_solver_class', default=NonlinearBlockGS,
-                             values=(NonlinearBlockGS, NewtonSolver, NonlinearRunOnce),
+        self.options.declare('k_solver_class', default=om.NonlinearBlockGS,
+                             values=(om.NonlinearBlockGS, om.NewtonSolver, om.NonlinearRunOnce),
                              allow_none=True,
                              desc='The nonlinear solver class used to converge the numerical '
                                   'integration across each segment.')
@@ -94,4 +93,4 @@ class RungeKuttaStateContinuityIterGroup(Group):
                          'initial_states_per_seg:{0}'.format(state_name),
                          src_indices=src_idxs, flat_src_indices=True)
 
-        self.linear_solver = DirectSolver()
+        self.linear_solver = om.DirectSolver()

--- a/dymos/transcriptions/runge_kutta/components/runge_kutta_state_continuity_iter_group.py
+++ b/dymos/transcriptions/runge_kutta/components/runge_kutta_state_continuity_iter_group.py
@@ -61,7 +61,8 @@ class RungeKuttaStateContinuityIterGroup(Group):
                                                 ode_init_kwargs=self.options['ode_init_kwargs'],
                                                 solver_class=self.options['k_solver_class'],
                                                 solver_options=self.options['k_solver_options']),
-                           promotes_inputs=['initial_states_per_seg:*'])
+                           promotes_inputs=['*'],
+                           promotes_outputs=['*'])
 
         self.add_subsystem('state_advance_comp',
                            RungeKuttaStateAdvanceComp(num_segments=self.options['num_segments'],
@@ -85,7 +86,7 @@ class RungeKuttaStateContinuityIterGroup(Group):
                            promotes_outputs=['states:*'])
 
         for state_name, options in iteritems(self.options['state_options']):
-            self.connect('k_iter_group.k_comp.k:{0}'.format(state_name),
+            self.connect('k_comp.k:{0}'.format(state_name),
                          'state_advance_comp.k:{0}'.format(state_name))
             row_idxs = np.arange(self.options['num_segments'], dtype=int)
             src_idxs = get_src_indices_by_row(row_idxs, options['shape'])

--- a/dymos/transcriptions/runge_kutta/components/runge_kutta_state_predict_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/runge_kutta_state_predict_comp.py
@@ -5,12 +5,12 @@ from six import iteritems
 import numpy as np
 from scipy.linalg import block_diag
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 from dymos.utils.rk_methods import rk_methods
 
 
-class RungeKuttaStatePredictComp(ExplicitComponent):
+class RungeKuttaStatePredictComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_segments', types=int,

--- a/dymos/transcriptions/runge_kutta/components/runge_kutta_stepsize_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/runge_kutta_stepsize_comp.py
@@ -5,10 +5,10 @@ from six import string_types
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class RungeKuttaStepsizeComp(ExplicitComponent):
+class RungeKuttaStepsizeComp(om.ExplicitComponent):
     """
     Given the duration of the phase and the segment relative lengths, compute the duration of
     each segment (the step size) for each segment (step).

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_comp.py
@@ -4,8 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp, NonlinearRunOnce, NonlinearBlockGS, \
-    NewtonSolver, DirectSolver
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 from dymos.transcriptions.runge_kutta.components.runge_kutta_state_continuity_comp import \
@@ -20,7 +19,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
                                'defect_scaler': None, 'defect_ref': None,
                                'lower': None, 'upper': None, 'connected_initial': False}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         p.model.add_subsystem('continuity_comp',
                               RungeKuttaStateContinuityComp(num_segments=num_seg,
@@ -28,8 +27,8 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
                               promotes_inputs=['*'],
                               promotes_outputs=['*'])
 
-        p.model.nonlinear_solver = NonlinearRunOnce()
-        p.model.linear_solver = DirectSolver()
+        p.model.nonlinear_solver = om.NonlinearRunOnce()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True, force_alloc_complex=True)
 
@@ -85,9 +84,9 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
                                'defect_scaler': None, 'defect_ref': None,
                                'lower': None, 'upper': None, 'connected_initial': True}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
         ivc.add_output('initial_states:y', units='m', shape=(1, 1))
 
         p.model.add_subsystem('continuity_comp',
@@ -96,8 +95,8 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
                               promotes_inputs=['*'],
                               promotes_outputs=['*'])
 
-        p.model.nonlinear_solver = NonlinearRunOnce()
-        p.model.linear_solver = DirectSolver()
+        p.model.nonlinear_solver = om.NonlinearRunOnce()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True, force_alloc_complex=True)
 
@@ -155,7 +154,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
                                'fix_final': False, 'defect_scaler': None, 'defect_ref': None,
                                'lower': None, 'upper': None, 'connected_initial': False}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         p.model.add_subsystem('continuity_comp',
                               RungeKuttaStateContinuityComp(num_segments=num_seg,
@@ -163,8 +162,8 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
                               promotes_inputs=['*'],
                               promotes_outputs=['*'])
 
-        p.model.nonlinear_solver = NonlinearBlockGS(iprint=2)
-        p.model.linear_solver = DirectSolver()
+        p.model.nonlinear_solver = om.NonlinearBlockGS(iprint=2)
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True, force_alloc_complex=True)
 
@@ -220,9 +219,9 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
                                'fix_final': False, 'defect_scaler': None, 'defect_ref': None,
                                'lower': None, 'upper': None, 'connected_initial': True}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
         ivc.add_output('initial_states:y', units='m', shape=(1, 1))
 
         p.model.add_subsystem('continuity_comp',
@@ -231,8 +230,8 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
                               promotes_inputs=['*'],
                               promotes_outputs=['*'])
 
-        p.model.nonlinear_solver = NonlinearBlockGS(iprint=2)
-        p.model.linear_solver = DirectSolver()
+        p.model.nonlinear_solver = om.NonlinearBlockGS(iprint=2)
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True, force_alloc_complex=True)
 
@@ -290,7 +289,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
                                'fix_final': False, 'defect_scaler': None, 'defect_ref': None,
                                'lower': None, 'upper': None, 'connected_initial': False}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         p.model.add_subsystem('continuity_comp',
                               RungeKuttaStateContinuityComp(num_segments=num_seg,
@@ -298,8 +297,8 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
                               promotes_inputs=['*'],
                               promotes_outputs=['*'])
 
-        p.model.nonlinear_solver = NewtonSolver(iprint=2)
-        p.model.linear_solver = DirectSolver()
+        p.model.nonlinear_solver = om.NewtonSolver(iprint=2)
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True, force_alloc_complex=True)
 
@@ -348,7 +347,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
                                'lower': None, 'upper': None, 'lower': None, 'upper': None,
                                'connected_initial': False}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         p.model.add_subsystem('continuity_comp',
                               RungeKuttaStateContinuityComp(num_segments=num_seg,
@@ -356,8 +355,8 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
                               promotes_inputs=['*'],
                               promotes_outputs=['*'])
 
-        p.model.nonlinear_solver = NonlinearRunOnce()
-        p.model.linear_solver = DirectSolver()
+        p.model.nonlinear_solver = om.NonlinearRunOnce()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True, force_alloc_complex=True)
 
@@ -410,7 +409,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
                                'fix_final': False, 'defect_ref': None, 'lower': None, 'upper': None,
                                'connected_initial': False}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         p.model.add_subsystem('continuity_comp',
                               RungeKuttaStateContinuityComp(num_segments=num_seg,
@@ -418,8 +417,8 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
                               promotes_inputs=['*'],
                               promotes_outputs=['*'])
 
-        p.model.nonlinear_solver = NonlinearBlockGS(iprint=2)
-        p.model.linear_solver = DirectSolver()
+        p.model.nonlinear_solver = om.NonlinearBlockGS(iprint=2)
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True, force_alloc_complex=True)
 
@@ -464,9 +463,9 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
                                'fix_final': False, 'defect_ref': None, 'lower': None, 'upper': None,
                                'connected_initial': True}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
         ivc.add_output('initial_states:y', units='m', shape=(1, 2))
 
         p.model.add_subsystem('continuity_comp',
@@ -475,8 +474,8 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
                               promotes_inputs=['*'],
                               promotes_outputs=['*'])
 
-        p.model.nonlinear_solver = NonlinearBlockGS(iprint=2)
-        p.model.linear_solver = DirectSolver()
+        p.model.nonlinear_solver = om.NonlinearBlockGS(iprint=2)
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True, force_alloc_complex=True)
 
@@ -523,7 +522,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
                                'fix_final': False, 'defect_ref': 1, 'lower': None, 'upper': None,
                                'connected_initial': False}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
         p.model.add_subsystem('continuity_comp',
                               RungeKuttaStateContinuityComp(num_segments=num_seg,
@@ -531,8 +530,8 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
                               promotes_inputs=['*'],
                               promotes_outputs=['*'])
 
-        p.model.nonlinear_solver = NewtonSolver(iprint=2)
-        p.model.linear_solver = DirectSolver()
+        p.model.nonlinear_solver = om.NewtonSolver(iprint=2)
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True, force_alloc_complex=True)
 

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_iter_group.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_iter_group.py
@@ -43,12 +43,11 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
                                   k_solver_class=NonlinearRunOnce),
                               promotes_outputs=['states:*'])
 
-        p.model.connect('h', 'cnty_iter_group.k_iter_group.k_comp.h')
-        p.model.connect('time', 'cnty_iter_group.k_iter_group.ode.t')
+        p.model.connect('h', 'cnty_iter_group.h')
+        p.model.connect('time', 'cnty_iter_group.ode.t')
 
         src_idxs = np.arange(16, dtype=int).reshape((num_seg, 4, 1))
-        p.model.connect('cnty_iter_group.k_iter_group.ode.ydot',
-                        'cnty_iter_group.k_iter_group.k_comp.f:y',
+        p.model.connect('cnty_iter_group.ode.ydot', 'cnty_iter_group.k_comp.f:y',
                         src_indices=src_idxs, flat_src_indices=True)
 
         p.model.nonlinear_solver = NonlinearRunOnce()
@@ -62,25 +61,25 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
                                   [4.006818970044454],
                                   [5.301605229265987]])
 
-        p['cnty_iter_group.k_iter_group.k_comp.k:y'] = np.array([[[0.75000000],
-                                                                  [0.90625000],
-                                                                  [0.94531250],
-                                                                  [1.09765625]],
+        p['cnty_iter_group.k_comp.k:y'] = np.array([[[0.75000000],
+                                                     [0.90625000],
+                                                     [0.94531250],
+                                                     [1.09765625]],
 
-                                                                 [[1.087565104166667],
-                                                                  [1.203206380208333],
-                                                                  [1.232116699218750],
-                                                                  [1.328623453776042]],
+                                                    [[1.087565104166667],
+                                                     [1.203206380208333],
+                                                     [1.232116699218750],
+                                                     [1.328623453776042]],
 
-                                                                 [[1.319801330566406],
-                                                                  [1.368501663208008],
-                                                                  [1.380676746368408],
-                                                                  [1.385139703750610]],
+                                                    [[1.319801330566406],
+                                                     [1.368501663208008],
+                                                     [1.380676746368408],
+                                                     [1.385139703750610]],
 
-                                                                 [[1.378409485022227],
-                                                                  [1.316761856277783],
-                                                                  [1.301349949091673],
-                                                                  [1.154084459568063]]])
+                                                    [[1.378409485022227],
+                                                     [1.316761856277783],
+                                                     [1.301349949091673],
+                                                     [1.154084459568063]]])
 
         p.run_model()
         p.model.run_apply_nonlinear()
@@ -131,21 +130,21 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
         ivc.add_output('h', val=np.array([0.5, 0.5, 0.5, 0.5]), units='s')
 
         p.model.add_subsystem('cnty_iter_group',
-                              RungeKuttaStateContinuityIterGroup(num_segments=num_seg,
-                                                                 method='RK4',
-                                                                 state_options=state_options,
-                                                                 time_units='s',
-                                                                 ode_class=TestODE,
-                                                                 ode_init_kwargs={},
-                                                                 k_solver_class=None),
+                              RungeKuttaStateContinuityIterGroup(
+                                  num_segments=num_seg,
+                                  method='RK4',
+                                  state_options=state_options,
+                                  time_units='s',
+                                  ode_class=TestODE,
+                                  ode_init_kwargs={},
+                                  k_solver_class=None),
                               promotes_outputs=['states:*'])
 
-        p.model.connect('h', 'cnty_iter_group.k_iter_group.k_comp.h')
-        p.model.connect('time', 'cnty_iter_group.k_iter_group.ode.t')
+        p.model.connect('h', 'cnty_iter_group.h')
+        p.model.connect('time', 'cnty_iter_group.ode.t')
 
         src_idxs = np.arange(16, dtype=int).reshape((num_seg, 4, 1))
-        p.model.connect('cnty_iter_group.k_iter_group.ode.ydot',
-                        'cnty_iter_group.k_iter_group.k_comp.f:y',
+        p.model.connect('cnty_iter_group.ode.ydot', 'cnty_iter_group.k_comp.f:y',
                         src_indices=src_idxs, flat_src_indices=True)
 
         p.model.nonlinear_solver = NewtonSolver()

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_iter_group.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_iter_group.py
@@ -4,8 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp, NonlinearRunOnce, \
-    NewtonSolver, DirectSolver
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 from dymos.transcriptions.runge_kutta.components import RungeKuttaStateContinuityIterGroup
@@ -21,9 +20,9 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
                                'defect_ref': None, 'lower': None, 'upper': None,
                                'connected_initial': False}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('time', val=np.array([0.00, 0.25, 0.25, 0.50,
                                              0.50, 0.75, 0.75, 1.00,
@@ -40,7 +39,7 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
                                   time_units='s',
                                   ode_class=TestODE,
                                   ode_init_kwargs={},
-                                  k_solver_class=NonlinearRunOnce),
+                                  k_solver_class=om.NonlinearRunOnce),
                               promotes_outputs=['states:*'])
 
         p.model.connect('h', 'cnty_iter_group.h')
@@ -50,8 +49,8 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
         p.model.connect('cnty_iter_group.ode.ydot', 'cnty_iter_group.k_comp.f:y',
                         src_indices=src_idxs, flat_src_indices=True)
 
-        p.model.nonlinear_solver = NonlinearRunOnce()
-        p.model.linear_solver = DirectSolver()
+        p.model.nonlinear_solver = om.NonlinearRunOnce()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True, force_alloc_complex=True)
 
@@ -118,9 +117,9 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
                                'defect_ref': 1.0, 'lower': None, 'upper': None,
                                'connected_initial': False}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('time', val=np.array([0.00, 0.25, 0.25, 0.50,
                                              0.50, 0.75, 0.75, 1.00,
@@ -147,8 +146,8 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
         p.model.connect('cnty_iter_group.ode.ydot', 'cnty_iter_group.k_comp.f:y',
                         src_indices=src_idxs, flat_src_indices=True)
 
-        p.model.nonlinear_solver = NewtonSolver()
-        p.model.linear_solver = DirectSolver()
+        p.model.nonlinear_solver = om.NewtonSolver()
+        p.model.linear_solver = om.DirectSolver()
 
         p.setup(check=True, force_alloc_complex=True)
 

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_k_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_k_comp.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
 
 from dymos.transcriptions.runge_kutta.components.runge_kutta_k_comp import RungeKuttaKComp
@@ -15,9 +15,9 @@ class TestRKKComp(unittest.TestCase):
     def test_rk_k_comp_rk4_scalar(self):
         state_options = {'y': {'shape': (1,), 'units': 'm'}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('h', shape=(4,), units='s')
         ivc.add_output('f:y', shape=(4, 4, 1), units='m/s')
@@ -86,9 +86,9 @@ class TestRKKComp(unittest.TestCase):
         num_seg = 2
         state_options = {'y': {'shape': (num_seg,), 'units': 'm'}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('h', shape=(num_seg,), units='s')
         ivc.add_output('f:y', shape=(num_seg, 4, 2), units='m/s')
@@ -134,9 +134,9 @@ class TestRKKComp(unittest.TestCase):
         num_stages = 4
         state_options = {'y': {'shape': (2, 2), 'units': 'm'}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('h', shape=(num_seg,), units='s')
         ivc.add_output('f:y', shape=(num_seg, num_stages, 2, 2), units='m/s')

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_k_iter_group.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_k_iter_group.py
@@ -5,8 +5,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from openmdao.api import Problem, Group, IndepVarComp, NonlinearRunOnce, NonlinearBlockGS, \
-    NewtonSolver
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from dymos.transcriptions.runge_kutta.components.runge_kutta_k_iter_group import RungeKuttaKIterGroup
@@ -20,9 +19,9 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
         num_stages = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y']}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('initial_states_per_seg:y', shape=(num_seg, 1), units='m')
         ivc.add_output('h', shape=(num_seg, 1), units='s')
@@ -35,7 +34,7 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
                                                    time_units='s',
                                                    ode_class=TestODE,
                                                    ode_init_kwargs={},
-                                                   solver_class=NonlinearRunOnce))
+                                                   solver_class=om.NonlinearRunOnce))
 
         p.model.connect('t', 'k_iter_group.ode.t')
         p.model.connect('h', 'k_iter_group.h')
@@ -95,9 +94,9 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
         num_stages = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y']}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('initial_states_per_seg:y', shape=(num_seg, 1), units='m')
         ivc.add_output('h', shape=(num_seg, 1), units='s')
@@ -110,7 +109,7 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
                                                    time_units='s',
                                                    ode_class=TestODE,
                                                    ode_init_kwargs={},
-                                                   solver_class=NonlinearBlockGS,
+                                                   solver_class=om.NonlinearBlockGS,
                                                    solver_options={'iprint': 2}))
 
         p.model.connect('t', 'k_iter_group.ode.t')
@@ -154,9 +153,9 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
         num_stages = 4
         state_options = {'y': {'shape': (1,), 'units': 'm', 'targets': ['y']}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('initial_states_per_seg:y', shape=(num_seg, 1), units='m')
         ivc.add_output('h', shape=(num_seg, 1), units='s')
@@ -169,7 +168,7 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
                                                    time_units='s',
                                                    ode_class=TestODE,
                                                    ode_init_kwargs={},
-                                                   solver_class=NewtonSolver,
+                                                   solver_class=om.NewtonSolver,
                                                    solver_options={'iprint': 2}))
 
         p.model.connect('t', 'k_iter_group.ode.t')

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_k_iter_group.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_k_iter_group.py
@@ -38,7 +38,7 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
                                                    solver_class=NonlinearRunOnce))
 
         p.model.connect('t', 'k_iter_group.ode.t')
-        p.model.connect('h', 'k_iter_group.k_comp.h')
+        p.model.connect('h', 'k_iter_group.h')
         p.model.connect('initial_states_per_seg:y', 'k_iter_group.initial_states_per_seg:y')
 
         src_idxs = np.arange(16, dtype=int).reshape((num_seg, num_stages, 1))
@@ -114,7 +114,7 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
                                                    solver_options={'iprint': 2}))
 
         p.model.connect('t', 'k_iter_group.ode.t')
-        p.model.connect('h', 'k_iter_group.k_comp.h')
+        p.model.connect('h', 'k_iter_group.h')
         p.model.connect('initial_states_per_seg:y', 'k_iter_group.initial_states_per_seg:y')
 
         src_idxs = np.arange(16, dtype=int).reshape((num_seg, num_stages, 1))
@@ -173,7 +173,7 @@ class TestRungeKuttaKIterGroup(unittest.TestCase):
                                                    solver_options={'iprint': 2}))
 
         p.model.connect('t', 'k_iter_group.ode.t')
-        p.model.connect('h', 'k_iter_group.k_comp.h')
+        p.model.connect('h', 'k_iter_group.h')
         p.model.connect('initial_states_per_seg:y', 'k_iter_group.initial_states_per_seg:y')
 
         src_idxs = np.arange(16, dtype=int).reshape((num_seg, num_stages, 1))

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_path_constraint_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_path_constraint_comp.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 from numpy.testing import assert_almost_equal
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials
 
 from dymos.transcriptions.runge_kutta.components import RungeKuttaPathConstraintComp
@@ -25,7 +25,7 @@ class TestPathConstraintCompExplicit(unittest.TestCase):
 
         nn = 4
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem(model=om.Group())
 
         controls = {'a': ControlOptionsDictionary(),
                     'b': ControlOptionsDictionary(),
@@ -36,7 +36,7 @@ class TestPathConstraintCompExplicit(unittest.TestCase):
         controls['b'].update({'units': 's', 'shape': (3,), 'opt': False})
         controls['c'].update({'units': 'kg', 'shape': (3, 3), 'opt': False})
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         self.p.model.add_subsystem('ivc', ivc, promotes_outputs=['*'])
 
         ivc.add_output('a_disc', val=np.zeros((nn, 1)), units='m')

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_state_advance_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_state_advance_comp.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
 
 from dymos.transcriptions.runge_kutta.components.runge_kutta_state_advance_comp import \
@@ -16,9 +16,9 @@ class TestRKStateAdvanceComp(unittest.TestCase):
     def test_rk_state_advance_comp_rk4_scalar(self):
         state_options = {'y': {'shape': (1,), 'units': 'm'}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('k:y', shape=(4, 4, 1), units='m')
         ivc.add_output('y0', shape=(4, 1), units='m')
@@ -70,9 +70,9 @@ class TestRKStateAdvanceComp(unittest.TestCase):
     def test_rk_state_advance_comp_rk4_vector(self):
         state_options = {'y': {'shape': (2,), 'units': 'm'}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('k:y', shape=(2, 4, 2), units='m')
         ivc.add_output('y0', shape=(2, 2), units='m')
@@ -107,9 +107,9 @@ class TestRKStateAdvanceComp(unittest.TestCase):
     def test_rk_state_advance_comp_rk4_matrix(self):
         state_options = {'y': {'shape': (2, 2), 'units': 'm'}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('k:y', shape=(4, 2, 2), units='m')
         ivc.add_output('y0', shape=(2, 2), units='m')

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_state_predict_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_state_predict_comp.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
 
 from dymos.transcriptions.runge_kutta.components.runge_kutta_state_predict_comp import \
@@ -17,9 +17,9 @@ class TestRKStatePredictComp(unittest.TestCase):
         num_seg = 4
         state_options = {'y': {'shape': (1,), 'units': 'm'}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('k:y', shape=(num_seg, 4, 1), units='m')
         ivc.add_output('y0', shape=(num_seg, 1), units='m')
@@ -87,9 +87,9 @@ class TestRKStatePredictComp(unittest.TestCase):
         num_seg = 3
         state_options = {'y': {'shape': (1,), 'units': 'm'}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('k:y', shape=(num_seg, 4, 1), units='m')
         ivc.add_output('y0', shape=(num_seg, 1), units='m')
@@ -147,9 +147,9 @@ class TestRKStatePredictComp(unittest.TestCase):
         num_seg = 2
         state_options = {'y': {'shape': (2,), 'units': 'm'}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('k:y', shape=(num_seg, 4, 2), units='m')
         ivc.add_output('y0', shape=(num_seg, 2), units='m')
@@ -195,9 +195,9 @@ class TestRKStatePredictComp(unittest.TestCase):
     def test_rk_state_advance_comp_rk4_matrix(self):
         state_options = {'y': {'shape': (2, 2), 'units': 'm'}}
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('k:y', shape=(1, 4, 2, 2), units='m')
         ivc.add_output('y0', shape=(1, 2, 2), units='m')

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_stepsize_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_stepsize_comp.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
 
 from dymos.transcriptions.runge_kutta.components.runge_kutta_stepsize_comp import RungeKuttaStepsizeComp
@@ -13,9 +13,9 @@ from dymos.transcriptions.runge_kutta.components.runge_kutta_stepsize_comp impor
 class TestRKStepsizeComp(unittest.TestCase):
 
     def test_rk_stepsize_comp(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('t_duration', shape=(1,), units='s')
 
@@ -41,9 +41,9 @@ class TestRKStepsizeComp(unittest.TestCase):
         assert_check_partials(cpd)
 
     def test_rk_stepsize_comp_nonuniform(self):
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        ivc = p.model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
 
         ivc.add_output('t_duration', shape=(1,), units='s')
 

--- a/dymos/transcriptions/runge_kutta/runge_kutta.py
+++ b/dymos/transcriptions/runge_kutta/runge_kutta.py
@@ -1,11 +1,8 @@
 from __future__ import division, print_function, absolute_import
 
-import warnings
-
 import numpy as np
 
-from openmdao.api import IndepVarComp, NonlinearRunOnce, NonlinearBlockGS, \
-    NewtonSolver, BoundsEnforceLS
+import openmdao.api as om
 from six import iteritems
 
 from ..transcription_base import TranscriptionBase
@@ -31,8 +28,8 @@ class RungeKutta(TranscriptionBase):
         self.options.declare('method', default='RK4', values=('RK4',),
                              desc='The integrator used within the explicit phase.')
 
-        self.options.declare('k_solver_class', default=NonlinearBlockGS,
-                             values=(NonlinearBlockGS, NewtonSolver, NonlinearRunOnce),
+        self.options.declare('k_solver_class', default=om.NonlinearBlockGS,
+                             values=(om.NonlinearBlockGS, om.NewtonSolver, om.NonlinearRunOnce),
                              allow_none=True,
                              desc='The nonlinear solver class used to converge the numerical '
                                   'integration across each segment.')
@@ -61,11 +58,11 @@ class RungeKutta(TranscriptionBase):
         -------
 
         """
-        phase.nonlinear_solver = NewtonSolver()
+        phase.nonlinear_solver = om.NewtonSolver()
         phase.nonlinear_solver.options['iprint'] = -1
         phase.nonlinear_solver.options['solve_subsystems'] = True
         phase.nonlinear_solver.options['err_on_maxiter'] = True
-        phase.nonlinear_solver.linesearch = BoundsEnforceLS()
+        phase.nonlinear_solver.linesearch = om.BoundsEnforceLS()
 
     def setup_time(self, phase):
         time_units = phase.time_options['units']
@@ -428,7 +425,7 @@ class RungeKutta(TranscriptionBase):
 
     def setup_endpoint_conditions(self, phase):
 
-        jump_comp = phase.add_subsystem('indep_jumps', subsys=IndepVarComp(),
+        jump_comp = phase.add_subsystem('indep_jumps', subsys=om.IndepVarComp(),
                                         promotes_outputs=['*'])
 
         jump_comp.add_output('initial_jump:time', val=0.0, units=phase.time_options['units'],

--- a/dymos/transcriptions/runge_kutta/test/rk_test_ode.py
+++ b/dymos/transcriptions/runge_kutta/test/rk_test_ode.py
@@ -1,13 +1,13 @@
 from __future__ import print_function, division, absolute_import
 
 import numpy as np
-from openmdao.api import ExplicitComponent
-from dymos import declare_time, declare_state
+import openmdao.api as om
+import dymos as dm
 
 
-@declare_time(targets=['t'], units='s')
-@declare_state('y', targets=['y'], rate_source='ydot', units='m')
-class TestODE(ExplicitComponent):
+@dm.declare_time(targets=['t'], units='s')
+@dm.declare_state('y', targets=['y'], rate_source='ydot', units='m')
+class TestODE(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)

--- a/dymos/transcriptions/runge_kutta/test/test_rk4_simple_integration.py
+++ b/dymos/transcriptions/runge_kutta/test/test_rk4_simple_integration.py
@@ -4,11 +4,10 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
-from dymos.phase import Phase
-from dymos.transcriptions import RungeKutta
+import dymos as dm
 from dymos.transcriptions.runge_kutta.test.rk_test_ode import TestODE, _test_ode_solution
 
 
@@ -16,8 +15,8 @@ class TestRK4SimpleIntegration(unittest.TestCase):
 
     def test_simple_integration_forward(self):
 
-        p = Problem(model=Group())
-        phase = Phase(ode_class=TestODE, transcription=RungeKutta(num_segments=200, method='RK4'))
+        p = om.Problem(model=om.Group())
+        phase = dm.Phase(ode_class=TestODE, transcription=dm.RungeKutta(num_segments=200, method='RK4'))
         p.model.add_subsystem('phase0', subsys=phase)
 
         phase.set_time_options(fix_initial=True, fix_duration=True)
@@ -39,10 +38,11 @@ class TestRK4SimpleIntegration(unittest.TestCase):
 
     def test_simple_integration_forward_connected_initial(self):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        phase = Phase(ode_class=TestODE, transcription=RungeKutta(num_segments=200, method='RK4'))
-        p.model.add_subsystem('phase0', subsys=phase)
+        traj = p.model.add_subsystem('traj', subsys=dm.Trajectory())
+        phase = dm.Phase(ode_class=TestODE, transcription=dm.RungeKutta(num_segments=200, method='RK4'))
+        traj.add_phase('phase0', phase)
 
         phase.set_time_options(fix_initial=True, fix_duration=True)
         phase.set_state_options('y', fix_initial=False, connected_initial=True)
@@ -51,25 +51,25 @@ class TestRK4SimpleIntegration(unittest.TestCase):
 
         p.setup(check=True, force_alloc_complex=True)
 
-        p['phase0.t_initial'] = 0.0
-        p['phase0.t_duration'] = 2.0
+        p['traj.phase0.t_initial'] = 0.0
+        p['traj.phase0.t_duration'] = 2.0
 
         # The initial guess of states at the segment boundaries
-        p['phase0.states:y'] = 0.0
+        p['traj.phase0.states:y'] = 0.0
 
         # The initial value of the states from which the integration proceeds
-        p['phase0.initial_states:y'] = 0.5
+        p['traj.phase0.initial_states:y'] = 0.5
 
         p.run_model()
 
-        expected = _test_ode_solution(p['phase0.ode.y'], p['phase0.ode.t'])
-        assert_rel_error(self, p['phase0.ode.y'], expected, tolerance=1.0E-3)
+        expected = _test_ode_solution(p['traj.phase0.ode.y'], p['traj.phase0.ode.t'])
+        assert_rel_error(self, p['traj.phase0.ode.y'], expected, tolerance=1.0E-3)
 
     def test_simple_integration_forward_connected_initial_fixed_initial(self):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        phase = Phase(ode_class=TestODE, transcription=RungeKutta(num_segments=200, method='RK4'))
+        phase = dm.Phase(ode_class=TestODE, transcription=dm.RungeKutta(num_segments=200, method='RK4'))
         p.model.add_subsystem('phase0', subsys=phase)
 
         phase.set_time_options(fix_initial=True, fix_duration=True)
@@ -85,9 +85,9 @@ class TestRK4SimpleIntegration(unittest.TestCase):
 
     def test_simple_integration_backward(self):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        phase = Phase(ode_class=TestODE, transcription=RungeKutta(num_segments=4, method='RK4'))
+        phase = dm.Phase(ode_class=TestODE, transcription=dm.RungeKutta(num_segments=4, method='RK4'))
         p.model.add_subsystem('phase0', subsys=phase)
 
         phase.set_time_options(fix_initial=True, fix_duration=True)
@@ -109,9 +109,9 @@ class TestRK4SimpleIntegration(unittest.TestCase):
 
     def test_simple_integration_backward_connected_initial(self):
 
-        p = Problem(model=Group())
+        p = om.Problem(model=om.Group())
 
-        phase = Phase(ode_class=TestODE, transcription=RungeKutta(num_segments=4, method='RK4'))
+        phase = dm.Phase(ode_class=TestODE, transcription=dm.RungeKutta(num_segments=4, method='RK4'))
         p.model.add_subsystem('phase0', subsys=phase)
 
         phase.set_time_options(fix_initial=True, fix_duration=True)

--- a/dymos/transcriptions/solve_ivp/components/ode_integration_interface.py
+++ b/dymos/transcriptions/solve_ivp/components/ode_integration_interface.py
@@ -7,9 +7,7 @@ from six import iteritems, string_types
 import numpy as np
 from .odeint_control_interpolation_comp import ODEIntControlInterpolationComp
 from .state_rate_collector_comp import StateRateCollectorComp
-from openmdao.core.group import Group
-from openmdao.core.indepvarcomp import IndepVarComp
-from openmdao.core.problem import Problem
+import openmdao.api as om
 
 
 class ODEIntegrationInterface(object):
@@ -74,11 +72,11 @@ class ODEIntegrationInterface(object):
         #
         # Build odeint problem interface
         #
-        self.prob = Problem(model=Group())
+        self.prob = om.Problem(model=om.Group())
         model = self.prob.model
 
         # The time IVC
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         time_units = self.time_options['units']
         ivc.add_output('time', val=0.0, units=time_units)
         ivc.add_output('time_phase', val=-88.0, units=time_units)

--- a/dymos/transcriptions/solve_ivp/components/odeint_control_interpolation_comp.py
+++ b/dymos/transcriptions/solve_ivp/components/odeint_control_interpolation_comp.py
@@ -1,9 +1,9 @@
 from dymos.utils.misc import get_rate_units
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
 from six import string_types, iteritems
 
 
-class ODEIntControlInterpolationComp(ExplicitComponent):
+class ODEIntControlInterpolationComp(om.ExplicitComponent):
     """
     Provides the interpolated value and rate of a control variable during explicit integration.
 

--- a/dymos/transcriptions/solve_ivp/components/segment_simulation_comp.py
+++ b/dymos/transcriptions/solve_ivp/components/segment_simulation_comp.py
@@ -10,15 +10,14 @@ from six import iteritems
 
 from scipy.integrate import solve_ivp
 
-from openmdao.api import ExplicitComponent
-
+import openmdao.api as om
 from ....utils.interpolate import LagrangeBarycentricInterpolant
 from ....utils.lgl import lgl
 from .ode_integration_interface import ODEIntegrationInterface
 from ....phase.options import TimeOptionsDictionary
 
 
-class SegmentSimulationComp(ExplicitComponent):
+class SegmentSimulationComp(om.ExplicitComponent):
     """
     SegmentSimulationComp is a component which, given values for time, states, and controls
     within a given segment, explicitly simulates the segment using scipy.integrate.solve_ivp.

--- a/dymos/transcriptions/solve_ivp/components/segment_state_mux_comp.py
+++ b/dymos/transcriptions/solve_ivp/components/segment_state_mux_comp.py
@@ -3,10 +3,10 @@ from __future__ import print_function, division, absolute_import
 from six import iteritems
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class SegmentStateMuxComp(ExplicitComponent):
+class SegmentStateMuxComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('grid_data', desc='the grid data of the corresponding phase.')

--- a/dymos/transcriptions/solve_ivp/components/solve_ivp_control_group.py
+++ b/dymos/transcriptions/solve_ivp/components/solve_ivp_control_group.py
@@ -5,14 +5,14 @@ from six import string_types, iteritems
 import numpy as np
 from scipy.linalg import block_diag
 
-from openmdao.api import ExplicitComponent, Group, IndepVarComp
+import openmdao.api as om
 
 from ...grid_data import GridData
 from dymos.utils.misc import get_rate_units
 from ....utils.lagrange import lagrange_matrices
 
 
-class SolveIVPControlInterpComp(ExplicitComponent):
+class SolveIVPControlInterpComp(om.ExplicitComponent):
     """
     Compute the approximated control values and rates given the values of a control at output nodes
     and the approximated values at output nodes, given values at the control input nodes.
@@ -187,7 +187,7 @@ class SolveIVPControlInterpComp(ExplicitComponent):
             outputs[self._output_rate2_names[name]] = (b / inputs['dt_dstau'] ** 2).T
 
 
-class SolveIVPControlGroup(Group):
+class SolveIVPControlGroup(om.Group):
 
     def initialize(self):
         self.options.declare('control_options', types=dict,
@@ -202,9 +202,6 @@ class SolveIVPControlGroup(Group):
 
     def setup(self):
 
-        ivc = IndepVarComp()
-
-        # opts = self.options
         gd = self.options['grid_data']
         control_options = self.options['control_options']
         time_units = self.options['time_units']
@@ -215,7 +212,7 @@ class SolveIVPControlGroup(Group):
         opt_controls = [name for (name, opts) in iteritems(control_options) if opts['opt']]
 
         if len(opt_controls) > 0:
-            ivc = self.add_subsystem('indep_controls', subsys=IndepVarComp(),
+            ivc = self.add_subsystem('indep_controls', subsys=om.IndepVarComp(),
                                      promotes_outputs=['*'])
 
         self.add_subsystem(

--- a/dymos/transcriptions/solve_ivp/components/solve_ivp_polynomial_control_group.py
+++ b/dymos/transcriptions/solve_ivp/components/solve_ivp_polynomial_control_group.py
@@ -3,7 +3,7 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from six import iteritems, string_types
 
-from openmdao.api import Group, ExplicitComponent, IndepVarComp
+import openmdao.api as om
 
 from ...grid_data import GridData
 from ....utils.lgl import lgl
@@ -11,7 +11,7 @@ from ....utils.lagrange import lagrange_matrices
 from ....utils.misc import get_rate_units
 
 
-class SolveIVPLGLPolynomialControlComp(ExplicitComponent):
+class SolveIVPLGLPolynomialControlComp(om.ExplicitComponent):
     """
     Component which interpolates controls as a single polynomial across the entire phase.
     """
@@ -197,7 +197,7 @@ class SolveIVPLGLPolynomialControlComp(ExplicitComponent):
                 (self.rate2_jacs[name] / (0.5 * t_duration_x_size) ** 2)[r_nz, c_nz]
 
 
-class SolveIVPPolynomialControlGroup(Group):
+class SolveIVPPolynomialControlGroup(om.Group):
 
     def initialize(self):
         self.options.declare('polynomial_control_options', types=dict,
@@ -212,7 +212,7 @@ class SolveIVPPolynomialControlGroup(Group):
 
     def setup(self):
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
 
         opts = self.options
         pcos = self.options['polynomial_control_options']

--- a/dymos/transcriptions/solve_ivp/components/state_rate_collector_comp.py
+++ b/dymos/transcriptions/solve_ivp/components/state_rate_collector_comp.py
@@ -1,10 +1,10 @@
 import numpy as np
 from dymos.utils.misc import get_rate_units
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
 from six import string_types, iteritems
 
 
-class StateRateCollectorComp(ExplicitComponent):
+class StateRateCollectorComp(om.ExplicitComponent):
     """
     Collects the state rates and outputs them in the units specified in the state options.
     For explicit integration this is necessary when the output providing the state rate has

--- a/dymos/transcriptions/solve_ivp/components/test/test_segment_simulation_comp.py
+++ b/dymos/transcriptions/solve_ivp/components/test/test_segment_simulation_comp.py
@@ -2,7 +2,7 @@ from __future__ import print_function, absolute_import, division
 
 import unittest
 
-from openmdao.api import Problem, Group
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 from dymos.transcriptions.solve_ivp.components.segment_simulation_comp import SegmentSimulationComp
@@ -15,8 +15,7 @@ class TestSegmentSimulationComp(unittest.TestCase):
 
     def test_simple_integration(self):
 
-        p = Problem(model=Group())
-        p.model = Group()
+        p = om.Problem(model=om.Group())
 
         time_options = TimeOptionsDictionary()
         time_options['units'] = 's'

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -2,11 +2,10 @@ from __future__ import division, print_function, absolute_import
 
 import numpy as np
 
-from openmdao.api import Group, IndepVarComp
+import openmdao.api as om
 from six import iteritems, string_types
 
 from ..transcription_base import TranscriptionBase
-from ..grid_data import GridData
 from .components import SegmentSimulationComp, ODEIntegrationInterface, SegmentStateMuxComp, \
     SolveIVPControlGroup, SolveIVPPolynomialControlGroup, SolveIVPTimeseriesOutputComp
 from ..common import TimeComp
@@ -117,7 +116,7 @@ class SolveIVP(TranscriptionBase):
         """
         num_seg = self.grid_data.num_segments
 
-        indep_states_ivc = phase.add_subsystem('indep_states', IndepVarComp(),
+        indep_states_ivc = phase.add_subsystem('indep_states', om.IndepVarComp(),
                                                promotes_outputs=['*'])
 
         for state_name, options in iteritems(phase.state_options):
@@ -158,7 +157,7 @@ class SolveIVP(TranscriptionBase):
         gd = self.grid_data
         num_seg = gd.num_segments
 
-        segments_group = phase.add_subsystem(name='segments', subsys=Group(),
+        segments_group = phase.add_subsystem(name='segments', subsys=om.Group(),
                                              promotes_outputs=['*'], promotes_inputs=['*'])
 
         # All segments use a common ODEIntegrationInterface to save some memory.

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -7,7 +7,7 @@ from six import iteritems
 
 import numpy as np
 
-from openmdao.api import IndepVarComp, OptionsDictionary
+import openmdao.api as om
 
 from .common import BoundaryConstraintComp, InputParameterComp, ControlGroup, \
     PolynomialControlGroup
@@ -22,7 +22,7 @@ class TranscriptionBase(object):
 
         self.grid_data = None
 
-        self.options = OptionsDictionary()
+        self.options = om.OptionsDictionary()
 
         self.options.declare('num_segments', types=int, desc='Number of segments')
         self.options.declare('segment_ends', default=None, types=(Sequence, np.ndarray),
@@ -92,7 +92,7 @@ class TranscriptionBase(object):
             # phase.connect('t_duration', 'time.t_duration')
 
         if indeps:
-            indep = IndepVarComp()
+            indep = om.IndepVarComp()
 
             for var in indeps:
                 indep.add_output(var, val=default_vals[var], units=time_units)
@@ -163,7 +163,8 @@ class TranscriptionBase(object):
         phase._check_design_parameter_options()
 
         if phase.design_parameter_options:
-            indep = phase.add_subsystem('design_params', subsys=IndepVarComp(),
+            indep = phase.add_subsystem('design_params',
+                                        subsys=om.IndepVarComp(),
                                         promotes_outputs=['*'])
 
             for name, options in iteritems(phase.design_parameter_options):


### PR DESCRIPTION
### Summary

Usages of `openmdao.api` now `import openmdao.api as om`.
Dymos examples now `import dymos as dm`
Switched driver option ['dynamic_simul_derivs'] to `driver.declare_coloring()`

### Related Issues

### Status

- [ ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
