### PR TITLE
fix simulate by overriding user specified time options

### DIFF
--- a/dymos/examples/double_integrator/double_integrator_ode.py
+++ b/dymos/examples/double_integrator/double_integrator_ode.py
@@ -11,7 +11,7 @@ class DoubleIntegratorODE(om.ExplicitComponent):
     Note we still have to declare the num_nodes option in initialize so that Dymos can instantiate
     the ODE.
 
-    Also note that neither time, states, nor paramters have targets, since there are no inputs
+    Also note that neither time, states, nor parameters have targets, since there are no inputs
     in the ODE system.
     """
 

--- a/dymos/examples/double_integrator/test/test_double_integrator.py
+++ b/dymos/examples/double_integrator/test/test_double_integrator.py
@@ -63,6 +63,20 @@ class TestDoubleIntegratorExample(unittest.TestCase):
             if os.path.exists(filename):
                 os.remove(filename)
 
+    def _assert_results(self, p, traj=True, tol=1.0E-4):
+        if traj:
+            x = p.get_val('traj.phase0.timeseries.states:x')
+            v = p.get_val('traj.phase0.timeseries.states:v')
+        else:
+            x = p.get_val('phase0.timeseries.states:x')
+            v = p.get_val('phase0.timeseries.states:v')
+
+        assert_rel_error(self, x[0], 0.0, tolerance=tol)
+        assert_rel_error(self, x[-1], 0.25, tolerance=tol)
+
+        assert_rel_error(self, v[0], 0.0, tolerance=tol)
+        assert_rel_error(self, v[-1], 0.0, tolerance=tol)
+
     def test_ex_double_integrator_gl_compressed(self):
         p = double_integrator_direct_collocation('gauss-lobatto',
                                                  compressed=True)
@@ -159,6 +173,10 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         p['phase0.controls:u'] = phase.interpolate(ys=[1, -1], nodes='control_input')
 
         p.run_driver()
+
+        self._assert_results(p, traj=False)
+        exp_out = phase.simulate()
+        self._assert_results(exp_out, traj=False, tol=1.0E-2)
 
     def test_ex_double_integrator_input_times_compressed(self):
         """

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -51,6 +51,9 @@ class SolveIVP(TranscriptionBase):
         grid_data = self.grid_data
         output_nodes_per_seg = self.options['output_nodes_per_seg']
 
+        time_options['input_initial'] = False  # True can break simulation
+        time_options['input_duration'] = False
+
         super(SolveIVP, self).setup_time(phase)
 
         if output_nodes_per_seg is None:


### PR DESCRIPTION
simulate() phase was failing with time options `input_initial=True` or `input_duration=True`

### Summary

Summary of PR.

### Related Issues

- Resolves #313

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
