### PR TITLE
use a specific version of pyoptspare for Travis compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,7 @@ install:
 
     git clone https://github.com/mdolab/pyoptsparse.git;
     cd pyoptsparse;
+    git checkout v1.2
 
     if [ "$SNOPT_LOCATION" ] && [ "${PY:0:1}" = "3" ]; then
       cd pyoptsparse/pySNOPT;


### PR DESCRIPTION
### Summary

Use a specific version of pyoptspare for SNOPT compatibility with Travis tests.

### Related Issues

- Resolves Travis failing after merge of command line update 

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
