### PR TITLE
Fixes deprecation warnings

### DIFF
--- a/dymos/ode_options.py
+++ b/dymos/ode_options.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
-from collections import Iterable
+from collections.abc import Iterable
 import warnings
 from six import string_types
 import numpy as np

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 from numbers import Number
 from six import string_types
 

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
-from collections import Iterable, Sequence
+from collections.abc import Iterable, Sequence
 import inspect
 import warnings
 

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
-from collections import Sequence, OrderedDict, Iterable
+from collections import OrderedDict
+from collections.abc import Sequence, Iterable
 import itertools
 from six import iteritems, string_types
 

--- a/dymos/transcriptions/pseudospectral/pseudospectral_base.py
+++ b/dymos/transcriptions/pseudospectral/pseudospectral_base.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function, absolute_import
 
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 from dymos.transcriptions.common import EndpointConditionsComp

--- a/dymos/transcriptions/runge_kutta/components/runge_kutta_stepsize_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/runge_kutta_stepsize_comp.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
-from collections import Sequence
+from collections.abc import Sequence
 from six import string_types
 
 import numpy as np

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
-from collections import Sequence
+from collections.abc import Sequence
 import warnings
 
 from six import iteritems

--- a/readme.md
+++ b/readme.md
@@ -32,22 +32,16 @@ differential equations to be integrated.  The user first builds an OpenMDAO mode
 that provide the rates of the state variables.  This model can be an OpenMDAO model of arbitrary
 complexity, including nested groups and components, layers of nonlinear solvers, etc.
 
-Next we can wrap our system with decorators that provide information regarding the states to be
-integrated, which sources in the model provide their rates, and where any externally provided
-parameters should be connected.  When used in an optimal control context, these external parameters
-may serve as controls.
+When setting up a phase, we can add state variables, dynamic controls, and design parameters to
+the phase, tell Dymos how to the value of each should be connected to the ODE system, tell Dymos
+the variable paths in the system that contain the rates of our state variables that are to be
+integrated.
+
 
     import numpy as np
     from openmdao.api import ExplicitComponent
     
-    from dymos import declare_time, declare_state, declare_parameter
-    
-    @declare_time(units='s')
-    @declare_state('x', rate_source='xdot', units='m')
-    @declare_state('y', rate_source='ydot', units='m')
-    @declare_state('v', rate_source='vdot', targets=['v'], units='m/s')
-    @declare_parameter('theta', targets=['theta'])
-    @declare_parameter('g', units='m/s**2', targets=['g'])
+
     class BrachistochroneEOM(ExplicitComponent):
     
         def initialize(self):


### PR DESCRIPTION
### Summary

Fixes deprecation warnings resulting from importing abstract base classes from collections rather than collections.abc.

Note this change breaks Python2 compatibility.

Also removed decorators from the ODE shown on the readme.md file.

### Related Issues

- Resolves #223 

### Status

- [x] Ready for merge

### Backwards incompatibilities

This change explicitly breaks functionality with Python 2.7.

### New Dependencies

None
