### PR TITLE
Sparsity update

### DIFF
--- a/dymos/examples/brachistochrone/test/test_ex_brachistochrone_vector_states.py
+++ b/dymos/examples/brachistochrone/test/test_ex_brachistochrone_vector_states.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from numpy.testing import assert_almost_equal
 
@@ -54,8 +53,8 @@ class TestBrachistochroneVectorStatesExample(unittest.TestCase):
         p = ex_brachistochrone_vs.brachistochrone_min_time(transcription='radau-ps',
                                                            compressed=True,
                                                            force_alloc_complex=True,
-                                                           run_driver=True)
-        self.assert_results(p)
+                                                           run_driver=False)
+        p.run_driver()
         self.assert_partials(p)
 
     def test_ex_brachistochrone_vs_radau_uncompressed(self):

--- a/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
@@ -122,7 +122,7 @@ class TestFiniteBurnOrbitRaise(unittest.TestCase):
 
         p.driver.add_recorder(om.SqliteRecorder('two_burn_orbit_raise_example.db'))
 
-        p.setup(check=True)
+        p.setup(check=True, mode='fwd')
 
         # Set Initial Guesses
         p.set_val('traj.design_parameters:c', value=1.5, units='DU/TU')

--- a/dymos/transcriptions/common/test/test_control_interp_comp.py
+++ b/dymos/transcriptions/common/test/test_control_interp_comp.py
@@ -158,10 +158,10 @@ class TestControlRateComp(unittest.TestCase):
         cpd = p.check_partials(compact_print=False, method='cs')
         assert_check_partials(cpd)
 
-    # @parameterized.expand(
-    #     itertools.product([True, False],  # compressed
-    #                       ), name_func=lambda f, n, p: '_'.join(
-    #         ['test_control_interp_scalar_RK4', str(p.args[0])]))
+    @parameterized.expand(
+        itertools.product([True, False],  # compressed
+                          ), name_func=lambda f, n, p: '_'.join(
+            ['test_control_interp_scalar_RK4', str(p.args[0])]))
     def test_control_interp_scalar_rk4(self, compressed=False):
 
         segends = np.array([0.0, 3.0, 9.0])
@@ -237,7 +237,7 @@ class TestControlRateComp(unittest.TestCase):
                             np.atleast_2d(a_rate2_expected).T)
 
         np.set_printoptions(linewidth=1024)
-        cpd = p.check_partials(compact_print=False, method='cs')
+        cpd = p.check_partials(compact_print=True, method='cs')
         assert_check_partials(cpd)
 
     @parameterized.expand(
@@ -338,7 +338,7 @@ class TestControlRateComp(unittest.TestCase):
                             a2_rate2_expected)
 
         np.set_printoptions(linewidth=1024)
-        cpd = p.check_partials(method='cs')
+        cpd = p.check_partials(compact_print=True, method='cs')
 
         assert_check_partials(cpd)
 
@@ -439,7 +439,7 @@ class TestControlRateComp(unittest.TestCase):
                             a2_rate2_expected)
 
         np.set_printoptions(linewidth=1024)
-        cpd = p.check_partials(compact_print=False, method='cs')
+        cpd = p.check_partials(compact_print=True, method='cs')
 
         assert_check_partials(cpd)
 
@@ -553,7 +553,7 @@ class TestControlRateComp(unittest.TestCase):
                             a3_rate2_expected)
 
         with np.printoptions(linewidth=100000, edgeitems=100000):
-            cpd = p.check_partials(compact_print=False, method='cs')
+            cpd = p.check_partials(compact_print=True, method='cs')
 
         assert_check_partials(cpd)
 

--- a/dymos/transcriptions/common/test/test_control_interp_comp.py
+++ b/dymos/transcriptions/common/test/test_control_interp_comp.py
@@ -155,7 +155,7 @@ class TestControlRateComp(unittest.TestCase):
                             np.atleast_2d(b_rate2_expected).T)
 
         np.set_printoptions(linewidth=1024)
-        cpd = p.check_partials(compact_print=False, out_stream=None, method='cs')
+        cpd = p.check_partials(compact_print=False, method='cs')
         assert_check_partials(cpd)
 
     @parameterized.expand(
@@ -237,7 +237,7 @@ class TestControlRateComp(unittest.TestCase):
                             np.atleast_2d(a_rate2_expected).T)
 
         np.set_printoptions(linewidth=1024)
-        cpd = p.check_partials(compact_print=False, out_stream=None, method='cs')
+        cpd = p.check_partials(compact_print=False, method='cs')
         assert_check_partials(cpd)
 
     @parameterized.expand(
@@ -338,7 +338,7 @@ class TestControlRateComp(unittest.TestCase):
                             a2_rate2_expected)
 
         np.set_printoptions(linewidth=1024)
-        cpd = p.check_partials(method='cs', out_stream=None)
+        cpd = p.check_partials(method='cs')
 
         assert_check_partials(cpd)
 
@@ -439,7 +439,7 @@ class TestControlRateComp(unittest.TestCase):
                             a2_rate2_expected)
 
         np.set_printoptions(linewidth=1024)
-        cpd = p.check_partials(compact_print=False, method='cs', out_stream=None)
+        cpd = p.check_partials(compact_print=False, method='cs')
 
         assert_check_partials(cpd)
 
@@ -552,8 +552,8 @@ class TestControlRateComp(unittest.TestCase):
         assert_almost_equal(p['control_interp_comp.control_rates:a_rate2'][:, 1, 1],
                             a3_rate2_expected)
 
-        np.set_printoptions(linewidth=1024)
-        cpd = p.check_partials(compact_print=False, method='cs', out_stream=None)
+        with np.printoptions(linewidth=100000, edgeitems=100000):
+            cpd = p.check_partials(compact_print=False, method='cs')
 
         assert_check_partials(cpd)
 

--- a/dymos/transcriptions/common/test/test_control_interp_comp.py
+++ b/dymos/transcriptions/common/test/test_control_interp_comp.py
@@ -158,11 +158,11 @@ class TestControlRateComp(unittest.TestCase):
         cpd = p.check_partials(compact_print=False, method='cs')
         assert_check_partials(cpd)
 
-    @parameterized.expand(
-        itertools.product([True, False],  # compressed
-                          ), name_func=lambda f, n, p: '_'.join(
-            ['test_control_interp_scalar_RK4', str(p.args[0])]))
-    def test_control_interp_scalar_rk4(self, compressed=True):
+    # @parameterized.expand(
+    #     itertools.product([True, False],  # compressed
+    #                       ), name_func=lambda f, n, p: '_'.join(
+    #         ['test_control_interp_scalar_RK4', str(p.args[0])]))
+    def test_control_interp_scalar_rk4(self, compressed=False):
 
         segends = np.array([0.0, 3.0, 9.0])
 

--- a/dymos/transcriptions/grid_data.py
+++ b/dymos/transcriptions/grid_data.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from scipy.linalg import block_diag
+import scipy.sparse as sp
 
 from dymos.utils.lgl import lgl
 from dymos.utils.lgr import lgr
@@ -472,7 +473,7 @@ class GridData(object):
         self.input_maps['dynamic_control_input_to_disc'] = make_subset_map(control_input_idxs,
                                                                            control_disc_idxs)
 
-    def phase_lagrange_matrices(self, given_set_name, eval_set_name):
+    def phase_lagrange_matrices(self, given_set_name, eval_set_name, sparse=False):
         """
         Compute the matrices mapping values at some nodes to values and derivatives at new nodes.
 
@@ -482,6 +483,9 @@ class GridData(object):
             Name of the set of nodes with which to perform the interpolation.
         eval_set_name : str
             Name of the set of nodes at which to evaluate the values and derivatives.
+        sparse : bool
+            If True, the returned matrix will be in scipy CSR sparse format.  Otherwise, it is
+            returned as a dense numpy.array.
 
         Returns
         -------
@@ -525,9 +529,13 @@ class GridData(object):
         L = block_diag(*L_blocks)
         D = block_diag(*D_blocks)
 
+        if sparse:
+            L = sp.csr_matrix(L)
+            D = sp.csr_matrix(D)
+
         return L, D
 
-    def phase_hermite_matrices(self, given_set_name, eval_set_name):
+    def phase_hermite_matrices(self, given_set_name, eval_set_name, sparse=False):
         """
         Compute the matrices mapping values at some nodes to values and derivatives at new nodes.
 
@@ -537,6 +545,9 @@ class GridData(object):
             Name of the set of nodes with which to perform the interpolation.
         eval_set_name : str
             Name of the set of nodes at which to evaluate the values and derivatives.
+        sparse : bool
+            If True, the returned matrix will be in scipy CSR sparse format.  Otherwise, it is
+            returned as a dense numpy.array.
 
         Returns
         -------
@@ -594,5 +605,11 @@ class GridData(object):
         Bi = block_diag(*Bi_list)
         Ad = block_diag(*Ad_list)
         Bd = block_diag(*Bd_list)
+
+        if sparse:
+            Ai = sp.csr_matrix(Ai)
+            Bi = sp.csr_matrix(Bi)
+            Ad = sp.csr_matrix(Ad)
+            Bd = sp.csr_matrix(Bd)
 
         return Ai, Bi, Ad, Bd

--- a/dymos/transcriptions/pseudospectral/components/state_interp_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/state_interp_comp.py
@@ -6,6 +6,19 @@ from ....utils.misc import get_rate_units
 
 
 def sparse_tensor_dot(sps_mat, dense_vecs):
+    """
+    Performance a tensordot using a sparse matrix and dense vectors.
+
+    Parameters
+    ----------
+    sps_mat : scipy.sparse.spmatrix
+        A scipy sparse matrix.
+    dense_vecs
+        Dense columns to be dot multiplied by the sparse matrix.
+
+    Returns
+    -------
+    """
     rows, cols = sps_mat.shape
     dense_vecs = dense_vecs.reshape(-1, cols)
     out = sps_mat.dot(dense_vecs.T).T
@@ -19,14 +32,14 @@ class StateInterpComp(om.ExplicitComponent):
     at discretization nodes and computes the interpolated state values and derivatives
     at the collocation nodes, using a Hermite interpolation scheme.
 
-    .. math:: x_c = \left[ A_i \right] x_d + \frac{dt}{d\tau} \left[ B_i \right] f_d
-    .. math:: \dot{x}_c = \frac{d\tau}{dt} \left[ A_d \right] x_d + \left[ B_d \right] f_d
+    .. math:: x_c = \left[ A_i \right] x_d + \frac{dt}{d\tau_s} \left[ B_i \right] f_d
+    .. math:: \dot{x}_c = \frac{d\tau_s}{dt} \left[ A_d \right] x_d + \left[ B_d \right] f_d
 
     When the transcription is *radau-ps* it accepts the state values at the discretization nodes
     and computes the interpolated state derivatives at the collocation nodes, using a Lagrange
     interpolation scheme.
 
-    .. math:: \dot{x}_c = \frac{d\tau}{dt} \left[ A_d \right] x_d
+    .. math:: \dot{x}_c = \frac{d\tau_s}{dt} \left[ A_d \right] x_d
 
     """
 
@@ -105,15 +118,17 @@ class StateInterpComp(om.ExplicitComponent):
             self.xdotc_str[state_name] = 'staterate_col:{0}'.format(state_name)
 
         if transcription == 'gauss-lobatto':
-            Ai, Bi, Ad, Bd = self.options['grid_data'].phase_hermite_matrices('state_disc', 'col')
+            Ai, Bi, Ad, Bd = self.options['grid_data'].phase_hermite_matrices('state_disc', 'col', sparse=True)
+
         elif transcription == 'radau-ps':
-            Ai, Ad = self.options['grid_data'].phase_lagrange_matrices('state_disc', 'col')
-            Bi = Bd = np.zeros(shape=(num_col_nodes, num_disc_nodes))
+            Ai, Ad = self.options['grid_data'].phase_lagrange_matrices('state_disc', 'col', sparse=True)
+            Bi = Bd = sp.csr_matrix(np.zeros(shape=(num_col_nodes, num_disc_nodes)))
+
         else:
             raise ValueError('unhandled transcription type: '
                              '{0}'.format(self.options['transcription']))
-        self.matrices = {'Ai': Ai, 'Bi': Bi, 'Ad': sp.csr_matrix(Ad), 'Bd': Bd}
 
+        self.matrices = {'Ai': Ai, 'Bi': Bi, 'Ad': Ad, 'Bd': Bd}
         # Setup partials
 
         self.jacs = {'Ai': {}, 'Bi': {}, 'Ad': {}, 'Bd': {}}
@@ -124,40 +139,20 @@ class StateInterpComp(om.ExplicitComponent):
         self.sizes = {}
         self.num_col_nodes = num_col_nodes
         self.num_disc_nodes = num_disc_nodes
+
         for name, options in state_options.items():
             shape = options['shape']
 
             size = np.prod(shape)
+            self.sizes[name] = size
 
             for key in self.jacs:
-                # jac = np.zeros((num_col_nodes, size, num_disc_nodes, size))
-                # for i in range(size):
-                #     jac[:, i, :, i] = self.matrices[key]
-                # jac = jac.reshape((num_col_nodes * size, num_disc_nodes * size), order='C')
-                # self.jacs[key][name] = sp.csr_matrix(jac)
-                # with np.printoptions(linewidth=1000000, edgeitems=1000000):
-                #     print(name)
-                #     print(key)
-                #     # print(self.matrices[key])
-                #     print(self.jacs[key][name].nonzero())
-
                 # Each jacobian matrix has a form that is defined by the Kronecker product
-                # of the interpolation matrix and np.eye(size).
-                #
-                # We zero out any elements less than 1E-16 to prevent spurious nonzeros in the
-                # sparse form.
-                # print(key)
-                try:
-                    jac = np.kron(self.matrices[key].toarray(), np.eye(size))
-                except:
-                    jac = np.kron(self.matrices[key], np.eye(size))
-                # print(jac)
-                # print(abs(jac) < 1.0E-16)
-                idxs_near_zero = np.where(abs(jac) < 1.0E-16)
-                jac[idxs_near_zero] = 0.0
-                self.jacs[key][name] = sp.csr_matrix(jac)
-
-                # self.jacs[key][name] = sp.kron(sp.csr_matrix(self.matrices[key]), sp.eye(size))
+                # of the interpolation matrix and np.eye(size). Make sure to specify csc format
+                # here to avoid spurious zeros.
+                self.jacs[key][name] = sp.kron(sp.csr_matrix(self.matrices[key]),
+                                               sp.eye(size),
+                                               format='csc')
 
             self.sizes[name] = size
 
@@ -184,33 +179,29 @@ class StateInterpComp(om.ExplicitComponent):
                     of=self.xc_str[name], wrt='dt_dstau',
                     rows=rs_dtdstau, cols=cs_dtdstau)
 
-                Ai_rows, Ai_cols = self.jacs['Ai'][name].nonzero()
+                Ai_rows, Ai_cols, data = sp.find(self.jacs['Ai'][name])
                 self.declare_partials(of=self.xc_str[name], wrt=self.xd_str[name],
-                                      rows=Ai_rows, cols=Ai_cols,
-                                      val=self.jacs['Ai'][name][Ai_rows, Ai_cols])
+                                      rows=Ai_rows, cols=Ai_cols, val=data)
 
-                self.Bi_rows[name], self.Bi_cols[name] = self.jacs['Bi'][name].nonzero()
+                self.Bi_rows[name], self.Bi_cols[name], _ = sp.find(self.jacs['Bi'][name])
                 self.declare_partials(of=self.xc_str[name], wrt=self.fd_str[name],
                                       rows=self.Bi_rows[name], cols=self.Bi_cols[name])
 
-                Bd_rows, Bd_cols = self.jacs['Bd'][name].nonzero()
+                Bd_rows, Bd_cols, data = sp.find(self.jacs['Bd'][name])
                 self.declare_partials(of=self.xdotc_str[name], wrt=self.fd_str[name],
-                                      rows=Bd_rows, cols=Bd_cols,
-                                      val=self.jacs['Bd'][name][Bd_rows, Bd_cols])
+                                      rows=Bd_rows, cols=Bd_cols, val=data)
 
-            self.Ad_rows[name], self.Ad_cols[name] = self.jacs['Ad'][name].nonzero()
+            self.Ad_rows[name], self.Ad_cols[name], _ = sp.find(self.jacs['Ad'][name])
             self.declare_partials(of=self.xdotc_str[name], wrt=self.xd_str[name],
                                   rows=self.Ad_rows[name], cols=self.Ad_cols[name])
 
-            # with np.printoptions(linewidth=1_000_000, edgeitems=1_000_000):
-            #     print(name)
-            #     print(self.Ad_rows[name])
-            #     print(self.Ad_cols[name])
-            #     print(self.jacs['Ad'][name])
-            #     print(self.jacs['Ad'][name].shape)
-            # exit(0)
-
     def _compute_radau(self, inputs, outputs):
+        """
+        For each state, compute
+
+
+        """
+
         state_options = self.options['state_options']
 
         dt_dstau = inputs['dt_dstau'][:, np.newaxis]
@@ -221,13 +212,7 @@ class StateInterpComp(om.ExplicitComponent):
 
             xd = np.atleast_2d(inputs[xd_str])
 
-            # Use transpose to divide each "row" of a by dt_dstau
-            # a = np.tensordot(self.matrices['Ad'], xd, axes=(1, 0)).T
-            # a = sparse_tensor_dot(self.matrices['Ad'], xd)
             outputs[xdotc_str] = self.matrices['Ad'].dot(xd) / dt_dstau
-            # print(a.shape)
-            # print(dt_dstau.shape)
-            # outputs[xdotc_str] = a / dt_dstau[:, np.newaxis]
 
     def _compute_gauss_lobatto(self, inputs, outputs):
         state_options = self.options['state_options']
@@ -244,13 +229,11 @@ class StateInterpComp(om.ExplicitComponent):
 
             xd = np.atleast_2d(inputs[xd_str])
 
-            a = np.tensordot(self.matrices['Bi'], inputs[fd_str], axes=(1, 0)).T
-            outputs[xc_str] = (a * dt_dstau).T
+            a = self.matrices['Bi'].dot(inputs[fd_str])
+            outputs[xc_str] = a * dt_dstau[:, np.newaxis]
+            outputs[xc_str] += self.matrices['Ai'].dot(xd)
 
-            outputs[xc_str] += np.tensordot(
-                self.matrices['Ai'], xd, axes=(1, 0))
-
-            outputs[xdotc_str] = np.tensordot(self.matrices['Ad'], xd, axes=(1, 0))
+            outputs[xdotc_str] = self.matrices['Ad'].dot(xd)
 
             if len(outputs[xdotc_str].shape) == 1:
                 outputs[xdotc_str] /= dt_dstau
@@ -262,8 +245,7 @@ class StateInterpComp(om.ExplicitComponent):
                 for i in range(num_col_nodes):
                     outputs[xdotc_str][i, ...] /= dt_dstau[i]
 
-            outputs[xdotc_str] += np.tensordot(
-                self.matrices['Bd'], inputs[fd_str], axes=(1, 0))
+            outputs[xdotc_str] += self.matrices['Bd'].dot(inputs[fd_str])
 
     def _compute_partials_radau(self, inputs, partials):
         state_options = self.options['state_options']
@@ -279,13 +261,13 @@ class StateInterpComp(om.ExplicitComponent):
             # Unroll matrix-shaped states into an array at each node
             xd = np.reshape(inputs[xd_name], (ndn, size))
 
-            partials[xdotc_name, 'dt_dstau'] = -self.matrices['Ad'].dot(xd).ravel(order='F') \
+            partials[xdotc_name, 'dt_dstau'] = -self.matrices['Ad'].dot(xd).T.ravel() \
                 / np.tile(inputs['dt_dstau'], size) ** 2
 
-            dt_dstau_x_size = np.repeat(inputs['dt_dstau'], size)
+            dt_dstau_x_size = np.repeat(inputs['dt_dstau'], size)[:, np.newaxis]
 
-            partial_xdotc_xd = self.jacs['Ad'][name] / dt_dstau_x_size[:, np.newaxis]
-            partials[xdotc_name, xd_name][:] = partial_xdotc_xd[partial_xdotc_xd.nonzero()]
+            partial_xdotc_xd = self.jacs['Ad'][name].multiply(np.reciprocal(dt_dstau_x_size))
+            partials[xdotc_name, xd_name][:] = partial_xdotc_xd.data
 
     def _compute_partials_gauss_lobatto(self, inputs, partials):
         ndn = self.num_disc_nodes
@@ -307,17 +289,16 @@ class StateInterpComp(om.ExplicitComponent):
 
             dt_dstau_x_size = np.repeat(inputs['dt_dstau'], size)[:, np.newaxis]
 
-            partials[xc_name, 'dt_dstau'] = np.dot(self.matrices['Bi'], fd).ravel(order='F')
+            partials[xc_name, 'dt_dstau'] = self.matrices['Bi'].dot(fd).T.ravel()
 
-            partials[xdotc_name, 'dt_dstau'] = -np.dot(self.matrices['Ad'], xd).ravel(order='F') \
+            partials[xdotc_name, 'dt_dstau'] = -self.matrices['Ad'].dot(xd).T.ravel() \
                 / np.tile(dt_dstau, size) ** 2
 
-            r_nz, c_nz = self.Bi_rows[name], self.Bi_cols[name]
-            partials[xc_name, fd_name] = (self.jacs['Bi'][name] * dt_dstau_x_size)[r_nz, c_nz]
+            dxc_dfd = self.jacs['Bi'][name].multiply(dt_dstau_x_size)
+            partials[xc_name, fd_name] = dxc_dfd.data
 
-            r_nz, c_nz = self.Ad_rows[name], self.Ad_cols[name]
-
-            partials[xdotc_name, xd_name] = (self.jacs['Ad'][name] / dt_dstau_x_size)[r_nz, c_nz]
+            dxdotc_dxd = self.jacs['Ad'][name].multiply(np.reciprocal(dt_dstau_x_size))
+            partials[xdotc_name, xd_name] = dxdotc_dxd.data
 
     def compute(self, inputs, outputs):
         transcription = self.options['transcription']
@@ -331,7 +312,6 @@ class StateInterpComp(om.ExplicitComponent):
 
     def compute_partials(self, inputs, partials):
         transcription = self.options['transcription']
-
         if transcription == 'gauss-lobatto':
             self._compute_partials_gauss_lobatto(inputs, partials)
         elif transcription == 'radau-ps':

--- a/dymos/transcriptions/pseudospectral/components/state_interp_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/state_interp_comp.py
@@ -5,26 +5,6 @@ from ...grid_data import GridData
 from ....utils.misc import get_rate_units
 
 
-def sparse_tensor_dot(sps_mat, dense_vecs):
-    """
-    Performance a tensordot using a sparse matrix and dense vectors.
-
-    Parameters
-    ----------
-    sps_mat : scipy.sparse.spmatrix
-        A scipy sparse matrix.
-    dense_vecs
-        Dense columns to be dot multiplied by the sparse matrix.
-
-    Returns
-    -------
-    """
-    rows, cols = sps_mat.shape
-    dense_vecs = dense_vecs.reshape(-1, cols)
-    out = sps_mat.dot(dense_vecs.T).T
-    return out.reshape(dense_vecs.shape[:-1] + (rows,))
-
-
 class StateInterpComp(om.ExplicitComponent):
     r""" Provide interpolated state values and/or rates for pseudospectral transcriptions.
 

--- a/dymos/transcriptions/pseudospectral/components/state_interp_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/state_interp_comp.py
@@ -218,9 +218,6 @@ class StateInterpComp(om.ExplicitComponent):
         Ad = self.matrices['Ad']
 
         dstau_dt = np.reciprocal(inputs['dt_dstau'])
-        dstau_dt2 = dstau_dt ** 2
-
-        dstau_dt = np.reciprocal(inputs['dt_dstau'])
         dstau_dt2 = (dstau_dt ** 2)
 
         for name in state_options:
@@ -241,6 +238,9 @@ class StateInterpComp(om.ExplicitComponent):
     def _compute_partials_gauss_lobatto(self, inputs, partials):
         ndn = self.options['grid_data'].subset_num_nodes['disc']
 
+        Ad = self.matrices['Ad']
+        Bi = self.matrices['Bi']
+
         dstau_dt = np.reciprocal(inputs['dt_dstau'])
         dstau_dt2 = dstau_dt ** 2
 
@@ -259,10 +259,9 @@ class StateInterpComp(om.ExplicitComponent):
 
             dt_dstau_x_size = np.repeat(inputs['dt_dstau'], size)[:, np.newaxis]
 
-            partials[xc_name, 'dt_dstau'] = self.matrices['Bi'].dot(fd).ravel()
+            partials[xc_name, 'dt_dstau'] = Bi.dot(fd).ravel()
 
-            partials[xdotc_name, 'dt_dstau'] = (-self.matrices['Ad'].dot(xd) \
-                                                * dstau_dt2[:, np.newaxis]).ravel()
+            partials[xdotc_name, 'dt_dstau'] = (-Ad.dot(xd) * dstau_dt2[:, np.newaxis]).ravel()
 
             dxc_dfd = self.jacs['Bi'][name].multiply(dt_dstau_x_size)
             partials[xc_name, fd_name] = dxc_dfd.data

--- a/dymos/utils/misc.py
+++ b/dymos/utils/misc.py
@@ -79,23 +79,3 @@ class CoerceDesvar(object):
                 raise ValueError('array-valued option {0} must have length '
                                  'num_input_nodes ({1})'.format(option, val))
             return val[self.desvar_indices]
-
-
-def sparse_tensor_dot(sps_mat, dense_vecs):
-    """
-    Performance a tensordot using a sparse matrix and dense vectors.
-
-    Parameters
-    ----------
-    sps_mat : scipy.sparse.spmatrix
-        A scipy sparse matrix.
-    dense_vecs
-        Dense columns to be dot multiplied by the sparse matrix.
-
-    Returns
-    -------
-    """
-    rows, cols = sps_mat.shape
-    dense_vecs = dense_vecs.reshape(-1, cols)
-    out = sps_mat.dot(dense_vecs.T).T
-    return out.reshape(dense_vecs.shape[:-1] + (rows,))

--- a/dymos/utils/misc.py
+++ b/dymos/utils/misc.py
@@ -79,3 +79,23 @@ class CoerceDesvar(object):
                 raise ValueError('array-valued option {0} must have length '
                                  'num_input_nodes ({1})'.format(option, val))
             return val[self.desvar_indices]
+
+
+def sparse_tensor_dot(sps_mat, dense_vecs):
+    """
+    Performance a tensordot using a sparse matrix and dense vectors.
+
+    Parameters
+    ----------
+    sps_mat : scipy.sparse.spmatrix
+        A scipy sparse matrix.
+    dense_vecs
+        Dense columns to be dot multiplied by the sparse matrix.
+
+    Returns
+    -------
+    """
+    rows, cols = sps_mat.shape
+    dense_vecs = dense_vecs.reshape(-1, cols)
+    out = sps_mat.dot(dense_vecs.T).T
+    return out.reshape(dense_vecs.shape[:-1] + (rows,))


### PR DESCRIPTION
### Summary

Cleanup of state and control interpolation to utilize sparse matrices via scipy.sparse.

Since theres significant sparsity in the state and control interpolation matrices, especially as the number of segments increases, this PR changes the state and control interpolation components to store components used for interpolation and partial evaluation as sparse matrices.

In addition, the components now reshape N-dimension inputs such that each element is treated as its own state vector.  This allows dymos to operate on states and controls with a completely arbitrary number of dimensions (previously states were limited to 3 dimensions).

### Related Issues

- Resolves #302

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
