### PR TITLE
updated travis to use petsc 3.10.0 after having problems with 3.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ os:
   - linux
 
 env:
-  - PY=3.7 PETSc=3.11.0
-  - PY=3.6 PETSc=3.11.0 UPLOAD_DOCS=1
+  - PY=3.7 PETSc=3.10.0
+  - PY=3.6 PETSc=3.10.0 UPLOAD_DOCS=1
 
 language: generic
 


### PR DESCRIPTION
### Summary

This PR attempts to resolve petsc hanging on travis-ci.org after master is merged.

### Related Issues

- Resolves #277 

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
