### PR TITLE
Grid refinement updates

### DIFF
--- a/dymos/examples/brachistochrone/test/test_ex_brachistochrone_refine_grid.py
+++ b/dymos/examples/brachistochrone/test/test_ex_brachistochrone_refine_grid.py
@@ -19,10 +19,7 @@ class TestBrachistochroneRefineGrid(unittest.TestCase):
 
         self.p = p = om.Problem(model=om.Group())
 
-        # p.driver = om.ScipyOptimizeDriver()
-        p.driver = om.pyOptSparseDriver()
-        p.driver.options['optimizer'] = 'SNOPT'
-        p.driver.opt_settings['iSumm'] = 6
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.declare_coloring()
 
         if transcription == 'gauss-lobatto':

--- a/dymos/examples/brachistochrone/test/test_ex_brachistochrone_refine_grid.py
+++ b/dymos/examples/brachistochrone/test/test_ex_brachistochrone_refine_grid.py
@@ -12,13 +12,14 @@ from openmdao.utils.testing_utils import use_tempdirs
 OPT, OPTIMIZER = set_pyoptsparse_opt('SNOPT', fallback=True)
 
 
-@use_tempdirs
+# @use_tempdirs
 class TestBrachistochroneRefineGrid(unittest.TestCase):
 
     def make_problem(self, transcription='radau-ps', num_segments=5, transcription_order=3, compressed=True):
 
         self.p = p = om.Problem(model=om.Group())
 
+        # p.driver = om.ScipyOptimizeDriver()
         p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'SNOPT'
         p.driver.opt_settings['iSumm'] = 6
@@ -39,7 +40,7 @@ class TestBrachistochroneRefineGrid(unittest.TestCase):
         traj = dm.Trajectory()
         phase = dm.Phase(ode_class=BrachistochroneODE, transcription=t)
 
-        phase.set_refine_options(tol=1.0E-6)
+        phase.set_refine_options(refine=True, tol=1.0E-6)
 
         traj.add_phase('phase0', phase)
 

--- a/dymos/examples/brachistochrone/test/test_ex_brachistochrone_refine_grid.py
+++ b/dymos/examples/brachistochrone/test/test_ex_brachistochrone_refine_grid.py
@@ -122,6 +122,11 @@ class TestBrachistochroneRefineGrid(unittest.TestCase):
 
         assert_almost_equal(thetaf, 100.12, decimal=0)
 
+    def test_refine_brachistochrone_rungekutta_compressed(self):
+        p = self.make_problem(transcription='runge-kutta', num_segments=10, transcription_order=3)
+        dm.run_problem(p, refine=True)
+        self.run_asserts(self.p)
+
     def test_refine_brachistochrone_radau_compressed(self):
         p = self.make_problem(transcription='radau-ps', num_segments=5, transcription_order=3, compressed=True)
         dm.run_problem(p, refine=True)

--- a/dymos/examples/brachistochrone/test/test_ex_brachistochrone_refine_grid.py
+++ b/dymos/examples/brachistochrone/test/test_ex_brachistochrone_refine_grid.py
@@ -12,7 +12,7 @@ from openmdao.utils.testing_utils import use_tempdirs
 OPT, OPTIMIZER = set_pyoptsparse_opt('SNOPT', fallback=True)
 
 
-# @use_tempdirs
+@use_tempdirs
 class TestBrachistochroneRefineGrid(unittest.TestCase):
 
     def make_problem(self, transcription='radau-ps', num_segments=5, transcription_order=3, compressed=True):

--- a/dymos/examples/brachistochrone/test/test_ex_brachistochrone_refine_grid.py
+++ b/dymos/examples/brachistochrone/test/test_ex_brachistochrone_refine_grid.py
@@ -1,0 +1,132 @@
+import os
+import unittest
+from numpy.testing import assert_almost_equal
+
+import openmdao.api as om
+
+import dymos as dm
+from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
+
+from openmdao.utils.general_utils import set_pyoptsparse_opt
+from openmdao.utils.testing_utils import use_tempdirs
+OPT, OPTIMIZER = set_pyoptsparse_opt('SNOPT', fallback=True)
+
+
+@use_tempdirs
+class TestBrachistochroneRefineGrid(unittest.TestCase):
+
+    def make_problem(self, transcription='radau-ps', num_segments=5, transcription_order=3, compressed=True):
+
+        self.p = p = om.Problem(model=om.Group())
+
+        p.driver = om.pyOptSparseDriver()
+        p.driver.options['optimizer'] = 'SNOPT'
+        p.driver.opt_settings['iSumm'] = 6
+        p.driver.declare_coloring()
+
+        if transcription == 'gauss-lobatto':
+            t = dm.GaussLobatto(num_segments=num_segments,
+                                order=transcription_order,
+                                compressed=compressed)
+        elif transcription == 'radau-ps':
+            t = dm.Radau(num_segments=num_segments,
+                         order=transcription_order,
+                         compressed=compressed)
+        elif transcription == 'runge-kutta':
+            t = dm.RungeKutta(num_segments=num_segments,
+                              order=transcription_order,
+                              compressed=compressed)
+        traj = dm.Trajectory()
+        phase = dm.Phase(ode_class=BrachistochroneODE, transcription=t)
+
+        phase.set_refine_options(tol=1.0E-6)
+
+        traj.add_phase('phase0', phase)
+
+        p.model.add_subsystem('traj0', traj)
+
+        phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
+
+        phase.add_state('x', rate_source=BrachistochroneODE.states['x']['rate_source'],
+                        units=BrachistochroneODE.states['x']['units'],
+                        fix_initial=True, fix_final=False, solve_segments=False)
+        phase.add_state('y', rate_source=BrachistochroneODE.states['y']['rate_source'],
+                        units=BrachistochroneODE.states['y']['units'],
+                        fix_initial=True, fix_final=False, solve_segments=False)
+        phase.add_state('v', rate_source=BrachistochroneODE.states['v']['rate_source'],
+                        targets=BrachistochroneODE.states['v']['targets'],
+                        units=BrachistochroneODE.states['v']['units'],
+                        fix_initial=True, fix_final=False, solve_segments=False)
+
+        phase.add_control('theta', targets=BrachistochroneODE.parameters['theta']['targets'],
+                          continuity=True, rate_continuity=True,
+                          units='deg', lower=0.01, upper=179.9)
+
+        phase.add_input_parameter('g', targets=BrachistochroneODE.parameters['g']['targets'],
+                                  units='m/s**2', val=9.80665)
+
+        phase.add_timeseries('timeseries2',
+                             transcription=dm.Radau(num_segments=num_segments * 5,
+                                                    order=transcription_order,
+                                                    compressed=compressed),
+                             subset='control_input')
+
+        phase.add_boundary_constraint('x', loc='final', equals=10)
+        phase.add_boundary_constraint('y', loc='final', equals=5)
+        # Minimize time at the end of the phase
+        phase.add_objective('time_phase', loc='final', scaler=10)
+
+        p.model.linear_solver = om.DirectSolver()
+        p.setup(check=['unconnected_inputs'])
+
+        p['traj0.phase0.t_initial'] = 0.0
+        p['traj0.phase0.t_duration'] = 2.0
+
+        p['traj0.phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_input')
+        p['traj0.phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_input')
+        p['traj0.phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+        p['traj0.phase0.controls:theta'] = phase.interpolate(ys=[5, 100], nodes='control_input')
+        p['traj0.phase0.input_parameters:g'] = 9.80665
+
+        return p
+
+    def run_asserts(self, p):
+
+        t_initial = p.get_val('traj0.phase0.timeseries.time')[0]
+        tf = p.get_val('traj0.phase0.timeseries.time')[-1]
+
+        x0 = p.get_val('traj0.phase0.timeseries.states:x')[0]
+        xf = p.get_val('traj0.phase0.timeseries.states:x')[-1]
+
+        y0 = p.get_val('traj0.phase0.timeseries.states:y')[0]
+        yf = p.get_val('traj0.phase0.timeseries.states:y')[-1]
+
+        v0 = p.get_val('traj0.phase0.timeseries.states:v')[0]
+        vf = p.get_val('traj0.phase0.timeseries.states:v')[-1]
+
+        g = p.get_val('traj0.phase0.timeseries.input_parameters:g')[0]
+
+        thetaf = p.get_val('traj0.phase0.timeseries.controls:theta')[-1]
+
+        assert_almost_equal(t_initial, 0.0)
+        assert_almost_equal(x0, 0.0)
+        assert_almost_equal(y0, 10.0)
+        assert_almost_equal(v0, 0.0)
+
+        assert_almost_equal(tf, 1.8016, decimal=4)
+        assert_almost_equal(xf, 10.0, decimal=3)
+        assert_almost_equal(yf, 5.0, decimal=3)
+        assert_almost_equal(vf, 9.902, decimal=3)
+        assert_almost_equal(g, 9.80665, decimal=3)
+
+        assert_almost_equal(thetaf, 100.12, decimal=0)
+
+    def test_refine_brachistochrone_radau_compressed(self):
+        p = self.make_problem(transcription='radau-ps', num_segments=5, transcription_order=3, compressed=True)
+        dm.run_problem(p, refine=True)
+        self.run_asserts(self.p)
+
+    def test_refine_brachistochrone_gauss_lobatto_compressed(self):
+        p = self.make_problem(transcription='gauss-lobatto', num_segments=5, transcription_order=3, compressed=True)
+        dm.run_problem(p, refine=True)
+        self.run_asserts(self.p)

--- a/dymos/grid_refinement/ph_adaptive/ph_adaptive.py
+++ b/dymos/grid_refinement/ph_adaptive/ph_adaptive.py
@@ -452,3 +452,67 @@ class PHAdaptive:
                 + oodt_dstau * np.dot(I, f_hat[state_name][not_left_end_idxs, ...])
 
         return x_hat, x_prime
+
+    def write_iteration(self, f, iter_number, phases, refine_results):
+        """
+        Writes a summary of the current grid refinement iteration to the given stream.
+
+        Parameters
+        ----------
+        f : stream
+            The output stream to which the grid refinment should be printed.
+        iter_number : int
+            The current grid refinement iteration index.
+        phases : dict of {phase_path: Phase}
+            The phases in the problem being refined.
+        refine_results : dict
+            A dictionary containing the grid refinement data for each phase, keyed by the phase path
+            in the model.
+        """
+        f.write('\n\n')
+        print(50 * '=', file=f)
+        str_gr = f'Grid Refinement - Iteration {iter_number}'
+        print(f'{str_gr:^50}', file=f)
+        print(50 * '-', file=f)
+        for phase_path, phase in phases.items():
+            refine_data = refine_results[phase_path]
+            refine_options = phase.refine_options
+
+            f.write('    Phase: {}\n'.format(phase_path))
+
+            # Print the phase grid-refinement settings
+            print('        Refinement Options:', file=f)
+            print('            Allow Refinement = {}'.format(refine_options['refine']), file=f)
+            print('            Tolerance = {}'.format(refine_options['tolerance']), file=f)
+            print('            Min Order = {}'.format(refine_options['min_order']), file=f)
+            print('            Max Order = {}'.format(refine_options['max_order']), file=f)
+
+            # Print the original grid specs
+            print('        Original Grid:', file=f)
+            print('            Number of Segments = {}'.format(refine_data['num_segments']), file=f)
+
+            str_segends = ', '.join(str(round(elem, 4)) for elem in refine_data['segment_ends'])
+            print(f'            Segment Ends = [{str_segends}]', file=f)
+
+            str_segorders = ', '.join(str(elem) for elem in refine_data['order'])
+            print(f'            Segment Order = [{str_segorders}]', file=f)
+
+            error = refine_data['error']
+            str_errors = ', '.join(f'{elem:8.4g}' for elem in error)
+            print(f'            Error = [{str_errors}]', file=f)
+
+            # Print the modified grid specs
+            print('        New Grid:', file=f)
+            print('            Number of Segments = {}'.format(refine_data['new_num_segments']), file=f)
+
+            str_segends = ', '.join(str(round(elem, 4)) for elem in refine_data['new_segment_ends'])
+            print(f'            Segment Ends = [{str_segends}]', file=f)
+
+            new_order = refine_data['new_order']
+            str_segorders = ', '.join(str(elem) for elem in new_order)
+
+            print(f'            Segment Order = [{str_segorders}]', file=f)
+
+            is_refined = True if np.any(refine_data['need_refinement']) and refine_options['refine'] else False
+            print(f'        Refined: {is_refined}', file=f)
+            print(file=f)

--- a/dymos/grid_refinement/ph_adaptive/ph_adaptive.py
+++ b/dymos/grid_refinement/ph_adaptive/ph_adaptive.py
@@ -156,9 +156,14 @@ class PHAdaptive:
             num_nodes = gd.subset_num_nodes['all']
             numseg = gd.num_segments
 
-            refine_results[phase_path]['num_segments'] = gd.num_segments
+            refine_results[phase_path]['num_segments'] = numseg
             refine_results[phase_path]['order'] = gd.transcription_order
             refine_results[phase_path]['segment_ends'] = gd.segment_ends
+            refine_results[phase_path]['need_refinement'] = np.zeros(numseg, dtype=bool)
+            refine_results[phase_path]['error'] = np.zeros(numseg, dtype=float)
+
+            if isinstance(tx, dm.RungeKutta):
+                continue
 
             outputs = phase.list_outputs(units=False, out_stream=None)
 

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -557,6 +557,27 @@ class TimeOptionsDictionary(om.OptionsDictionary):
                           'connected')
 
 
+class GridRefinementOptionsDictionary(om.OptionsDictionary):
+    """
+    An OptionsDictionary for grid refinement options in a Phase.
+    """
+
+    def __init__(self, read_only=False):
+        super(GridRefinementOptionsDictionary, self).__init__(read_only)
+
+        self.declare('refine', types=bool, default=True,
+                     desc='If True, this Phase may be refined during the grid refinement procedure.')
+
+        self.declare(name='tolerance', types=float, default=1.0E-4,
+                     desc='Default tolerance for grid refinement in this phase.')
+
+        self.declare(name='min_order', types=int, default=3,
+                     desc='Minimum transcription order for segments in this phase.')
+
+        self.declare(name='max_order', types=int, default=3,
+                     desc='Maximum transcription order for segments in this phase.')
+
+
 class _ForDocs(object):  # pragma: no cover
     """
     This class is provided as a way to automatically display options dictionaries in the docs,

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -574,7 +574,7 @@ class GridRefinementOptionsDictionary(om.OptionsDictionary):
         self.declare(name='min_order', types=int, default=3,
                      desc='Minimum transcription order for segments in this phase.')
 
-        self.declare(name='max_order', types=int, default=3,
+        self.declare(name='max_order', types=int, default=14,
                      desc='Maximum transcription order for segments in this phase.')
 
 

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -82,7 +82,7 @@ class Phase(om.Group):
             self.design_parameter_options = from_phase.design_parameter_options.copy()
             self.input_parameter_options = from_phase.input_parameter_options.copy()
 
-            self.refine_options = from_phase.refine_options.copy()
+            self.refine_options.update(from_phase.refine_options)
 
             self._initial_boundary_constraints = from_phase._initial_boundary_constraints.copy()
             self._final_boundary_constraints = from_phase._final_boundary_constraints.copy()

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -12,7 +12,7 @@ import dymos as dm
 
 from .options import ControlOptionsDictionary, DesignParameterOptionsDictionary, \
     InputParameterOptionsDictionary, StateOptionsDictionary, TimeOptionsDictionary, \
-    PolynomialControlOptionsDictionary
+    PolynomialControlOptionsDictionary, GridRefinementOptionsDictionary
 
 from ..transcriptions.transcription_base import TranscriptionBase
 
@@ -60,15 +60,11 @@ class Phase(om.Group):
         self.polynomial_control_options = {}
         self.design_parameter_options = {}
         self.input_parameter_options = {}
+        self.refine_options = GridRefinementOptionsDictionary()
 
         # Dictionaries of variable options that are set by the user via the API
         # These will be applied over any defaults specified by decorators on the ODE
         if from_phase is None:
-            self.refine_options = {'refine': False,
-                                   'iteration_limit': 10,
-                                   'tolerance': 1e-4,
-                                   'min_order': 3,
-                                   'max_order': 14}
 
             self._initial_boundary_constraints = {}
             self._final_boundary_constraints = {}
@@ -1833,11 +1829,27 @@ class Phase(om.Group):
 
         return sim_prob
 
-    def set_refine_options(self, refine=False, iteration_limit=10, tol=1e-4, min_order=3, max_order=14):
-        self.refine_options['refine'] = refine
-        self.refine_options['iteration_limit'] = iteration_limit
-        self.refine_options['tolerance'] = tol
-        self.refine_options['min_order'] = min_order
-        self.refine_options['max_order'] = max_order
+    def set_refine_options(self, refine=_unspecified, tol=_unspecified, min_order=_unspecified,
+                           max_order=_unspecified):
+        """
+        Set the specified option(s) for grid refinement in the phase.
 
-        return
+        Parameters
+        ----------
+        refine : bool
+            If True, this Phase will undergo refinement during the grid refinement procedure.
+        tol : float
+            The error tolerance for the ph grid refinement algorithm.
+        min_order : int
+            The minimum allowable transcription order for segments in the phase.
+        max_order : int
+            The maximum allowable transcription order for segments in the phase.
+        """
+        if refine is not _unspecified:
+            self.refine_options['refine'] = refine
+        if tol is not _unspecified:
+            self.refine_options['tolerance'] = tol
+        if min_order is not _unspecified:
+            self.refine_options['min_order'] = min_order
+        if max_order is not _unspecified:
+            self.refine_options['max_order'] = max_order

--- a/dymos/run_problem.py
+++ b/dymos/run_problem.py
@@ -189,18 +189,6 @@ def re_interpolate_solution(problem, phases, previous_solution):
                             phase.interpolate(xs=prev_time, ys=prev_control_val, nodes='control_input', kind='slinear'))
 
 
-def write_initial(f, phases):
-    f.write('======================\n')
-    f.write('   Grid Refinement\n')
-    f.write('======================\n')
-    f.write('ph-refinement\n')
-    for phase_path, phase in phases.items():
-        f.write('Phase: {}\n'.format(phase_path))
-        f.write('Tolerance: {}\n'.format(phase.refine_options['tolerance']))
-        f.write('Minimum Order: {}\n'.format(phase.refine_options['min_order']))
-        f.write('Maximum Order: {}\n'.format(phase.refine_options['max_order']))
-
-
 def write_iteration(f, iter_number, phases, refine_results):
     """
     Writes a summary of the current grid refinement iteration to the given stream.


### PR DESCRIPTION
### Summary

Various updates to the grid_refinement capability of OpenMDAO.

- refinement options moved to an OptionsDictionary
- `phase.refine_options['refine']` now defaults to True
- `re_interpolate_solution` now uses the promoted names given by list_inputs and list_outputs rather than trying to determine them itself.
- Grid refinement summary is now printed to both grid_refinement.out and standard output at each iteration, and the initial header has been removed.
- set_refine_options now only overwrites those options which have been specified the the argument list.
- Grid refinement will now gracefully bypass phases using the RungeKutta transcription.
- added a new test_ex_brachistochrone_refine_grid to test that grid refinement works for LGL, LGR, and RK4.

### Related Issues

- Resolves #281 

### Status

- [ ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
