### PR TITLE
Optional timeseries

### DIFF
--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -273,6 +273,9 @@ class DesignParameterOptionsDictionary(om.OptionsDictionary):
                      desc='The unit-reference value of the design parameter. This '
                           'option is invalid if opt=False.')
 
+        self.declare(name='include_timeseries', types=bool, default=True,
+                     desc='True if the static design parameters should be included in output timeseries, else False')
+
 
 class TrajDesignParameterOptionsDictionary(DesignParameterOptionsDictionary):
     """
@@ -329,6 +332,9 @@ class InputParameterOptionsDictionary(om.OptionsDictionary):
 
         self.declare(name='shape', types=Iterable, default=(1,),
                      desc='The shape of the design parameter.')
+
+        self.declare(name='include_timeseries', types=bool, default=True,
+                     desc='True if the static input parameters should be included in output timeseries, else False')
 
 
 class TrajInputParameterOptionsDictionary(InputParameterOptionsDictionary):

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -773,7 +773,7 @@ class Phase(om.Group):
     def add_design_parameter(self, name, val=_unspecified, units=_unspecified, opt=_unspecified,
                              desc=_unspecified, lower=_unspecified, upper=_unspecified, scaler=_unspecified,
                              adder=_unspecified, ref0=_unspecified, ref=_unspecified, targets=_unspecified,
-                             shape=_unspecified, dynamic=_unspecified):
+                             shape=_unspecified, dynamic=_unspecified, include_timeseries=_unspecified):
         """
         Add a design parameter (static control variable) to the phase.
 
@@ -812,6 +812,8 @@ class Phase(om.Group):
         dynamic : bool
             True if the targets in the ODE may be dynamic (if the inputs are sized to the number
             of nodes) else False.
+        include_timeseries : bool
+            True if the static design parameters should be included in output timeseries, else False.
         """
         self.check_parameter(name)
 
@@ -820,13 +822,13 @@ class Phase(om.Group):
             self.design_parameter_options[name]['name'] = name
 
         self.set_design_parameter_options(name, val, units, opt, desc, lower, upper,
-                                          scaler, adder, ref0, ref, targets, shape, dynamic)
+                                          scaler, adder, ref0, ref, targets, shape, dynamic, include_timeseries)
 
     def set_design_parameter_options(self, name, val=_unspecified, units=_unspecified, opt=_unspecified,
                                      desc=_unspecified, lower=_unspecified, upper=_unspecified,
                                      scaler=_unspecified, adder=_unspecified, ref0=_unspecified,
                                      ref=_unspecified, targets=_unspecified, shape=_unspecified,
-                                     dynamic=_unspecified):
+                                     dynamic=_unspecified, include_timeseries=_unspecified):
         """
         Set options for an existing design parameter (static control variable) in the phase.
 
@@ -865,6 +867,8 @@ class Phase(om.Group):
         dynamic : bool
             True if the targets in the ODE may be dynamic (if the inputs are sized to the number
             of nodes) else False.
+        include_timeseries : bool
+            True if the static design parameters should be included in output timeseries, else False.
         """
         if units is not _unspecified:
             self.design_parameter_options[name]['units'] = units
@@ -908,8 +912,12 @@ class Phase(om.Group):
         if ref is not _unspecified:
             self.design_parameter_options[name]['ref'] = ref
 
+        if include_timeseries is not _unspecified:
+            self.design_parameter_options[name]['include_timeseries'] = include_timeseries
+
     def add_input_parameter(self, name, val=_unspecified, units=_unspecified, targets=_unspecified,
-                            desc=_unspecified, shape=_unspecified, dynamic=_unspecified):
+                            desc=_unspecified, shape=_unspecified, dynamic=_unspecified,
+                            include_timeseries=_unspecified):
         """
         Add an input parameter to the phase.
 
@@ -931,6 +939,8 @@ class Phase(om.Group):
         dynamic : bool
             True if the targets in the ODE may be dynamic (if the inputs are sized to the number
             of nodes) else False.
+        include_timeseries : bool
+            True if the static input parameters should be included in output timeseries, else False.
         """
         self.check_parameter(name)
 
@@ -966,8 +976,12 @@ class Phase(om.Group):
         if dynamic is not _unspecified:
             self.input_parameter_options[name]['dynamic'] = dynamic
 
+        if include_timeseries is not _unspecified:
+            self.input_parameter_options[name]['include_timeseries'] = include_timeseries
+
     def set_input_parameter_options(self, name, val=_unspecified, units=_unspecified, targets=_unspecified,
-                                    desc=_unspecified, shape=_unspecified, dynamic=_unspecified):
+                                    desc=_unspecified, shape=_unspecified, dynamic=_unspecified,
+                                    include_timeseries=_unspecified):
         """
         Set options of an existing input parameter in the phase.
 
@@ -989,6 +1003,8 @@ class Phase(om.Group):
         dynamic : bool
             True if the targets in the ODE may be dynamic (if the inputs are sized to the number
             of nodes) else False.
+        include_timeseries : bool
+            True if the static input parameters should be included in output timeseries, else False.
         """
         if units is not _unspecified:
             self.input_parameter_options[name]['units'] = units
@@ -1017,6 +1033,9 @@ class Phase(om.Group):
 
         if dynamic is not _unspecified:
             self.input_parameter_options[name]['dynamic'] = dynamic
+
+        if include_timeseries is not _unspecified:
+            self.input_parameter_options[name]['include_timeseries'] = include_timeseries
 
     def add_boundary_constraint(self, name, loc, constraint_name=None, units=None,
                                 shape=None, indices=None, lower=None, upper=None, equals=None,

--- a/dymos/phase/test/test_timeseries.py
+++ b/dymos/phase/test/test_timeseries.py
@@ -103,6 +103,14 @@ class TestTimeseriesOutput(unittest.TestCase):
                                      p.get_val('phase0.design_parameters:{0}'.format(dp))[0, :],
                                      p.get_val('phase0.timeseries.design_parameters:{0}'.format(dp))[i])
 
+        # call simulate to test SolveIVP transcription
+        exp_out = phase.simulate()
+        if test_smaller_timeseries:
+            with self.assertRaises(KeyError):
+                exp_out.get_val('phase0.timeseries.design_parameters:{0}'.format(dp))
+        else:  # no error accessing timseries.design_parameter
+            exp_out.get_val('phase0.timeseries.design_parameters:{0}'.format(dp))
+
     def test_timeseries_gl_smaller_timeseries(self):
         self.test_timeseries_gl(test_smaller_timeseries=True)
 
@@ -195,6 +203,14 @@ class TestTimeseriesOutput(unittest.TestCase):
                                      p.get_val('phase0.design_parameters:{0}'.format(dp))[0, :],
                                      p.get_val('phase0.timeseries.design_parameters:'
                                                '{0}'.format(dp))[i])
+
+        # call simulate to test SolveIVP transcription
+        exp_out = phase.simulate()
+        if test_smaller_timeseries:
+            with self.assertRaises(KeyError):
+                exp_out.get_val('phase0.timeseries.design_parameters:{0}'.format(dp))
+        else:  # no error accessing timseries.design_parameter
+            exp_out.get_val('phase0.timeseries.design_parameters:{0}'.format(dp))
 
     def test_timeseries_radau_smaller_timeseries(self):
         self.test_timeseries_radau(test_smaller_timeseries=True)

--- a/dymos/phase/test/test_timeseries.py
+++ b/dymos/phase/test/test_timeseries.py
@@ -9,7 +9,7 @@ from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneOD
 
 class TestTimeseriesOutput(unittest.TestCase):
 
-    def test_timeseries_gl(self):
+    def test_timeseries_gl(self, test_smaller_timeseries=False):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
@@ -39,8 +39,12 @@ class TestTimeseriesOutput(unittest.TestCase):
                           targets=BrachistochroneODE.parameters['theta']['targets'],
                           units='deg', lower=0.01, upper=179.9, ref=1, ref0=0)
 
-        phase.add_design_parameter('g', targets=BrachistochroneODE.parameters['g']['targets'],
-                                   opt=True, units='m/s**2', val=9.80665)
+        if test_smaller_timeseries:
+            phase.add_design_parameter('g', targets=BrachistochroneODE.parameters['g']['targets'],
+                                       opt=True, units='m/s**2', val=9.80665, include_timeseries=False)
+        else:
+            phase.add_design_parameter('g', targets=BrachistochroneODE.parameters['g']['targets'],
+                                       opt=True, units='m/s**2', val=9.80665)
 
         # Minimize time at the end of the phase
         phase.add_objective('time_phase', loc='final', scaler=10)
@@ -91,11 +95,18 @@ class TestTimeseriesOutput(unittest.TestCase):
 
         for dp in ('g',):
             for i in range(gd.subset_num_nodes['all']):
-                assert_rel_error(self,
-                                 p.get_val('phase0.design_parameters:{0}'.format(dp))[0, :],
-                                 p.get_val('phase0.timeseries.design_parameters:{0}'.format(dp))[i])
+                if test_smaller_timeseries:
+                    with self.assertRaises(KeyError):
+                        p.get_val('phase0.timeseries.design_parameters:{0}'.format(dp))
+                else:
+                    assert_rel_error(self,
+                                     p.get_val('phase0.design_parameters:{0}'.format(dp))[0, :],
+                                     p.get_val('phase0.timeseries.design_parameters:{0}'.format(dp))[i])
 
-    def test_timeseries_radau(self):
+    def test_timeseries_gl_smaller_timeseries(self):
+        self.test_timeseries_gl(test_smaller_timeseries=True)
+
+    def test_timeseries_radau(self, test_smaller_timeseries=False):
         p = om.Problem(model=om.Group())
 
         p.driver = om.ScipyOptimizeDriver()
@@ -125,8 +136,12 @@ class TestTimeseriesOutput(unittest.TestCase):
                           targets=BrachistochroneODE.parameters['theta']['targets'],
                           units='deg', lower=0.01, upper=179.9, ref=1, ref0=0)
 
-        phase.add_design_parameter('g', targets=BrachistochroneODE.parameters['g']['targets'],
-                                   opt=True, units='m/s**2', val=9.80665)
+        if test_smaller_timeseries:
+            phase.add_design_parameter('g', targets=BrachistochroneODE.parameters['g']['targets'],
+                                       opt=True, units='m/s**2', val=9.80665, include_timeseries=False)
+        else:
+            phase.add_design_parameter('g', targets=BrachistochroneODE.parameters['g']['targets'],
+                                       opt=True, units='m/s**2', val=9.80665)
 
         # Minimize time at the end of the phase
         phase.add_objective('time_phase', loc='final', scaler=10)
@@ -172,10 +187,17 @@ class TestTimeseriesOutput(unittest.TestCase):
 
         for dp in ('g',):
             for i in range(gd.subset_num_nodes['all']):
-                assert_rel_error(self,
-                                 p.get_val('phase0.design_parameters:{0}'.format(dp))[0, :],
-                                 p.get_val('phase0.timeseries.design_parameters:'
-                                           '{0}'.format(dp))[i])
+                if test_smaller_timeseries:
+                    with self.assertRaises(KeyError):
+                        p.get_val('phase0.timeseries.design_parameters:{0}'.format(dp))
+                else:
+                    assert_rel_error(self,
+                                     p.get_val('phase0.design_parameters:{0}'.format(dp))[0, :],
+                                     p.get_val('phase0.timeseries.design_parameters:'
+                                               '{0}'.format(dp))[i])
+
+    def test_timeseries_radau_smaller_timeseries(self):
+        self.test_timeseries_radau(test_smaller_timeseries=True)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/transcriptions/pseudospectral/gauss_lobatto.py
+++ b/dymos/transcriptions/pseudospectral/gauss_lobatto.py
@@ -555,32 +555,34 @@ class GaussLobatto(PseudospectralBase):
                                        'polynomial_control_rates:{1}_rate2'.format(name, control_name))
 
             for param_name, options in phase.design_parameter_options.items():
-                units = options['units']
-                timeseries_comp._add_timeseries_output('design_parameters:{0}'.format(param_name),
-                                                       var_class=phase.classify_var(param_name),
-                                                       shape=options['shape'],
-                                                       units=units)
+                if options['include_timeseries']:
+                    units = options['units']
+                    timeseries_comp._add_timeseries_output('design_parameters:{0}'.format(param_name),
+                                                           var_class=phase.classify_var(param_name),
+                                                           shape=options['shape'],
+                                                           units=units)
 
-                src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
+                    src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
+                    src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
 
-                phase.connect(src_name='design_parameters:{0}'.format(param_name),
-                              tgt_name='{0}.input_values:design_parameters:{1}'.format(name, param_name),
-                              src_indices=src_idxs, flat_src_indices=True)
+                    phase.connect(src_name='design_parameters:{0}'.format(param_name),
+                                  tgt_name='{0}.input_values:design_parameters:{1}'.format(name, param_name),
+                                  src_indices=src_idxs, flat_src_indices=True)
 
             for param_name, options in phase.input_parameter_options.items():
-                units = options['units']
-                timeseries_comp._add_timeseries_output('input_parameters:{0}'.format(param_name),
-                                                       var_class=phase.classify_var(param_name),
-                                                       shape=options['shape'],
-                                                       units=units)
+                if options['include_timeseries']:
+                    units = options['units']
+                    timeseries_comp._add_timeseries_output('input_parameters:{0}'.format(param_name),
+                                                           var_class=phase.classify_var(param_name),
+                                                           shape=options['shape'],
+                                                           units=units)
 
-                src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
+                    src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
+                    src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
 
-                phase.connect(src_name='input_parameters:{0}_out'.format(param_name),
-                              tgt_name='{0}.input_values:input_parameters:{1}'.format(name, param_name),
-                              src_indices=src_idxs, flat_src_indices=True)
+                    phase.connect(src_name='input_parameters:{0}_out'.format(param_name),
+                                  tgt_name='{0}.input_values:input_parameters:{1}'.format(name, param_name),
+                                  src_indices=src_idxs, flat_src_indices=True)
 
             for var, options in phase._timeseries[name]['outputs'].items():
                 output_name = options['output_name']

--- a/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
+++ b/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
@@ -409,32 +409,34 @@ class Radau(PseudospectralBase):
                                        '{1}_rate2'.format(name, control_name))
 
             for param_name, options in phase.design_parameter_options.items():
-                units = options['units']
-                timeseries_comp._add_timeseries_output('design_parameters:{0}'.format(param_name),
-                                                       var_class=phase.classify_var(param_name),
-                                                       shape=options['shape'],
-                                                       units=units)
+                if options['include_timeseries']:
+                    units = options['units']
+                    timeseries_comp._add_timeseries_output('design_parameters:{0}'.format(param_name),
+                                                           var_class=phase.classify_var(param_name),
+                                                           shape=options['shape'],
+                                                           units=units)
 
-                src_idxs_raw = np.zeros(gd.subset_num_nodes['all'], dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
+                    src_idxs_raw = np.zeros(gd.subset_num_nodes['all'], dtype=int)
+                    src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
 
-                phase.connect(src_name='design_parameters:{0}'.format(param_name),
-                              tgt_name='{0}.input_values:design_parameters:{1}'.format(name, param_name),
-                              src_indices=src_idxs, flat_src_indices=True)
+                    phase.connect(src_name='design_parameters:{0}'.format(param_name),
+                                  tgt_name='{0}.input_values:design_parameters:{1}'.format(name, param_name),
+                                  src_indices=src_idxs, flat_src_indices=True)
 
             for param_name, options in phase.input_parameter_options.items():
-                units = options['units']
-                timeseries_comp._add_timeseries_output('input_parameters:{0}'.format(param_name),
-                                                       var_class=phase.classify_var(param_name),
-                                                       shape=options['shape'],
-                                                       units=units)
+                if options['include_timeseries']:
+                    units = options['units']
+                    timeseries_comp._add_timeseries_output('input_parameters:{0}'.format(param_name),
+                                                           var_class=phase.classify_var(param_name),
+                                                           shape=options['shape'],
+                                                           units=units)
 
-                src_idxs_raw = np.zeros(gd.subset_num_nodes['all'], dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
+                    src_idxs_raw = np.zeros(gd.subset_num_nodes['all'], dtype=int)
+                    src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
 
-                phase.connect(src_name='input_parameters:{0}_out'.format(param_name),
-                              tgt_name='{0}.input_values:input_parameters:{1}'.format(name, param_name),
-                              src_indices=src_idxs, flat_src_indices=True)
+                    phase.connect(src_name='input_parameters:{0}_out'.format(param_name),
+                                  tgt_name='{0}.input_values:input_parameters:{1}'.format(name, param_name),
+                                  src_indices=src_idxs, flat_src_indices=True)
 
             for var, options in phase._timeseries[name]['outputs'].items():
                 output_name = options['output_name']

--- a/dymos/transcriptions/runge_kutta/runge_kutta.py
+++ b/dymos/transcriptions/runge_kutta/runge_kutta.py
@@ -801,31 +801,33 @@ class RungeKutta(TranscriptionBase):
                               src_indices=src_idxs, flat_src_indices=True)
 
             for param_name, options in phase.design_parameter_options.items():
-                units = options['units']
-                timeseries_comp._add_timeseries_output('design_parameters:{0}'.format(param_name),
-                                                       var_class=phase.classify_var(param_name),
-                                                       shape=options['shape'],
-                                                       units=units)
+                if options['include_timeseries']:
+                    units = options['units']
+                    timeseries_comp._add_timeseries_output('design_parameters:{0}'.format(param_name),
+                                                           var_class=phase.classify_var(param_name),
+                                                           shape=options['shape'],
+                                                           units=units)
 
-                src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['segment_ends'], dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
+                    src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['segment_ends'], dtype=int)
+                    src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
 
-                phase.connect(src_name='design_parameters:{0}'.format(param_name),
-                              tgt_name='{0}.input_values:design_parameters:{1}'.format(name, param_name),
-                              src_indices=src_idxs, flat_src_indices=True)
+                    phase.connect(src_name='design_parameters:{0}'.format(param_name),
+                                  tgt_name='{0}.input_values:design_parameters:{1}'.format(name, param_name),
+                                  src_indices=src_idxs, flat_src_indices=True)
 
             for param_name, options in phase.input_parameter_options.items():
-                units = options['units']
-                timeseries_comp._add_timeseries_output('input_parameters:{0}'.format(param_name),
-                                                       var_class=phase.classify_var(param_name),
-                                                       units=units)
+                if options['include_timeseries']:
+                    units = options['units']
+                    timeseries_comp._add_timeseries_output('input_parameters:{0}'.format(param_name),
+                                                           var_class=phase.classify_var(param_name),
+                                                           units=units)
 
-                src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['segment_ends'], dtype=int)
-                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
+                    src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['segment_ends'], dtype=int)
+                    src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
 
-                phase.connect(src_name='input_parameters:{0}_out'.format(param_name),
-                              tgt_name='{0}.input_values:input_parameters:{1}'.format(name, param_name),
-                              src_indices=src_idxs, flat_src_indices=True)
+                    phase.connect(src_name='input_parameters:{0}_out'.format(param_name),
+                                  tgt_name='{0}.input_values:input_parameters:{1}'.format(name, param_name),
+                                  src_indices=src_idxs, flat_src_indices=True)
 
             for var, options in phase._timeseries[name]['outputs'].items():
                 output_name = options['output_name']

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -406,15 +406,15 @@ class SolveIVP(TranscriptionBase):
                                                        shape=options['shape'],
                                                        units=units)
 
-            if output_nodes_per_seg is None:
-                src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
-            else:
-                src_idxs_raw = np.zeros(num_seg * output_nodes_per_seg, dtype=int)
-            src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
+                if output_nodes_per_seg is None:
+                    src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
+                else:
+                    src_idxs_raw = np.zeros(num_seg * output_nodes_per_seg, dtype=int)
+                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
 
-            phase.connect(src_name='design_parameters:{0}'.format(name),
-                          tgt_name='timeseries.all_values:design_parameters:{0}'.format(name),
-                          src_indices=src_idxs, flat_src_indices=True)
+                phase.connect(src_name='design_parameters:{0}'.format(name),
+                              tgt_name='timeseries.all_values:design_parameters:{0}'.format(name),
+                              src_indices=src_idxs, flat_src_indices=True)
 
         for name, options in phase.input_parameter_options.items():
             if options['include_timeseries']:
@@ -424,16 +424,16 @@ class SolveIVP(TranscriptionBase):
                                                        shape=options['shape'],
                                                        units=units)
 
-            if output_nodes_per_seg is None:
-                src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
-            else:
-                src_idxs_raw = np.zeros(num_seg * output_nodes_per_seg, dtype=int)
+                if output_nodes_per_seg is None:
+                    src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
+                else:
+                    src_idxs_raw = np.zeros(num_seg * output_nodes_per_seg, dtype=int)
 
-            src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
+                src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
 
-            phase.connect(src_name='input_parameters:{0}_out'.format(name),
-                          tgt_name='timeseries.all_values:input_parameters:{0}'.format(name),
-                          src_indices=src_idxs, flat_src_indices=True)
+                phase.connect(src_name='input_parameters:{0}_out'.format(name),
+                              tgt_name='timeseries.all_values:input_parameters:{0}'.format(name),
+                              src_indices=src_idxs, flat_src_indices=True)
 
         for var, options in phase._timeseries['timeseries']['outputs'].items():
             output_name = options['output_name']

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -399,11 +399,12 @@ class SolveIVP(TranscriptionBase):
                                    ':{0}_rate2'.format(name))
 
         for name, options in phase.design_parameter_options.items():
-            units = options['units']
-            timeseries_comp._add_timeseries_output('design_parameters:{0}'.format(name),
-                                                   var_class=phase.classify_var(name),
-                                                   shape=options['shape'],
-                                                   units=units)
+            if options['include_timeseries']:
+                units = options['units']
+                timeseries_comp._add_timeseries_output('design_parameters:{0}'.format(name),
+                                                       var_class=phase.classify_var(name),
+                                                       shape=options['shape'],
+                                                       units=units)
 
             if output_nodes_per_seg is None:
                 src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
@@ -416,11 +417,12 @@ class SolveIVP(TranscriptionBase):
                           src_indices=src_idxs, flat_src_indices=True)
 
         for name, options in phase.input_parameter_options.items():
-            units = options['units']
-            timeseries_comp._add_timeseries_output('input_parameters:{0}'.format(name),
-                                                   var_class=phase.classify_var(name),
-                                                   shape=options['shape'],
-                                                   units=units)
+            if options['include_timeseries']:
+                units = options['units']
+                timeseries_comp._add_timeseries_output('input_parameters:{0}'.format(name),
+                                                       var_class=phase.classify_var(name),
+                                                       shape=options['shape'],
+                                                       units=units)
 
             if output_nodes_per_seg is None:
                 src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)


### PR DESCRIPTION
### Summary

Add a new argument include_timeseries=True/False to add_input_parameter and  add_design_parameter, to allow static parameters to be omitted from the timeseries
output when they are large.

### Related Issues

- Resolves #300

### Status

- [ ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
