### PR TITLE
Traj parameter targets rework

### DIFF
--- a/dymos/docs/feature_reference/timeseries.rst
+++ b/dymos/docs/feature_reference/timeseries.rst
@@ -27,7 +27,6 @@ Path                                                           Description
 ``<phase path>.timeseries.polynomial_control_rates:<p>_rate2`` Second time derivative of polynomial control named u
 ``<phase path>.timeseries.design_parameters:<d>``              Value of design parameter named d
 ``<phase path>.timeseries.input_parameters:<s>``               Value of input parameter named s
-``<phase path>.timeseries.traj_parameters:<s>``                Value of the trajectory parameter named s
 ============================================================== ====================================================
 
 In addition to these default values, any output of the ODE can be added to the timeseries output

--- a/dymos/docs/feature_reference/trajectories.rst
+++ b/dymos/docs/feature_reference/trajectories.rst
@@ -64,20 +64,17 @@ for parameters (e.g. 'mass', 'm', 'm_total', etc) Dymos allows the user to speci
 ODE parameters on a phase-by-phase basis using the `targets` and `target_params` option.
 It can take on the following values.
 
-*  If `targets` is `None` the trajectory design or input parameter will be connected to the phase input parameter of the same name in each phase.
+*  If `targets` is `None` the trajectory design or input parameter will be connected to the phase input parameter of the same name in each phase, if it exists (otherwise it is not connected to that phase).
 
-*  Otherwise targets should be specified as a dictionary.
+*  Otherwise targets should be specified as a dictionary. And the behavior depends on the value associated with each phase name:
 
-    * For each phase name specified as a key in `targets`, the parameter will be connected to the ODE inputs whose names are given as a sequence.
+    * If the phase name is not in the given dictionary, attempt to connect to an existing input parameter of the same name in that phase.
 
-    * If the phase is specified but the corresponding value is `None, **the trajectory parameter will not be passed to the phase**.
+    * If the associated value is None, explicitly omit a connection to that phase.
 
-    * If the phase is specified and the corresponding value is a string, assume the given value is a decorated ODE parameter to which the trajectory parameter should be connected.
+    * If the associated value is a string, connect to an existing input parameter whose name is given by the string in that phase.
 
-    * If the phase is specified and the corresponding parameter value is a list, assume the list gives ODE-level targets to which the parameter should be connected in that phase.
-
-If a phase exists within the Trajectory that doesn't utilize the trajectory
-design/input parameters, it is simply ignored for the purposes of that phase.
+    * If the associated value is a Sequence, create an input parameter in that phase connected to the ODE targets given by the Sequence.
 
 Explicit Simulation of Trajectories
 -----------------------------------

--- a/dymos/docs/feature_reference/trajectories.rst
+++ b/dymos/docs/feature_reference/trajectories.rst
@@ -61,16 +61,16 @@ at the trajectory level which may be connected to some output external to the tr
 When using Trajectory Design and Input parameters, their values are connected to each phase as an
 Input Parameter within the Phase.  Because ODEs in different phases may have different names
 for parameters (e.g. 'mass', 'm', 'm_total', etc) Dymos allows the user to specify the targeted
-ODE parameters on a phase-by-phase basis using the `custom_targets` option.  It can take on the
-following values.
+ODE parameters on a phase-by-phase basis using the `targets` and `target_params` option.
+It can take on the following values.
 
-*  Left unspecified (`custom_targets = None`), a trajectory design or input parameter will be connected to a decorated ODE parameter of the same name in each phase.
+*  If `targets` is `None` the trajectory design or input parameter will be connected to the phase input parameter of the same name in each phase.
 
-*  Otherwise, `custom_targets` is specified as a dictionary keyed by phase name.
+*  Otherwise targets should be specified as a dictionary.
 
-    * If the name of a phase is omitted from `custom_targets`, the trajectory design or input parameter will be connected to a decorated ODE parameter of the same name in that phase.
+    * For each phase name specified as a key in `targets`, the parameter will be connected to the ODE inputs whose names are given as a sequence.
 
-    * If the phase is specified with a corresponding value of `None`, **the trajectory parameter will not be passed to the phase**.
+    * If the phase is specified but the corresponding value is `None, **the trajectory parameter will not be passed to the phase**.
 
     * If the phase is specified and the corresponding value is a string, assume the given value is a decorated ODE parameter to which the trajectory parameter should be connected.
 
@@ -78,24 +78,6 @@ following values.
 
 If a phase exists within the Trajectory that doesn't utilize the trajectory
 design/input parameters, it is simply ignored for the purposes of that phase.
-
-Retrieving the Solution
------------------------
-
-The current solution (the values of the time, states, controls, design parameters, etc.) for the
-trajectory can be obtained using the `get_values` method.  This method is almost identical to
-the `get_values` method on Phases, with two exceptions.  First, it accepts an argument `phases`,
-which allows the user to specify from which phase or phases the values of a variable should be
-retrieved.  This allows the user to obtain values from only those phases which are contiguous in time,
-such as the abort branch of a trajectory.
-The other difference is that the Trajectory `get_values` method provides a `flat` argument which defaults
-to False.  By default, `get_values` returns a dictionary which maps the name of a phase to the values
-of the requested variable within that phase.  If `flat == True`, then the return value is a single
-array of the variable values sorted in ascending time.  If requesting flattened values for one or
-more phases which are parallel in time, the user may receive confusing results!
-
-.. note::
-    If the variable is not present in a given phase, it is returned as np.nan for each returned node in the phase.
 
 Explicit Simulation of Trajectories
 -----------------------------------

--- a/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
+++ b/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
@@ -100,9 +100,12 @@ class TestTwoPhaseCannonballForDocs(unittest.TestCase):
                                   val=0.0, units='deg', opt=False)
 
         # Add externally-provided design parameters to the trajectory.
-        # Note that by omitting targets, we're connecting these parameters to parameters
+        # In this case, we connect 'm' to pre-existing input parameters named 'mass' in each phase.
+        traj.add_input_parameter('m', units='kg', val=1.0,
+                                 targets={'ascent': 'mass', 'descent': 'mass'})
+
+        # In this case, by omitting targets, we're connecting these parameters to parameters
         # with the same name in each phase.
-        traj.add_input_parameter('mass', units='kg', val=1.0)
         traj.add_input_parameter('S', units='m**2', val=0.005)
 
         # Link Phases (link time and all state variables)
@@ -112,7 +115,7 @@ class TestTwoPhaseCannonballForDocs(unittest.TestCase):
         p.model.connect('external_params.radius', 'size_comp.radius')
         p.model.connect('external_params.dens', 'size_comp.dens')
 
-        p.model.connect('size_comp.mass', 'traj.input_parameters:mass')
+        p.model.connect('size_comp.mass', 'traj.input_parameters:m')
         p.model.connect('size_comp.S', 'traj.input_parameters:S')
 
         # Finish Problem Setup
@@ -120,7 +123,7 @@ class TestTwoPhaseCannonballForDocs(unittest.TestCase):
 
         p.driver.add_recorder(om.SqliteRecorder('ex_two_phase_cannonball.db'))
 
-        p.setup(check=True)
+        p.setup()
 
         # Set Initial Guesses
         p.set_val('external_params.radius', 0.05, units='m')

--- a/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
+++ b/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division, absolute_import
 import unittest
 
 import matplotlib.pyplot as plt
-plt.switch_backend('Agg')
+# plt.switch_backend('Agg')
 
 
 class TestTwoPhaseCannonballForDocs(unittest.TestCase):
@@ -53,6 +53,9 @@ class TestTwoPhaseCannonballForDocs(unittest.TestCase):
                          targets=['dynamic_pressure.v', 'eom.v', 'kinetic_energy.v'],
                          fix_initial=False, fix_final=False)
 
+        ascent.add_input_parameter('S', targets=['aero.S'], units='m**2')
+        ascent.add_input_parameter('mass', targets=['eom.m', 'kinetic_energy.m'], units='kg')
+
         # Limit the muzzle energy
         ascent.add_boundary_constraint('kinetic_energy.ke', loc='initial', units='J',
                                        upper=400000, lower=0, ref=100000, shape=(1,))
@@ -77,34 +80,30 @@ class TestTwoPhaseCannonballForDocs(unittest.TestCase):
                           targets=['dynamic_pressure.v', 'eom.v', 'kinetic_energy.v'],
                           fix_initial=False, fix_final=False)
 
+        descent.add_input_parameter('S', targets=['aero.S'], units='m**2')
+        descent.add_input_parameter('mass', targets=['eom.m', 'kinetic_energy.m'], units='kg')
+
         descent.add_objective('r', loc='final', scaler=-1.0)
 
         # Add internally-managed design parameters to the trajectory.
         traj.add_design_parameter('CD',
-                                  custom_targets={'ascent': ['aero.CD'], 'descent': ['aero.CD']},
+                                  targets={'ascent': ['aero.CD'], 'descent': ['aero.CD']},
                                   val=0.5, units=None, opt=False)
         traj.add_design_parameter('CL',
-                                  custom_targets={'ascent': ['aero.CL'], 'descent': ['aero.CL']},
+                                  targets={'ascent': ['aero.CL'], 'descent': ['aero.CL']},
                                   val=0.0, units=None, opt=False)
         traj.add_design_parameter('T',
-                                  custom_targets={'ascent': ['eom.T'], 'descent': ['eom.T']},
+                                  targets={'ascent': ['eom.T'], 'descent': ['eom.T']},
                                   val=0.0, units='N', opt=False)
         traj.add_design_parameter('alpha',
-                                  custom_targets={'ascent': ['eom.alpha'], 'descent': ['eom.alpha']},
+                                  targets={'ascent': ['eom.alpha'], 'descent': ['eom.alpha']},
                                   val=0.0, units='deg', opt=False)
 
         # Add externally-provided design parameters to the trajectory.
-        traj.add_input_parameter('mass',
-                                 units='kg',
-                                 custom_targets={'ascent': ['eom.m', 'kinetic_energy.m'],
-                                                 'descent': ['eom.m', 'kinetic_energy.m']},
-                                 val=1.0)
-
-        traj.add_input_parameter('S',
-                                 units='m**2',
-                                 custom_targets={'ascent': ['aero.S'],
-                                                 'descent': ['aero.S']},
-                                 val=0.005)
+        # Note that by omitting targets, we're connecting these parameters to parameters
+        # with the same name in each phase.
+        traj.add_input_parameter('mass', units='kg', val=1.0)
+        traj.add_input_parameter('S', units='m**2', val=0.005)
 
         # Link Phases (link time and all state variables)
         traj.link_phases(phases=['ascent', 'descent'], vars=['*'])
@@ -216,13 +215,13 @@ class TestTwoPhaseCannonballForDocs(unittest.TestCase):
         fig, axes = plt.subplots(nrows=6, ncols=1, figsize=(12, 6))
         for i, param in enumerate(params):
             p_imp = {
-                'ascent': p.get_val('traj.ascent.timeseries.traj_parameters:{0}'.format(param)),
-                'descent': p.get_val('traj.descent.timeseries.traj_parameters:{0}'.format(param))}
+                'ascent': p.get_val('traj.ascent.timeseries.input_parameters:{0}'.format(param)),
+                'descent': p.get_val('traj.descent.timeseries.input_parameters:{0}'.format(param))}
 
             p_exp = {'ascent': exp_out.get_val('traj.ascent.timeseries.'
-                                               'traj_parameters:{0}'.format(param)),
+                                               'input_parameters:{0}'.format(param)),
                      'descent': exp_out.get_val('traj.descent.timeseries.'
-                                                'traj_parameters:{0}'.format(param))}
+                                                'input_parameters:{0}'.format(param))}
 
             axes[i].set_ylabel(param)
 

--- a/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
@@ -27,7 +27,7 @@ class TestFiniteBurnOrbitRaise(unittest.TestCase):
         traj = dm.Trajectory()
 
         traj.add_design_parameter('c', opt=False, val=1.5, units='DU/TU',
-                                  custom_targets={'burn1': ['c'], 'coast': ['c'], 'burn2': ['c']})
+                                  targets={'burn1': ['c'], 'coast': ['c'], 'burn2': ['c']})
 
         # First Phase (burn)
 

--- a/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise.py
@@ -23,7 +23,7 @@ def make_traj(transcription='gauss-lobatto', transcription_order=3, compressed=F
     traj = dm.Trajectory()
 
     traj.add_design_parameter('c', opt=False, val=1.5, units='DU/TU',
-                              custom_targets={'burn1': ['c'], 'coast': ['c'], 'burn2': ['c']})
+                              targets={'burn1': ['c'], 'coast': ['c'], 'burn2': ['c']})
 
     # First Phase (burn)
 

--- a/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
@@ -34,7 +34,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
         p.driver.declare_coloring()
 
         traj.add_design_parameter('c', opt=False, val=1.5, units='DU/TU',
-                                  custom_targets={'burn1': ['c'], 'coast': ['c'], 'burn2': ['c']})
+                                  targets={'burn1': ['c'], 'coast': ['c'], 'burn2': ['c']})
 
         # First Phase (burn)
 

--- a/dymos/examples/shuttle_reentry/test/test_reentry.py
+++ b/dymos/examples/shuttle_reentry/test/test_reentry.py
@@ -40,7 +40,7 @@ class TestReentry(unittest.TestCase):
                          rate_source='thetadot', targets=['theta'],
                          lower=-89. * np.pi / 180, upper=89. * np.pi / 180)
         phase0.add_state('v', fix_initial=True, fix_final=True, units='ft/s',
-                         rate_source='vdot', targets=['v'], lower=0, ref0=2500, ref=25000)
+                         rate_source='vdot', targets=['v'], lower=1, ref0=2500, ref=25000)
         phase0.add_control('alpha', units='rad', opt=True,
                            lower=-np.pi / 2, upper=np.pi / 2, targets=['alpha'])
         phase0.add_control('beta', units='rad', opt=True,

--- a/dymos/load_case.py
+++ b/dymos/load_case.py
@@ -128,10 +128,6 @@ def load_case(problem, case):
             param_val = outputs[f'{phase_path}.input_parameters:{param_name}']
             problem[f'{phase_path}.input_parameters:{param_name}'] = param_val
 
-        for param_name, options in phase.traj_parameter_options.items():
-            param_val = outputs[f'{phase_path}.traj_parameters:{param_name}']
-            problem[f'{phase_path}.traj_parameters:{param_name}'] = param_val
-
         for var_path in phase_inputs[phase] + phase_outputs[phase]:
             if f'{phase_path}.rhs_all' in var_path:
                 val_all = inputs[var_path]

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -290,6 +290,16 @@ class TrajDesignParameterOptionsDictionary(DesignParameterOptionsDictionary):
 
         self._dict.pop('targets')
 
+        self.declare(name='targets', types=dict, default=None, allow_none=True,
+                     desc='Used to specify the targets for the input parameter in each phase. '
+                          'If None, Dymos will attempt to connect it to an input parameter of '
+                          'the same name in each phase.  Otherwise, targets should be a given '
+                          'as a dictionary.  For each phase name given as a key in the dictionary,'
+                          'if the associated value is a string, connect the parameter to the phase'
+                          ' input parameter given by the string. If the associated value is a'
+                          ' sequence, treat it as a list of ODE-relative targets for the parameter'
+                          ' in that phase')
+
 
 class InputParameterOptionsDictionary(om.OptionsDictionary):
     """
@@ -300,7 +310,7 @@ class InputParameterOptionsDictionary(om.OptionsDictionary):
         super(InputParameterOptionsDictionary, self).__init__(read_only)
 
         self.declare(name='name', types=string_types,
-                     desc='The name of ODE system parameter to be set via input parameter, or'
+                     desc='The name of ODE system parameter to be set via input parameter, or '
                           'an alias.  If an alias is provided, then "target_param" should provide'
                           'the ODE system parameter name.')
 
@@ -336,6 +346,16 @@ class TrajInputParameterOptionsDictionary(InputParameterOptionsDictionary):
                           ' in each phase.  By default its target will be the same as its name')
 
         self._dict.pop('targets')
+
+        self.declare(name='targets', types=dict, default=None, allow_none=True,
+                     desc='Used to specify the targets for the input parameter in each phase. '
+                          'If None, Dymos will attempt to connect it to an input parameter of '
+                          'the same name in each phase.  Otherwise, targets should be a given '
+                          'as a dictionary.  For each phase name given as a key in the dictionary,'
+                          'if the associated value is a string, connect the parameter to the phase'
+                          ' input parameter given by the string. If the associated value is a'
+                          ' sequence, treat it as a list of ODE-relative targets for the parameter'
+                          ' in that phase')
 
 
 class StateOptionsDictionary(om.OptionsDictionary):

--- a/dymos/test/test_load_case.py
+++ b/dymos/test/test_load_case.py
@@ -385,7 +385,6 @@ class TestLoadCase(unittest.TestCase):
     @use_tempdirs
     def test_load_case_lgl_to_rk4(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -448,7 +448,7 @@ class Trajectory(om.Group):
 
             for phase_name, phs in iteritems(self._phases):
 
-                if targets is None:
+                if targets is None or phase_name not in targets:
                     # Attempt to connect to an input parameter of the same name in the phase, if
                     # it exists.
                     if name in phs.user_input_parameter_options:

--- a/dymos/transcriptions/common/input_parameter_comp.py
+++ b/dymos/transcriptions/common/input_parameter_comp.py
@@ -26,7 +26,7 @@ class InputParameterComp(om.ExplicitComponent):
         self._input_names = {}
 
     def setup(self):
-        name_prefix = 'traj_parameters' if self.options['traj_params'] else 'input_parameters'
+        name_prefix = 'input_parameters'
 
         for param_name, options in iteritems(self.options['input_parameter_options']):
 

--- a/dymos/transcriptions/common/path_constraint_comp.py
+++ b/dymos/transcriptions/common/path_constraint_comp.py
@@ -75,8 +75,7 @@ class PathConstraintComp(om.ExplicitComponent):
         src_all = var_class in ['time', 'time_phase', 'indep_control', 'input_control',
                                 'control_rate', 'control_rate2', 'indep_polynomial_control',
                                 'input_polynomial_control', 'polynomial_control_rate',
-                                'polynomial_control_rate2', 'design_parameter', 'input_parameter',
-                                'traj_parameter']
+                                'polynomial_control_rate2', 'design_parameter', 'input_parameter']
 
         lower = -INF_BOUND if upper is not None and lower is None else lower
         upper = INF_BOUND if lower is not None and upper is None else upper

--- a/dymos/transcriptions/common/timeseries_output_comp.py
+++ b/dymos/transcriptions/common/timeseries_output_comp.py
@@ -68,8 +68,7 @@ class TimeseriesOutputCompBase(om.ExplicitComponent):
         src_all = var_class in ['time', 'time_phase', 'indep_control', 'input_control',
                                 'control_rate', 'control_rate2', 'indep_polynomial_control',
                                 'input_polynomial_control', 'polynomial_control_rate',
-                                'polynomial_control_rate2', 'design_parameter', 'input_parameter',
-                                'traj_parameter']
+                                'polynomial_control_rate2', 'design_parameter', 'input_parameter']
         kwargs = {'shape': shape, 'units': units, 'desc': desc, 'src_all': src_all,
                   'distributed': distributed}
         self._timeseries_outputs.append((name, kwargs))

--- a/dymos/transcriptions/pseudospectral/gauss_lobatto.py
+++ b/dymos/transcriptions/pseudospectral/gauss_lobatto.py
@@ -576,20 +576,6 @@ class GaussLobatto(PseudospectralBase):
                               tgt_name='{0}.input_values:input_parameters:{1}'.format(name, param_name),
                               src_indices=src_idxs, flat_src_indices=True)
 
-            for param_name, options in iteritems(phase.traj_parameter_options):
-                units = options['units']
-                timeseries_comp._add_timeseries_output('traj_parameters:{0}'.format(param_name),
-                                                       var_class=phase.classify_var(param_name),
-                                                       shape=options['shape'],
-                                                       units=units)
-
-                src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
-
-                phase.connect(src_name='traj_parameters:{0}_out'.format(param_name),
-                              tgt_name='{0}.input_values:traj_parameters:{1}'.format(name, param_name),
-                              src_indices=src_idxs, flat_src_indices=True)
-
             for var, options in iteritems(phase._timeseries[name]['outputs']):
                 output_name = options['output_name']
 
@@ -710,7 +696,6 @@ class GaussLobatto(PseudospectralBase):
 
         parameter_options = phase.design_parameter_options.copy()
         parameter_options.update(phase.input_parameter_options)
-        parameter_options.update(phase.traj_parameter_options)
         parameter_options.update(phase.control_options)
 
         if name in parameter_options:

--- a/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
+++ b/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
@@ -443,19 +443,6 @@ class Radau(PseudospectralBase):
                               tgt_name='{0}.input_values:input_parameters:{1}'.format(name, param_name),
                               src_indices=src_idxs, flat_src_indices=True)
 
-            for param_name, options in iteritems(phase.traj_parameter_options):
-                units = options['units']
-                timeseries_comp._add_timeseries_output('traj_parameters:{0}'.format(param_name),
-                                                       var_class=phase.classify_var(param_name),
-                                                       units=units)
-
-                src_idxs_raw = np.zeros(gd.subset_num_nodes['all'], dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
-
-                phase.connect(src_name='traj_parameters:{0}_out'.format(param_name),
-                              tgt_name='{0}.input_values:traj_parameters:{1}'.format(name, param_name),
-                              src_indices=src_idxs, flat_src_indices=True)
-
             for var, options in iteritems(phase._timeseries[name]['outputs']):
                 output_name = options['output_name']
 
@@ -584,7 +571,6 @@ class Radau(PseudospectralBase):
 
         parameter_options = phase.design_parameter_options.copy()
         parameter_options.update(phase.input_parameter_options)
-        parameter_options.update(phase.traj_parameter_options)
         parameter_options.update(phase.control_options)
 
         if name in parameter_options:

--- a/dymos/transcriptions/runge_kutta/runge_kutta.py
+++ b/dymos/transcriptions/runge_kutta/runge_kutta.py
@@ -816,19 +816,6 @@ class RungeKutta(TranscriptionBase):
                               tgt_name='{0}.input_values:input_parameters:{1}'.format(name, param_name),
                               src_indices=src_idxs, flat_src_indices=True)
 
-            for param_name, options in iteritems(phase.traj_parameter_options):
-                units = options['units']
-                timeseries_comp._add_timeseries_output('traj_parameters:{0}'.format(param_name),
-                                                       var_class=phase.classify_var(param_name),
-                                                       units=units)
-
-                src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['segment_ends'], dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
-
-                phase.connect(src_name='traj_parameters:{0}_out'.format(param_name),
-                              tgt_name='{0}.input_values:traj_parameters:{1}'.format(name, param_name),
-                              src_indices=src_idxs, flat_src_indices=True)
-
             for var, options in iteritems(phase._timeseries[name]['outputs']):
                 output_name = options['output_name']
 
@@ -880,7 +867,6 @@ class RungeKutta(TranscriptionBase):
 
         parameter_options = phase.design_parameter_options.copy()
         parameter_options.update(phase.input_parameter_options)
-        parameter_options.update(phase.traj_parameter_options)
         parameter_options.update(phase.control_options)
 
         if name in parameter_options:

--- a/dymos/transcriptions/solve_ivp/components/ode_integration_interface.py
+++ b/dymos/transcriptions/solve_ivp/components/ode_integration_interface.py
@@ -41,7 +41,7 @@ class ODEIntegrationInterface(object):
     """
     def __init__(self, ode_class, time_options, state_options, control_options,
                  polynomial_control_options, design_parameter_options, input_parameter_options,
-                 traj_parameter_options, ode_init_kwargs=None):
+                 ode_init_kwargs=None):
 
         # Get the state vector.  This isn't necessarily ordered
         # so just pick the default ordering and go with it.
@@ -51,7 +51,6 @@ class ODEIntegrationInterface(object):
         self.polynomial_control_options = polynomial_control_options
         self.design_parameter_options = design_parameter_options
         self.input_parameter_options = input_parameter_options
-        self.traj_parameter_options = traj_parameter_options
         self.control_interpolants = {}
         self.polynomial_control_interpolants = {}
 
@@ -182,18 +181,6 @@ class ODEIntegrationInterface(object):
                     model.connect('input_parameters:{0}'.format(name),
                                   ['ode.{0}'.format(tgt) for tgt in tgts])
 
-        if self.traj_parameter_options:
-            for name, options in iteritems(self.traj_parameter_options):
-                ivc.add_output('traj_parameters:{0}'.format(name),
-                               shape=options['shape'],
-                               units=options['units'])
-                if options['targets'] is not None:
-                    tgts = options['targets']
-                    if isinstance(tgts, string_types):
-                        tgts = [tgts]
-                    model.connect('traj_parameters:{0}'.format(name),
-                                  ['ode.{0}'.format(tgt) for tgt in tgts])
-
         # The ODE System
         if ode_class is not None:
             model.add_subsystem('ode', subsys=ode_class(num_nodes=1, **ode_init_kwargs))
@@ -223,8 +210,6 @@ class ODEIntegrationInterface(object):
             rate_path = 'design_parameters:{0}'.format(var)
         elif self.input_parameter_options is not None and var in self.input_parameter_options:
             rate_path = 'input_parameters:{0}'.format(var)
-        elif self.traj_parameter_options is not None and var in self.traj_parameter_options:
-            rate_path = 'traj_parameters:{0}'.format(var)
         elif var.endswith('_rate') and self.control_options is not None and \
                 var[:-5] in self.control_options:
             rate_path = 'control_rates:{0}'.format(var)

--- a/dymos/transcriptions/solve_ivp/components/segment_simulation_comp.py
+++ b/dymos/transcriptions/solve_ivp/components/segment_simulation_comp.py
@@ -66,10 +66,6 @@ class SegmentSimulationComp(om.ExplicitComponent):
                              desc='Dictionary of input parameter names/options for the segments '
                                   'parent Phase.')
 
-        self.options.declare('traj_parameter_options', default=None, types=dict, allow_none=True,
-                             desc='Dictionary of traj parameter names/options for the segments '
-                                  'parent Phase.')
-
         self.options.declare('ode_integration_interface', default=None, allow_none=True,
                              types=ODEIntegrationInterface,
                              desc='The instance of the ODE integration interface used to provide '
@@ -113,7 +109,6 @@ class SegmentSimulationComp(om.ExplicitComponent):
                 polynomial_control_options=self.options['polynomial_control_options'],
                 design_parameter_options=self.options['design_parameter_options'],
                 input_parameter_options=self.options['input_parameter_options'],
-                traj_parameter_options=self.options['traj_parameter_options'],
                 ode_init_kwargs=self.options['ode_init_kwargs'])
 
         self.add_input(name='time', val=np.ones(nnps_i),
@@ -179,12 +174,6 @@ class SegmentSimulationComp(om.ExplicitComponent):
                                units=options['units'],
                                desc='values of input parameter {0}'.format(name))
 
-        if self.options['traj_parameter_options']:
-            for name, options in iteritems(self.options['traj_parameter_options']):
-                self.add_input(name='traj_parameters:{0}'.format(name), val=np.ones(options['shape']),
-                               units=options['units'],
-                               desc='values of trajectory parameter {0}'.format(name))
-
         self.options['ode_integration_interface'].prob.setup(check=False)
 
         self.declare_partials(of='*', wrt='*', method='fd')
@@ -245,13 +234,6 @@ class SegmentSimulationComp(om.ExplicitComponent):
             for param_name, options in iteritems(self.options['input_parameter_options']):
                 iface_prob.set_val('input_parameters:{0}'.format(param_name),
                                    value=inputs['input_parameters:{0}'.format(param_name)],
-                                   units=options['units'])
-
-        # Set the values of the trajectory parameters
-        if self.options['traj_parameter_options']:
-            for param_name, options in iteritems(self.options['traj_parameter_options']):
-                iface_prob.set_val('traj_parameters:{0}'.format(param_name),
-                                   value=inputs['traj_parameters:{0}'.format(param_name)],
                                    units=options['units'])
 
         # Setup the evaluation times.

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -175,7 +175,6 @@ class SolveIVP(TranscriptionBase):
                 polynomial_control_options=phase.polynomial_control_options,
                 design_parameter_options=phase.design_parameter_options,
                 input_parameter_options=phase.input_parameter_options,
-                traj_parameter_options=phase.traj_parameter_options,
                 output_nodes_per_seg=self.options['output_nodes_per_seg'])
 
             segments_group.add_subsystem('segment_{0}'.format(i), subsys=seg_i_comp)
@@ -287,13 +286,6 @@ class SolveIVP(TranscriptionBase):
         for name, options in iteritems(phase.input_parameter_options):
             phase.connect('input_parameters:{0}_out'.format(name),
                           ['segment_{0}.input_parameters:{1}'.format(iseg, name) for iseg in range(num_seg)])
-
-    def setup_traj_parameters(self, phase):
-        super(SolveIVP, self).setup_traj_parameters(phase)
-        num_seg = self.grid_data.num_segments
-        for name, options in iteritems(phase.traj_parameter_options):
-            phase.connect('traj_parameters:{0}_out'.format(name),
-                          ['segment_{0}.traj_parameters:{1}'.format(iseg, name) for iseg in range(num_seg)])
 
     def setup_defects(self, phase):
         """
@@ -444,23 +436,6 @@ class SolveIVP(TranscriptionBase):
                           tgt_name='timeseries.all_values:input_parameters:{0}'.format(name),
                           src_indices=src_idxs, flat_src_indices=True)
 
-        for name, options in iteritems(phase.traj_parameter_options):
-            units = options['units']
-            timeseries_comp._add_timeseries_output('traj_parameters:{0}'.format(name),
-                                                   var_class=phase.classify_var(name),
-                                                   units=units)
-
-            if output_nodes_per_seg is None:
-                src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
-            else:
-                src_idxs_raw = np.zeros(num_seg * output_nodes_per_seg, dtype=int)
-
-            src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
-
-            phase.connect(src_name='traj_parameters:{0}_out'.format(name),
-                          tgt_name='timeseries.all_values:traj_parameters:{0}'.format(name),
-                          src_indices=src_idxs, flat_src_indices=True)
-
         for var, options in iteritems(phase._timeseries['timeseries']['outputs']):
             output_name = options['output_name']
 
@@ -508,7 +483,6 @@ class SolveIVP(TranscriptionBase):
 
         parameter_options = phase.design_parameter_options.copy()
         parameter_options.update(phase.input_parameter_options)
-        parameter_options.update(phase.traj_parameter_options)
         parameter_options.update(phase.control_options)
 
         if name in parameter_options:

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -211,24 +211,6 @@ class TranscriptionBase(object):
                 phase.connect(src_name, [t for t in tgts],
                               src_indices=src_idxs, flat_src_indices=True)
 
-    def setup_traj_parameters(self, phase):
-        """
-        Adds a InputParameterComp to allow input parameters to be connected from sources
-        external to the phase.
-        """
-        if phase.traj_parameter_options:
-            passthru = \
-                InputParameterComp(input_parameter_options=phase.traj_parameter_options,
-                                   traj_params=True)
-
-            phase.add_subsystem('traj_params', subsys=passthru, promotes_inputs=['*'],
-                                promotes_outputs=['*'])
-
-        for name, options in iteritems(phase.traj_parameter_options):
-            src_name = 'traj_parameters:{0}_out'.format(name)
-            for tgts, src_idxs in self.get_parameter_connections(name, phase):
-                phase.connect(src_name, [t for t in tgts], src_indices=src_idxs)
-
     def setup_states(self, phase):
         raise NotImplementedError('Transcription {0} does not implement method '
                                   'setup_states.'.format(self.__class__.__name__))


### PR DESCRIPTION
### Summary

Argument `custom_targets` for trajectory design and input parameters is now just `targets`, with the following rules:

*  If `targets` is `None` the trajectory design or input parameter will be connected to the phase input parameter of the same name in each phase, if it exists (otherwise it is not connected to that phase).

*  Otherwise targets should be specified as a dictionary. And the behavior depends on the value associated with each phase name:

    * If the phase name is not in the given dictionary, attempt to connect to an existing input parameter of the same name in that phase.

    * If the associated value is None, explicitly omit a connection to that phase.

    * If the associated value is a string, connect to an existing input parameter whose name is given by the string in that phase.

    * If the associated value is a Sequence, create an input parameter in that phase connected to the ODE targets given by the Sequence.

Argument `custom_targets` will throw a DeprecationWarning and be treated as `targets`, with the behavior above.

### Related Issues

- Resolves #230 

### Status

- [ ] Ready for merge

### Backwards incompatibilities

1. Argument `custom_targets` for trajectory input and design parameters is deprecated, use `targets` instead.
2. Removed the notion of `traj_parameters` from phases, since ultimately they behave as `input_parameters` and it significantly simplifies the code.  Any codes which rely on `phase_name.timeseries.traj_parameters:foo` should change to `phase_name.timeseries.input_parameters:foo`

### New Dependencies

None
