### PR TITLE
Fix for some test failures due to removal of Jrev from openmdao check_partials.

### DIFF
--- a/build_pyoptsparse_ipopt.sh
+++ b/build_pyoptsparse_ipopt.sh
@@ -42,7 +42,7 @@ NOTES:
 
     If PARDISO is selected as the linear solver, the Intel compiler suite
     with MKL must be available.
-    
+
     Examples:
       $0
       $0 -l pardiso
@@ -215,7 +215,7 @@ build_pyoptsparse() {
 	echo these variables before building it yourself:
 	echo
 	echo export IPOPT_INC=$PREFIX/include/coin-or
-        echo export IPOPT_LIB=$PREFIX/lib
+    echo export IPOPT_LIB=$PREFIX/lib
 	echo -----------------------------------------------------
     fi
 }
@@ -229,7 +229,9 @@ install_with_mumps() {
     pushd ThirdParty-Mumps
     ./get.Mumps
     ./configure --with-metis --with-metis-lflags="-L${PREFIX}/lib -lcoinmetis" \
-       --with-metis-cflags="-I${PREFIX}/include" --prefix=$PREFIX
+       --with-metis-cflags="-I${PREFIX}/include -I${PREFIX}/include/coin-or -I${PREFIX}/include/coin-or/metis" \
+       --prefix=$PREFIX CFLAGS="-I${PREFIX}/include -I${PREFIX}/include/coin-or -I${PREFIX}/include/coin-or/metis" \
+       FCFLAGS="-I${PREFIX}/include -I${PREFIX}/include/coin-or -I${PREFIX}/include/coin-or/metis"
     make
     make install
     popd

--- a/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 
 import dymos as dm
@@ -280,8 +280,8 @@ class TestExampleTwoBurnOrbitRaise(unittest.TestCase):
                                          show_output=False)
 
         if p.model.traj.phases.burn2 in p.model.traj.phases._subsystems_myproc:
-            assert_rel_error(self, p.get_val('traj.burn2.states:deltav')[-1], 0.3995,
-                             tolerance=2.0E-3)
+            assert_near_equal(p.get_val('traj.burn2.states:deltav')[-1], 0.3995,
+                              tolerance=2.0E-3)
 
 
 # This test is separate because connected phases aren't directly parallelizable.
@@ -297,8 +297,8 @@ class TestExampleTwoBurnOrbitRaiseConnected(unittest.TestCase):
                                          show_output=False, connected=True)
 
         if p.model.traj.phases.burn2 in p.model.traj.phases._subsystems_myproc:
-            assert_rel_error(self, p.get_val('traj.burn2.states:deltav')[0], 0.3995,
-                             tolerance=4.0E-3)
+            assert_near_equal(p.get_val('traj.burn2.states:deltav')[0], 0.3995,
+                              tolerance=4.0E-3)
 
 
 class TestExampleTwoBurnOrbitRaiseMPI(TestExampleTwoBurnOrbitRaise):

--- a/dymos/models/eom/test/test_flight_path_eom_2d.py
+++ b/dymos/models/eom/test/test_flight_path_eom_2d.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 
 import dymos as dm
 from dymos.models.eom import FlightPathEOM2D
@@ -76,14 +76,14 @@ class TestFlightPathEOM2D(unittest.TestCase):
 
         exp_out = phase.simulate()
 
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:h', units='km')[-1], 0.0,
-                         tolerance=0.001)
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:r')[-1], v0**2 / g,
-                         tolerance=0.001)
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:gam')[-1], -gam0,
-                         tolerance=0.001)
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:v')[-1], v0,
-                         tolerance=0.001)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:h', units='km')[-1], 0.0,
+                          tolerance=0.001)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:r')[-1], v0**2 / g,
+                          tolerance=0.001)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:gam')[-1], -gam0,
+                          tolerance=0.001)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:v')[-1], v0,
+                          tolerance=0.001)
 
     def test_cannonball_max_range(self):
         self.p.setup()
@@ -108,12 +108,12 @@ class TestFlightPathEOM2D(unittest.TestCase):
 
         exp_out = phase.simulate(times_per_seg=None)
 
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:r')[-1], v0**2 / g,
-                         tolerance=0.001)
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:gam')[-1], -np.radians(45),
-                         tolerance=0.001)
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:v')[-1], v0,
-                         tolerance=0.001)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:r')[-1], v0**2 / g,
+                          tolerance=0.001)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:gam')[-1], -np.radians(45),
+                          tolerance=0.001)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:v')[-1], v0,
+                          tolerance=0.001)
 
     def test_partials(self):
         self.p.setup(force_alloc_complex=True)
@@ -137,12 +137,7 @@ class TestFlightPathEOM2D(unittest.TestCase):
 
         cpd = self.p.check_partials(compact_print=True, method='cs')
 
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                assert_almost_equal(cpd[comp][var, wrt]['abs error'], 0.0, decimal=2,
-                                    err_msg='error in partial of'
-                                            ' {0} wrt {1} in {2}'.format(var, wrt, comp))
-
+        assert_check_partials(cpd)
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_comp.py
@@ -62,18 +62,14 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         cpd = p.check_partials(method='cs', out_stream=None)
 
         J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
-        J_rev = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
         J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
-        J_rev = cpd['continuity_comp']['states:y', 'states:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
 
         J_fd[0, 0] = -1.0
 
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
     def test_continuity_comp_connected_scalar_no_iteration_fwd(self):
@@ -132,18 +128,13 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         cpd = p.check_partials(method='cs')
 
         J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
-        J_rev = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_rev)
-        assert_rel_error(self, J_fwd, J_fd)
 
         J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
-        J_rev = cpd['continuity_comp']['states:y', 'states:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
 
         J_fd[0, 0] = -1.0
 
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
     def test_continuity_comp_scalar_nonlinearblockgs_fwd(self):
@@ -197,18 +188,14 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         cpd = p.check_partials(method='cs', out_stream=None)
 
         J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
-        J_rev = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
         J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
-        J_rev = cpd['continuity_comp']['states:y', 'states:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
 
         J_fd[0, 0] = -1.0
 
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
     def test_continuity_comp_connected_scalar_nonlinearblockgs_fwd(self):
@@ -267,18 +254,14 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         cpd = p.check_partials(method='cs', out_stream=None)
 
         J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
-        J_rev = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
         J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
-        J_rev = cpd['continuity_comp']['states:y', 'states:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
 
         J_fd[0, 0] = -1.0
 
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
     def test_continuity_comp_scalar_newton_fwd(self):
@@ -324,18 +307,14 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         cpd = p.check_partials(method='cs', out_stream=None)
 
         J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
-        J_rev = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
         J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
-        J_rev = cpd['continuity_comp']['states:y', 'states:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
 
         J_fd[0, 0] = -1.0
 
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
     def test_continuity_comp_vector_no_iteration_fwd(self):
@@ -386,19 +365,15 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         cpd = p.check_partials(method='cs')
 
         J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
-        J_rev = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
         J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
-        J_rev = cpd['continuity_comp']['states:y', 'states:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
 
         size = np.prod(state_options['y']['shape'])
         J_fd[:size, :size] = -np.eye(size)
 
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
     def test_continuity_comp_vector_nonlinearblockgs_fwd(self):
@@ -440,19 +415,15 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         cpd = p.check_partials(method='cs', out_stream=None)
 
         J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
-        J_rev = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
         J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
-        J_rev = cpd['continuity_comp']['states:y', 'states:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
 
         size = np.prod(state_options['y']['shape'])
         J_fd[:size, :size] = -np.eye(size)
 
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
     def test_continuity_comp_connected_vector_nonlinearblockgs_fwd(self):
@@ -499,19 +470,15 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         cpd = p.check_partials(method='cs', out_stream=None)
 
         J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
-        J_rev = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
         J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
-        J_rev = cpd['continuity_comp']['states:y', 'states:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
 
         size = np.prod(state_options['y']['shape'])
         J_fd[:size, :size] = -np.eye(size)
 
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
     def test_continuity_comp_vector_newton_fwd(self):
@@ -553,17 +520,13 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         cpd = p.check_partials(method='cs', out_stream=None)
 
         J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
-        J_rev = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
         J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
-        J_rev = cpd['continuity_comp']['states:y', 'states:y']['J_rev']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
 
         size = np.prod(state_options['y']['shape'])
         J_fd[:size, :size] = -np.eye(size)
 
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_iter_group.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_iter_group.py
@@ -94,18 +94,14 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
         cpd = p.check_partials(method='cs', out_stream=None)
 
         J_fwd = cpd['cnty_iter_group.continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
-        J_rev = cpd['cnty_iter_group.continuity_comp']['states:y', 'state_integrals:y']['J_rev']
         J_fd = cpd['cnty_iter_group.continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
         J_fwd = cpd['cnty_iter_group.continuity_comp']['states:y', 'states:y']['J_fwd']
-        J_rev = cpd['cnty_iter_group.continuity_comp']['states:y', 'states:y']['J_rev']
         J_fd = cpd['cnty_iter_group.continuity_comp']['states:y', 'states:y']['J_fd']
 
         J_fd[0, 0] = -1.0
 
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
     def test_continuity_comp_newtonsolver(self):
@@ -168,16 +164,12 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
         cpd = p.check_partials(method='cs', out_stream=None)
 
         J_fwd = cpd['cnty_iter_group.continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
-        J_rev = cpd['cnty_iter_group.continuity_comp']['states:y', 'state_integrals:y']['J_rev']
         J_fd = cpd['cnty_iter_group.continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)
 
         J_fwd = cpd['cnty_iter_group.continuity_comp']['states:y', 'states:y']['J_fwd']
-        J_rev = cpd['cnty_iter_group.continuity_comp']['states:y', 'states:y']['J_rev']
         J_fd = cpd['cnty_iter_group.continuity_comp']['states:y', 'states:y']['J_fd']
 
         J_fd[0, 0] = -1.0
 
-        assert_rel_error(self, J_fwd, J_rev)
         assert_rel_error(self, J_fwd, J_fd)


### PR DESCRIPTION
### Summary

Fix for some test failures due to removal of Jrev from openmdao check_partials.

### Related Issues

- Resolves #

### Status

- [x ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
