### PR TITLE
sort linkage order to make converged solutions repeatable

### DIFF
--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -352,9 +352,12 @@ class Trajectory(om.Group):
             _vars = {}
             for var in sorted(vars.keys()):
                 if var == '*':
-                    _vars['time'] = vars[var].copy()
+                    names = ['time']
                     for state in p2_states:
-                        _vars[state] = vars[var].copy()
+                        names.append(state)
+                    # sort to make converged solutions repeatable
+                    for n in sorted(names):
+                        _vars[n] = vars[var].copy()
                 else:
                     _vars[var] = vars[var].copy()
 


### PR DESCRIPTION
### Summary

Use repeatable linkage order when linking multiple phases into a trajectory using a wildcard for variables so that converged solutions are repeatable.

### Related Issues

- Resolves #297

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
