### PR TITLE
Travis uses pyoptsparse setup from gist instead of keeping it local

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,15 +98,17 @@ install:
     echo "Install pyoptsparse and along with IPOPT";
     git clone https://gist.github.com/robfalck/9fcefe17464bd1e6dccf0ccb21e59f46 ./pyoptsparse;
     cd pyoptsparse;
+    echo $PWD
+    ls
     chmod 755 ./build_pyoptsparse_ipopt.sh; ./build_pyoptsparse_ipopt.sh;
 
-    if [ "$SNOPT_LOCATION" ] && [ "${PY:0:1}" = "3" ]; then
-      echo "Install SNOPT";
-      cd pyoptsparse/pySNOPT;
-      scp -r "$SNOPT_LOCATION";
-      cd ../../;
-      pwd;
-    fi
+#    if [ "$SNOPT_LOCATION" ] && [ "${PY:0:1}" = "3" ]; then
+#      echo "Install SNOPT";
+#      cd pyoptsparse/pySNOPT;
+#      scp -r "$SNOPT_LOCATION";
+#      cd ../../;
+#      pwd;
+#    fi
 
     cd ..
     git clone https://github.com/OpenMDAO/MBI.git;

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,14 +102,6 @@ install:
     ls
     chmod 755 ./build_pyoptsparse_ipopt.sh; ./build_pyoptsparse_ipopt.sh;
 
-#    if [ "$SNOPT_LOCATION" ] && [ "${PY:0:1}" = "3" ]; then
-#      echo "Install SNOPT";
-#      cd pyoptsparse/pySNOPT;
-#      scp -r "$SNOPT_LOCATION";
-#      cd ../../;
-#      pwd;
-#    fi
-
     cd ..
     git clone https://github.com/OpenMDAO/MBI.git;
     cd MBI;

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,8 +96,8 @@ install:
     pip install --user travis-sphinx;
 
     echo "Install pyoptsparse and along with IPOPT";
-    git clone https://gist.github.com/robfalck/9fcefe17464bd1e6dccf0ccb21e59f46 ./pyoptsparse;
-    cd pyoptsparse;
+    git clone https://gist.github.com/robfalck/9fcefe17464bd1e6dccf0ccb21e59f46 ./pyoptsparse.git
+    cd pyoptsparse.git
     echo $PWD
     ls
     chmod 755 ./build_pyoptsparse_ipopt.sh; ./build_pyoptsparse_ipopt.sh;
@@ -122,6 +122,8 @@ install:
 - cd ..;
 
 # install dymos itself.
+- echo $PWD
+- ls -la
 - python -m pip install -e .;
 
 # display summary of installed packages and their versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,16 +96,19 @@ install:
     pip install --user travis-sphinx;
 
     echo "Install pyoptsparse and along with IPOPT";
+    git clone https://gist.github.com/robfalck/9fcefe17464bd1e6dccf0ccb21e59f46 ./pyoptsparse;
+    cd pyoptsparse;
     chmod 755 ./build_pyoptsparse_ipopt.sh; ./build_pyoptsparse_ipopt.sh;
 
     if [ "$SNOPT_LOCATION" ] && [ "${PY:0:1}" = "3" ]; then
       echo "Install SNOPT";
-      cd pyoptsparse/pyoptsparse/pySNOPT;
+      cd pyoptsparse/pySNOPT;
       scp -r "$SNOPT_LOCATION";
-      cd ../../../;
+      cd ../../;
       pwd;
     fi
 
+    cd ..
     git clone https://github.com/OpenMDAO/MBI.git;
     cd MBI;
     python setup.py build install;

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,13 +96,16 @@ install:
     pip install --user travis-sphinx;
 
     echo "Install pyoptsparse and along with IPOPT";
-    git clone https://gist.github.com/robfalck/9fcefe17464bd1e6dccf0ccb21e59f46 ./pyoptsparse.git
-    cd pyoptsparse.git
-    echo $PWD
-    ls
     chmod 755 ./build_pyoptsparse_ipopt.sh; ./build_pyoptsparse_ipopt.sh;
 
-    cd ..
+    if [ "$SNOPT_LOCATION" ] && [ "${PY:0:1}" = "3" ]; then
+      echo "Install SNOPT";
+      cd pyoptsparse/pyoptsparse/pySNOPT;
+      scp -r "$SNOPT_LOCATION";
+      cd ../../../;
+      pwd;
+    fi
+
     git clone https://github.com/OpenMDAO/MBI.git;
     cd MBI;
     python setup.py build install;
@@ -122,8 +125,6 @@ install:
 - cd ..;
 
 # install dymos itself.
-- echo $PWD
-- ls -la
 - python -m pip install -e .;
 
 # display summary of installed packages and their versions

--- a/build_pyoptsparse_ipopt.sh
+++ b/build_pyoptsparse_ipopt.sh
@@ -42,7 +42,7 @@ NOTES:
 
     If PARDISO is selected as the linear solver, the Intel compiler suite
     with MKL must be available.
-    
+
     Examples:
       $0
       $0 -l pardiso
@@ -215,7 +215,7 @@ build_pyoptsparse() {
 	echo these variables before building it yourself:
 	echo
 	echo export IPOPT_INC=$PREFIX/include/coin-or
-        echo export IPOPT_LIB=$PREFIX/lib
+    echo export IPOPT_LIB=$PREFIX/lib
 	echo -----------------------------------------------------
     fi
 }
@@ -229,7 +229,9 @@ install_with_mumps() {
     pushd ThirdParty-Mumps
     ./get.Mumps
     ./configure --with-metis --with-metis-lflags="-L${PREFIX}/lib -lcoinmetis" \
-       --with-metis-cflags="-I${PREFIX}/include" --prefix=$PREFIX
+       --with-metis-cflags="-I${PREFIX}/include -I${PREFIX}/include/coin-or -I${PREFIX}/include/coin-or/metis" \
+       --prefix=$PREFIX CFLAGS="-I${PREFIX}/include -I${PREFIX}/include/coin-or -I${PREFIX}/include/coin-or/metis" \
+       FCFLAGS="-I${PREFIX}/include -I${PREFIX}/include/coin-or -I${PREFIX}/include/coin-or/metis"
     make
     make install
     popd


### PR DESCRIPTION
### Summary

Changed travis setup to use the pyoptsparse setup script from a gist

### Related Issues

N/A

### Status

- [ ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
