### PR TITLE
hide the SNOPT file that prevents compilation

### DIFF
--- a/build_pyoptsparse_ipopt.sh
+++ b/build_pyoptsparse_ipopt.sh
@@ -200,6 +200,7 @@ build_pyoptsparse() {
 
     if [ $INCLUDE_SNOPT = 1 ]; then
         cp -a "${SNOPT_DIR}/." ./pyoptsparse/pyoptsparse/pySNOPT/source/.
+        mv pyoptsparse/pyoptsparse/pySNOPT/source/snopth.f pyoptsparse/pyoptsparse/pySNOPT/source/snopth.f.bak
     fi
 
     if [ $BUILD_PYOPTSPARSE = 1 ]; then


### PR DESCRIPTION
### Summary

Using the build_pyoptsparse_ipopt.sh script to install IPOPT and SNOPT was failing to compile
SNOPT due to an SNOPT file that should not be copied.

### Related Issues

- Resolves #

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
