### PR TITLE
update assert_rel_error to assert_near_equal

### DIFF
--- a/benchmark/benchmark_brachistochrone.py
+++ b/benchmark/benchmark_brachistochrone.py
@@ -2,7 +2,7 @@
 import unittest
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 import dymos as dm
 from dymos.examples.brachistochrone import BrachistochroneODE
@@ -93,18 +93,18 @@ class BenchmarkBrachistochrone(unittest.TestCase):
 
         thetaf = p.get_val('phase0.timeseries.controls:theta')[-1]
 
-        assert_rel_error(self, t_initial, 0.0)
-        assert_rel_error(self, x0, 0.0)
-        assert_rel_error(self, y0, 10.0)
-        assert_rel_error(self, v0, 0.0)
+        assert_near_equal(t_initial, 0.0)
+        assert_near_equal(x0, 0.0)
+        assert_near_equal(y0, 10.0)
+        assert_near_equal(v0, 0.0)
 
-        assert_rel_error(self, tf, 1.8016, tolerance=0.0001)
-        assert_rel_error(self, xf, 10.0, tolerance=0.001)
-        assert_rel_error(self, yf, 5.0, tolerance=0.001)
-        assert_rel_error(self, vf, 9.902, tolerance=0.001)
-        assert_rel_error(self, g, 9.80665, tolerance=0.001)
+        assert_near_equal(tf, 1.8016, tolerance=0.0001)
+        assert_near_equal(xf, 10.0, tolerance=0.001)
+        assert_near_equal(yf, 5.0, tolerance=0.001)
+        assert_near_equal(vf, 9.902, tolerance=0.001)
+        assert_near_equal(g, 9.80665, tolerance=0.001)
 
-        assert_rel_error(self, thetaf, 100.12, tolerance=1)
+        assert_near_equal(thetaf, 100.12, tolerance=1)
 
     def benchmark_radau_30_3_color_simul_compressed_snopt(self):
         p = brachistochrone_min_time(transcription='radau-ps',

--- a/dymos/examples/aircraft_steady_flight/aero/test/test_aero_coef_comp.py
+++ b/dymos/examples/aircraft_steady_flight/aero/test/test_aero_coef_comp.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy import array
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 from dymos.examples.aircraft_steady_flight.aero.aero_coef_comp import AeroCoefComp
 
@@ -178,5 +178,5 @@ class TestAeroCoefComp(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['aero.CL'], CL_test, tolerance=0.005)
-        assert_rel_error(self, prob['aero.CD'], CD_test, tolerance=0.005)
+        assert_near_equal(prob['aero.CL'], CL_test, tolerance=0.005)
+        assert_near_equal(prob['aero.CD'], CD_test, tolerance=0.005)

--- a/dymos/examples/aircraft_steady_flight/aero/test/test_mbi_aero_coef_comp.py
+++ b/dymos/examples/aircraft_steady_flight/aero/test/test_mbi_aero_coef_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 from dymos.examples.aircraft_steady_flight.aero.mbi_aero_coef_comp import setup_surrogates_all, \
     MBIAeroCoeffComp
@@ -204,15 +204,13 @@ class TestAeroCoefComp(unittest.TestCase):
                             0.021332763445,  0.020777569791,  0.020306416459,  0.019901757560,
                             0.019550206447,  0.019241644947,  0.018968388593,  0.018724538140])
 
-        assert_rel_error(self,
-                         prob['aero.CL'],
-                         CL_data,
-                         tolerance=0.003)
+        assert_near_equal(prob['aero.CL'],
+                          CL_data,
+                          tolerance=0.003)
 
-        assert_rel_error(self,
-                         prob['aero.CD'],
-                         CD_data,
-                         tolerance=0.003)
+        assert_near_equal(prob['aero.CD'],
+                          CD_data,
+                          tolerance=0.003)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/examples/aircraft_steady_flight/doc/test_doc_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/doc/test_doc_aircraft_steady_flight.py
@@ -18,7 +18,7 @@ class TestSteadyAircraftFlightForDocs(unittest.TestCase):
         import matplotlib.pyplot as plt
 
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
 
         import dymos as dm
 
@@ -106,8 +106,8 @@ class TestSteadyAircraftFlightForDocs(unittest.TestCase):
 
         dm.run_problem(p)
 
-        assert_rel_error(self, p.get_val('traj.phase0.timeseries.states:range', units='NM')[-1],
-                         726.85, tolerance=1.0E-2)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.states:range', units='NM')[-1],
+                          726.85, tolerance=1.0E-2)
 
         exp_out = traj.simulate()
 

--- a/dymos/examples/aircraft_steady_flight/flight_equlibrium/test/test_flight_equilibrium_group.py
+++ b/dymos/examples/aircraft_steady_flight/flight_equlibrium/test/test_flight_equilibrium_group.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 
 from dymos.examples.aircraft_steady_flight.flight_equlibrium.steady_flight_equilibrium_group \
     import SteadyFlightEquilibriumGroup
@@ -62,8 +62,8 @@ class TestFlightEquilibriumGroup(unittest.TestCase):
         CL = self.p['aero.CL']
         CM = self.p['aero.CM']
 
-        assert_rel_error(self,  CL_eq, CL, tolerance=1.0E-12)
-        assert_rel_error(self,  CM, np.zeros_like(CM), tolerance=1.0E-12)
+        assert_near_equal(CL_eq, CL, tolerance=1.0E-12)
+        assert_near_equal(CM, np.zeros_like(CM), tolerance=1.0E-12)
 
     def test_partials(self):
         cpd = self.p.check_partials(out_stream=None, method='fd', step=1.0E-6)

--- a/dymos/examples/aircraft_steady_flight/propulsion/test/test_propulsion_group.py
+++ b/dymos/examples/aircraft_steady_flight/propulsion/test/test_propulsion_group.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 
 from dymos.examples.aircraft_steady_flight.propulsion.propulsion_group import PropulsionGroup
 
@@ -36,9 +36,8 @@ class TestPropulsionComp(unittest.TestCase):
 
     def test_results(self):
 
-        assert_rel_error(self,
-                         self.p['propulsion.tsfc'],
-                         2 * 8.951e-6 * 9.80665 * np.ones(self.n))
+        assert_near_equal(self.p['propulsion.tsfc'],
+                          2 * 8.951e-6 * 9.80665 * np.ones(self.n))
 
     def test_partials(self):
         cpd = self.p.check_partials(method='cs', out_stream=None)

--- a/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
@@ -2,7 +2,7 @@ import os
 import unittest
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 import dymos as dm
 from dymos.examples.aircraft_steady_flight.aircraft_ode import AircraftODE
@@ -105,7 +105,7 @@ class TestAircraftCruise(unittest.TestCase):
         tas = p.get_val('phase0.timeseries.TAS', units='km/s')
         range = p.get_val('phase0.timeseries.states:range')
 
-        assert_rel_error(self, range, tas*time, tolerance=1.0E-4)
+        assert_near_equal(range, tas*time, tolerance=1.0E-4)
 
     def test_cruise_results_radau(self):
         p = om.Problem(model=om.Group())
@@ -199,7 +199,7 @@ class TestAircraftCruise(unittest.TestCase):
         tas = p.get_val('phase0.timeseries.TAS', units='km/s')
         range = p.get_val('phase0.timeseries.states:range')
 
-        assert_rel_error(self, range, tas*time, tolerance=1.0E-4)
+        assert_near_equal(range, tas*time, tolerance=1.0E-4)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/examples/aircraft_steady_flight/test/test_aircraft_ode.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_aircraft_ode.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 from dymos.examples.aircraft_steady_flight.aircraft_ode import AircraftODE
 
@@ -52,9 +52,8 @@ class TestAircraftODEGroup(unittest.TestCase):
         cls.p.run_model()
 
     def test_results(self):
-        assert_rel_error(self,
-                         self.p['ode.range_rate_comp.dXdt:range'],
-                         self.p['ode.tas_comp.TAS'] * np.cos(self.p['ode.gam_comp.gam']))
+        assert_near_equal(self.p['ode.range_rate_comp.dXdt:range'],
+                          self.p['ode.tas_comp.TAS'] * np.cos(self.p['ode.gam_comp.gam']))
 
 
 if __name__ == "__main__":

--- a/dymos/examples/aircraft_steady_flight/test/test_ex_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_ex_aircraft_steady_flight.py
@@ -3,7 +3,7 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.general_utils import set_pyoptsparse_opt
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 import dymos as dm
 from dymos.utils.lgl import lgl
@@ -120,14 +120,14 @@ class TestExSteadyAircraftFlight(unittest.TestCase):
 
     def test_ex_aircraft_steady_flight_opt(self):
         p = ex_aircraft_steady_flight(optimizer='SLSQP', solve_segments=False)
-        assert_rel_error(self, p.get_val('phase0.timeseries.states:range', units='NM')[-1],
-                         726.85, tolerance=1.0E-2)
+        assert_near_equal(p.get_val('phase0.timeseries.states:range', units='NM')[-1],
+                          726.85, tolerance=1.0E-2)
 
     def test_ex_aircraft_steady_flight_solve(self):
         p = ex_aircraft_steady_flight(optimizer='SLSQP', solve_segments=True,
                                       use_boundary_constraints=True)
-        assert_rel_error(self, p.get_val('phase0.timeseries.states:range', units='NM')[-1],
-                         726.85, tolerance=1.0E-2)
+        assert_near_equal(p.get_val('phase0.timeseries.states:range', units='NM')[-1],
+                          726.85, tolerance=1.0E-2)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/examples/battery_multibranch/doc/test_multibranch_trajectory_for_docs.py
+++ b/dymos/examples/battery_multibranch/doc/test_multibranch_trajectory_for_docs.py
@@ -13,7 +13,7 @@ class TestBatteryBranchingPhasesForDocs(unittest.TestCase):
         import matplotlib.pyplot as plt
 
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
 
         import dymos as dm
         from dymos.examples.battery_multibranch.battery_multibranch_ode import BatteryODE
@@ -100,13 +100,13 @@ class TestBatteryBranchingPhasesForDocs(unittest.TestCase):
 
         # Final value for State of Chrage in each segment should be a good test.
         print('State of Charge after 1 hour')
-        assert_rel_error(self, soc0[-1], 0.63464982, 1e-6)
+        assert_near_equal(soc0[-1], 0.63464982, 1e-6)
         print('State of Charge after 2 hours')
-        assert_rel_error(self, soc1[-1], 0.23794217, 1e-6)
+        assert_near_equal(soc1[-1], 0.23794217, 1e-6)
         print('State of Charge after 2 hours, battery fails at 1 hour')
-        assert_rel_error(self, soc1b[-1], 0.0281523, 1e-6)
+        assert_near_equal(soc1b[-1], 0.0281523, 1e-6)
         print('State of Charge after 2 hours, motor fails at 1 hour')
-        assert_rel_error(self, soc1m[-1], 0.18625395, 1e-6)
+        assert_near_equal(soc1m[-1], 0.18625395, 1e-6)
 
         # Plot Results
         t0 = prob['traj.phases.phase0.time.time']/3600

--- a/dymos/examples/battery_multibranch/test/test_multibranch_trajectory.py
+++ b/dymos/examples/battery_multibranch/test/test_multibranch_trajectory.py
@@ -5,7 +5,7 @@ import os
 import unittest
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 import dymos as dm
 from dymos.examples.battery_multibranch.battery_multibranch_ode import BatteryODE
@@ -109,10 +109,10 @@ class TestBatteryBranchingPhases(unittest.TestCase):
         soc1m = prob['traj.phase1_mfail.states:state_of_charge']
 
         # Final value for State of Chrage in each segment should be a good test.
-        assert_rel_error(self, soc0[-1], 0.63464982, 1e-6)
-        assert_rel_error(self, soc1[-1], 0.23794217, 1e-6)
-        assert_rel_error(self, soc1b[-1], 0.0281523, 1e-6)
-        assert_rel_error(self, soc1m[-1], 0.18625395, 1e-6)
+        assert_near_equal(soc0[-1], 0.63464982, 1e-6)
+        assert_near_equal(soc1[-1], 0.23794217, 1e-6)
+        assert_near_equal(soc1b[-1], 0.0281523, 1e-6)
+        assert_near_equal(soc1m[-1], 0.18625395, 1e-6)
 
     def test_solver_defects(self):
         prob = om.Problem()
@@ -195,10 +195,10 @@ class TestBatteryBranchingPhases(unittest.TestCase):
         soc1m = prob['traj.phase1_mfail.states:state_of_charge']
 
         # Final value for State of Charge in each segment should be a good test.
-        assert_rel_error(self, soc0[-1], 0.63464982, 1e-6)
-        assert_rel_error(self, soc1[-1], 0.23794217, 1e-6)
-        assert_rel_error(self, soc1b[-1], 0.0281523, 1e-6)
-        assert_rel_error(self, soc1m[-1], 0.18625395, 1e-6)
+        assert_near_equal(soc0[-1], 0.63464982, 1e-6)
+        assert_near_equal(soc1[-1], 0.23794217, 1e-6)
+        assert_near_equal(soc1b[-1], 0.0281523, 1e-6)
+        assert_near_equal(soc1m[-1], 0.18625395, 1e-6)
 
     def test_solver_defects_single_phase_reverse_propagation(self):
         prob = om.Problem()
@@ -227,7 +227,7 @@ class TestBatteryBranchingPhases(unittest.TestCase):
         prob.run_model()
 
         soc0 = prob['phase0.states:state_of_charge']
-        assert_rel_error(self, soc0[-1], 1.0, 1e-6)
+        assert_near_equal(soc0[-1], 1.0, 1e-6)
 
     def test_solver_defects_reverse_propagation(self):
         prob = om.Problem()
@@ -273,7 +273,7 @@ class TestBatteryBranchingPhases(unittest.TestCase):
         prob.run_model()
 
         soc1 = prob['traj.phase1.states:state_of_charge']
-        assert_rel_error(self, soc1[-1], 1.0, 1e-6)
+        assert_near_equal(soc1[-1], 1.0, 1e-6)
 
     def test_optimizer_segments_direct_connections(self):
         prob = om.Problem()
@@ -365,10 +365,10 @@ class TestBatteryBranchingPhases(unittest.TestCase):
         soc1m = prob['traj.phase1_mfail.states:state_of_charge']
 
         # Final value for State of Chrage in each segment should be a good test.
-        assert_rel_error(self, soc0[-1], 0.63464982, 1e-6)
-        assert_rel_error(self, soc1[-1], 0.23794217, 1e-6)
-        assert_rel_error(self, soc1b[-1], 0.0281523, 1e-6)
-        assert_rel_error(self, soc1m[-1], 0.18625395, 1e-6)
+        assert_near_equal(soc0[-1], 0.63464982, 1e-6)
+        assert_near_equal(soc1[-1], 0.23794217, 1e-6)
+        assert_near_equal(soc1b[-1], 0.0281523, 1e-6)
+        assert_near_equal(soc1m[-1], 0.18625395, 1e-6)
 
 
 class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
@@ -465,10 +465,10 @@ class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
         soc1m = prob['traj.phase1_mfail.states:state_of_charge']
 
         # Final value for State of Charge in each segment should be a good test.
-        assert_rel_error(self, soc0[-1], 0.63464982, 1e-4)
-        assert_rel_error(self, soc1[-1], 0.23794217, 1e-4)
-        assert_rel_error(self, soc1b[-1], 0.0281523, 1e-4)
-        assert_rel_error(self, soc1m[-1], 0.18625395, 1e-4)
+        assert_near_equal(soc0[-1], 0.63464982, 1e-4)
+        assert_near_equal(soc1[-1], 0.23794217, 1e-4)
+        assert_near_equal(soc1b[-1], 0.0281523, 1e-4)
+        assert_near_equal(soc1m[-1], 0.18625395, 1e-4)
 
     def test_single_phase_reverse_propagation_rk(self):
         prob = om.Problem()
@@ -495,7 +495,7 @@ class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
         prob.run_model()
 
         soc0 = prob['phase0.states:state_of_charge']
-        assert_rel_error(self, soc0[-1], 1.0, 1e-6)
+        assert_near_equal(soc0[-1], 1.0, 1e-6)
 
     def test_connected_linkages_rk(self):
         prob = om.Problem()
@@ -592,10 +592,10 @@ class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
         soc1m = prob['traj.phase1_mfail.states:state_of_charge']
 
         # Final value for State of Chrage in each segment should be a good test.
-        assert_rel_error(self, soc0[-1], 0.63464982, 5e-5)
-        assert_rel_error(self, soc1[-1], 0.23794217, 5e-5)
-        assert_rel_error(self, soc1b[-1], 0.0281523, 5e-5)
-        assert_rel_error(self, soc1m[-1], 0.18625395, 5e-5)
+        assert_near_equal(soc0[-1], 0.63464982, 5e-5)
+        assert_near_equal(soc1[-1], 0.23794217, 5e-5)
+        assert_near_equal(soc1b[-1], 0.0281523, 5e-5)
+        assert_near_equal(soc1m[-1], 0.18625395, 5e-5)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
@@ -16,7 +16,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
 
     def test_brachistochrone_for_docs_gauss_lobatto(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.plotting import plot_results
         from dymos.examples.brachistochrone import BrachistochroneODE
@@ -90,7 +90,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         dm.run_problem(p)
 
         # Test the results
-        assert_rel_error(self, p.get_val('traj.phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = traj.simulate()
@@ -106,7 +106,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
 
     def test_brachistochrone_for_docs_radau(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.plotting import plot_results
         from dymos.examples.brachistochrone import BrachistochroneODE
@@ -181,8 +181,8 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         dm.run_problem(p)
 
         # Test the results
-        assert_rel_error(self, p.get_val('traj.phase0.timeseries.time')[-1], 1.8016,
-                         tolerance=1.0E-3)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.time')[-1], 1.8016,
+                          tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = traj.simulate()
@@ -198,7 +198,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
 
     def test_brachistochrone_for_docs_runge_kutta(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.plotting import plot_results
         from dymos.examples.brachistochrone import BrachistochroneODE
@@ -280,8 +280,8 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         dm.run_problem(p)
 
         # Test the results
-        assert_rel_error(self, p.get_val('traj.phase0.timeseries.time')[-1], 1.8016,
-                         tolerance=1.0E-3)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.time')[-1], 1.8016,
+                          tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = traj.simulate()
@@ -297,7 +297,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
 
     def test_brachistochrone_for_docs_runge_kutta_polynomial_controls(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.plotting import plot_results
         from dymos.examples.brachistochrone import BrachistochroneODE
@@ -380,8 +380,8 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         dm.run_problem(p)
 
         # Test the results
-        assert_rel_error(self, p.get_val('traj.phase0.timeseries.time')[-1], 1.8016,
-                         tolerance=1.0E-3)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.time')[-1], 1.8016,
+                          tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = traj.simulate()

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_tandem_phases.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_tandem_phases.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import openmdao.api as om
 import dymos as dm
 
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 plt.switch_backend('Agg')
@@ -175,7 +175,7 @@ class TestDocTandemPhases(unittest.TestCase):
         dm.run_problem(p)
 
         expected = np.sqrt((10-0)**2 + (10 - 5)**2)
-        assert_rel_error(self, p['phase1.timeseries.states:S'][-1], expected, tolerance=1.0E-3)
+        assert_near_equal(p['phase1.timeseries.states:S'][-1], expected, tolerance=1.0E-3)
 
         fig, (ax0, ax1) = plt.subplots(2, 1)
         fig.tight_layout()

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_implicit_recorder.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_implicit_recorder.py
@@ -16,7 +16,7 @@ class TestBrachistochroneRecordingExample(unittest.TestCase):
         import matplotlib
         matplotlib.use('Agg')
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -81,7 +81,7 @@ class TestBrachistochroneRecordingExample(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         cr = om.CaseReader('brachistochrone_solution.db')
         system_cases = cr.list_cases('root')
@@ -90,8 +90,8 @@ class TestBrachistochroneRecordingExample(unittest.TestCase):
         outputs = dict([(o[0], o[1]) for o in case.list_outputs(units=True, shape=True,
                                                                 out_stream=None)])
 
-        assert_rel_error(self, p['phase0.controls:theta'],
-                         outputs['phase0.control_group.indep_controls.controls:theta']['value'])
+        assert_near_equal(p['phase0.controls:theta'],
+                          outputs['phase0.control_group.indep_controls.controls:theta']['value'])
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_control.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_control.py
@@ -90,7 +90,7 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
     def test_brachistochrone_integrated_control_gauss_lobatto(self):
         import numpy as np
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
 
         p = om.Problem(model=om.Group())
@@ -132,7 +132,7 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         sim_out = phase.simulate(times_per_seg=20)
 
@@ -156,16 +156,16 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         theta_interp = interp1d(time_sim[:, 0], theta_sim[:, 0])
         theta_dot_interp = interp1d(time_sim[:, 0], theta_dot_sim[:, 0])
 
-        assert_rel_error(self, x_interp(time_sol), x_sol, tolerance=1.0E-5)
-        assert_rel_error(self, y_interp(time_sol), y_sol, tolerance=1.0E-5)
-        assert_rel_error(self, v_interp(time_sol), v_sol, tolerance=1.0E-5)
-        assert_rel_error(self, theta_interp(time_sol), theta_sol, tolerance=1.0E-5)
-        assert_rel_error(self, theta_dot_interp(time_sol), theta_dot_sol, tolerance=1.0E-5)
+        assert_near_equal(x_interp(time_sol), x_sol, tolerance=1.0E-5)
+        assert_near_equal(y_interp(time_sol), y_sol, tolerance=1.0E-5)
+        assert_near_equal(v_interp(time_sol), v_sol, tolerance=1.0E-5)
+        assert_near_equal(theta_interp(time_sol), theta_sol, tolerance=1.0E-5)
+        assert_near_equal(theta_dot_interp(time_sol), theta_dot_sol, tolerance=1.0E-5)
 
     def test_brachistochrone_integrated_control_radau_ps(self):
         import numpy as np
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
 
         p = om.Problem(model=om.Group())
@@ -208,7 +208,7 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         sim_out = phase.simulate(times_per_seg=20)
 
@@ -232,8 +232,8 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         theta_interp = interp1d(time_sim[:, 0], theta_sim[:, 0])
         theta_dot_interp = interp1d(time_sim[:, 0], theta_dot_sim[:, 0])
 
-        assert_rel_error(self, x_interp(time_sol), x_sol, tolerance=1.0E-5)
-        assert_rel_error(self, y_interp(time_sol), y_sol, tolerance=1.0E-5)
-        assert_rel_error(self, v_interp(time_sol), v_sol, tolerance=1.0E-5)
-        assert_rel_error(self, theta_interp(time_sol), theta_sol, tolerance=1.0E-5)
-        assert_rel_error(self, theta_dot_interp(time_sol), theta_dot_sol, tolerance=1.0E-5)
+        assert_near_equal(x_interp(time_sol), x_sol, tolerance=1.0E-5)
+        assert_near_equal(y_interp(time_sol), y_sol, tolerance=1.0E-5)
+        assert_near_equal(v_interp(time_sol), v_sol, tolerance=1.0E-5)
+        assert_near_equal(theta_interp(time_sol), theta_sol, tolerance=1.0E-5)
+        assert_near_equal(theta_dot_interp(time_sol), theta_dot_sol, tolerance=1.0E-5)

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_rk4.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_rk4.py
@@ -5,7 +5,7 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
 
     def test_brachistochrone_forward_shooting(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -64,19 +64,19 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p['phase0.time'][-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p['phase0.time'][-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
 
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 10,
-                         tolerance=1.0E-3)
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 5,
-                         tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 10,
+                          tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 5,
+                          tolerance=1.0E-3)
 
     def test_brachistochrone_backward_shooting(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -136,19 +136,19 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p['phase0.time'][-1], -1.8016, tolerance=1.0E-3)
+        assert_near_equal(p['phase0.time'][-1], -1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
 
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 0,
-                         tolerance=1.0E-3)
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 10,
-                         tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 0,
+                          tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 10,
+                          tolerance=1.0E-3)
 
     def test_brachistochrone_forward_shooting_path_constrained_state(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -208,19 +208,19 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p['phase0.time'][-1], 1.805, tolerance=1.0E-2)
+        assert_near_equal(p['phase0.time'][-1], 1.805, tolerance=1.0E-2)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
 
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 10,
-                         tolerance=1.0E-3)
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 5,
-                         tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 10,
+                          tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 5,
+                          tolerance=1.0E-3)
 
     def test_brachistochrone_forward_shooting_path_constrained_control(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -280,19 +280,19 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p['phase0.time'][-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p['phase0.time'][-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
 
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 10,
-                         tolerance=1.0E-3)
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 5,
-                         tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 10,
+                          tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 5,
+                          tolerance=1.0E-3)
 
     def test_brachistochrone_forward_shooting_path_constrained_control_rate(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -352,19 +352,19 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p['phase0.time'][-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p['phase0.time'][-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
 
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 10,
-                         tolerance=1.0E-3)
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 5,
-                         tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 10,
+                          tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 5,
+                          tolerance=1.0E-3)
 
     def test_brachistochrone_forward_shooting_path_constrained_ode_output(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -424,19 +424,19 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p['phase0.time'][-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p['phase0.time'][-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
 
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 10,
-                         tolerance=1.0E-3)
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 5,
-                         tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 10,
+                          tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 5,
+                          tolerance=1.0E-3)
 
     def test_brachistochrone_forward_shooting_boundary_constrained_control_rate(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -496,21 +496,21 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p['phase0.time'][-1], 1.8016, tolerance=1.0E-3)
-        assert_rel_error(self, p.get_val('phase0.timeseries.control_rates:theta_rate2')[-1, 0], 0,
-                         tolerance=1.0E-6)
+        assert_near_equal(p['phase0.time'][-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.control_rates:theta_rate2')[-1, 0], 0,
+                          tolerance=1.0E-6)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
 
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 10,
-                         tolerance=1.0E-3)
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 5,
-                         tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 10,
+                          tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 5,
+                          tolerance=1.0E-3)
 
     def test_brachistochrone_forward_shooting_boundary_constrained_design_parameter(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -569,24 +569,23 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p['phase0.time'][-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p['phase0.time'][-1], 1.8016, tolerance=1.0E-3)
 
-        assert_rel_error(self,
-                         p.get_val('phase0.timeseries.polynomial_control_rates:theta_rate2')[-1, 0],
-                         0.0,
-                         tolerance=1.0E-9)
+        assert_near_equal(p.get_val('phase0.timeseries.polynomial_control_rates:theta_rate2')[-1, 0],
+                          0.0,
+                          tolerance=1.0E-9)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
 
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 10,
-                         tolerance=1.0E-3)
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 5,
-                         tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 10,
+                          tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 5,
+                          tolerance=1.0E-3)
 
     def test_brachistochrone_forward_shooting_boundary_constrained_ode_output(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -646,19 +645,19 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p['phase0.time'][-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p['phase0.time'][-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
 
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 10,
-                         tolerance=1.0E-3)
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 5,
-                         tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 10,
+                          tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 5,
+                          tolerance=1.0E-3)
 
     def test_brachistochrone_forward_shooting_path_constrained_time(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -719,12 +718,12 @@ class TestBrachistochroneRK4Example(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p['phase0.time'][-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p['phase0.time'][-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
 
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 10,
-                         tolerance=1.0E-3)
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 5,
-                         tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:x')[-1, 0], 10,
+                          tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:y')[-1, 0], 5,
+                          tolerance=1.0E-3)

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_undecorated_ode.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_undecorated_ode.py
@@ -82,7 +82,7 @@ class TestBrachistochroneUndecoratedODE(unittest.TestCase):
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
 
         p = om.Problem(model=om.Group())
@@ -121,7 +121,7 @@ class TestBrachistochroneUndecoratedODE(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
     def test_brachistochrone_undecorated_ode_radau(self):
         import numpy as np
@@ -129,7 +129,7 @@ class TestBrachistochroneUndecoratedODE(unittest.TestCase):
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
 
         p = om.Problem(model=om.Group())
@@ -168,7 +168,7 @@ class TestBrachistochroneUndecoratedODE(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
     def test_brachistochrone_undecorated_ode_rk(self):
         import numpy as np
@@ -176,7 +176,7 @@ class TestBrachistochroneUndecoratedODE(unittest.TestCase):
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
 
         p = om.Problem(model=om.Group())
@@ -218,14 +218,14 @@ class TestBrachistochroneUndecoratedODE(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
 
 class TestBrachistochroneBasePhaseClass(unittest.TestCase):
 
     def test_brachistochrone_base_phase_class_gl(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
 
         class BrachistochronePhase(dm.Phase):
@@ -273,9 +273,9 @@ class TestBrachistochroneBasePhaseClass(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         exp_out = phase.simulate()
 
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:x')[-1], 10, tolerance=1.0E-3)
-        assert_rel_error(self, exp_out.get_val('phase0.timeseries.states:y')[-1], 5, tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:x')[-1], 10, tolerance=1.0E-3)
+        assert_near_equal(exp_out.get_val('phase0.timeseries.states:y')[-1], 5, tolerance=1.0E-3)

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_vector_boundary_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_vector_boundary_constraints.py
@@ -5,7 +5,7 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_vector_states_ode \
@@ -70,7 +70,7 @@ class TestBrachistochroneVectorBoundaryConstraints(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self, p.get_val('phase0.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Plot results
         if SHOW_PLOTS:
@@ -168,7 +168,7 @@ class TestBrachistochroneVectorBoundaryConstraints(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self, p.get_val('phase0.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Plot results
         if SHOW_PLOTS:
@@ -266,7 +266,7 @@ class TestBrachistochroneVectorBoundaryConstraints(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self, p.get_val('phase0.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Plot results
         if SHOW_PLOTS:

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 plt.switch_backend('Agg')
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_vector_states_ode \
@@ -75,8 +75,8 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self, np.min(p.get_val('phase0.timeseries.states:pos')[:, 1]), 5.0,
-                         tolerance=1.0E-3)
+        assert_near_equal(np.min(p.get_val('phase0.timeseries.states:pos')[:, 1]), 5.0,
+                          tolerance=1.0E-3)
 
         # Plot results
         if SHOW_PLOTS:
@@ -200,10 +200,9 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self,
-                         np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
-                         -4,
-                         tolerance=1.0E-2)
+        assert_near_equal(np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
+                          -4,
+                          tolerance=1.0E-2)
 
         # Plot results
         if SHOW_PLOTS:
@@ -327,10 +326,9 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self,
-                         np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
-                         -4,
-                         tolerance=1.0E-2)
+        assert_near_equal(np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
+                          -4,
+                          tolerance=1.0E-2)
 
         # Plot results
         if SHOW_PLOTS:
@@ -453,10 +451,9 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self,
-                         np.min(p.get_val('phase0.timeseries.states:pos')[:, 1]),
-                         5,
-                         tolerance=1.0E-2)
+        assert_near_equal(np.min(p.get_val('phase0.timeseries.states:pos')[:, 1]),
+                          5,
+                          tolerance=1.0E-2)
 
         # Plot results
         if SHOW_PLOTS:
@@ -582,8 +579,8 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self, np.min(p.get_val('phase0.timeseries.pos_dot')[:, 1]), -4.0,
-                         tolerance=1.0E-3)
+        assert_near_equal(np.min(p.get_val('phase0.timeseries.pos_dot')[:, 1]), -4.0,
+                          tolerance=1.0E-3)
 
         # Plot results
         if SHOW_PLOTS:
@@ -707,10 +704,9 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self,
-                         np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
-                         -4,
-                         tolerance=1.0E-2)
+        assert_near_equal(np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
+                          -4,
+                          tolerance=1.0E-2)
 
         # Plot results
         if SHOW_PLOTS:
@@ -833,8 +829,8 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self, np.min(p.get_val('phase0.timeseries.states:pos')[:, 1]), 5.0,
-                         tolerance=1.0E-3)
+        assert_near_equal(np.min(p.get_val('phase0.timeseries.states:pos')[:, 1]), 5.0,
+                          tolerance=1.0E-3)
 
         # Plot results
         if SHOW_PLOTS:
@@ -960,10 +956,9 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self,
-                         np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
-                         -4,
-                         tolerance=1.0E-2)
+        assert_near_equal(np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
+                          -4,
+                          tolerance=1.0E-2)
 
         # Plot results
         if SHOW_PLOTS:
@@ -1089,10 +1084,9 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self,
-                         np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
-                         -4,
-                         tolerance=1.0E-2)
+        assert_near_equal(np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
+                          -4,
+                          tolerance=1.0E-2)
 
         # Plot results
         if SHOW_PLOTS:

--- a/dymos/examples/brachistochrone/test/test_doc_brachistochrone_polynomial_controls.py
+++ b/dymos/examples/brachistochrone/test/test_doc_brachistochrone_polynomial_controls.py
@@ -8,7 +8,7 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -61,7 +61,7 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
@@ -103,7 +103,7 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -156,7 +156,7 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
@@ -198,7 +198,7 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -254,7 +254,7 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
@@ -298,7 +298,7 @@ class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase)
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -354,7 +354,7 @@ class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase)
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
@@ -395,7 +395,7 @@ class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase)
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -451,7 +451,7 @@ class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase)
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
@@ -491,7 +491,7 @@ class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase)
         import matplotlib.pyplot as plt
         plt.switch_backend('Agg')
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -550,7 +550,7 @@ class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase)
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
@@ -593,7 +593,7 @@ class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
         import matplotlib.pyplot as plt
         plt.switch_backend('Agg')
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -648,7 +648,7 @@ class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
@@ -688,7 +688,7 @@ class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
         import matplotlib.pyplot as plt
         plt.switch_backend('Agg')
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -743,7 +743,7 @@ class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
@@ -783,7 +783,7 @@ class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
         import matplotlib.pyplot as plt
         plt.switch_backend('Agg')
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -841,7 +841,7 @@ class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
@@ -886,7 +886,7 @@ class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase)
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -941,7 +941,7 @@ class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase)
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
@@ -983,7 +983,7 @@ class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase)
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -1038,7 +1038,7 @@ class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase)
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
@@ -1080,7 +1080,7 @@ class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase)
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -1138,7 +1138,7 @@ class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase)
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
@@ -1183,7 +1183,7 @@ class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -1238,7 +1238,7 @@ class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
@@ -1280,7 +1280,7 @@ class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase
         matplotlib.use('Agg')
         import matplotlib.pyplot as plt
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -1335,7 +1335,7 @@ class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
@@ -1375,7 +1375,7 @@ class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase
         import matplotlib.pyplot as plt
         plt.switch_backend('Agg')
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -1433,7 +1433,7 @@ class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
@@ -1474,7 +1474,7 @@ class TestBrachistochronePolynomialControlSimulation(unittest.TestCase):
 
     def test_brachistochrone_polynomial_control_gauss_lobatto(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -1527,7 +1527,7 @@ class TestBrachistochronePolynomialControlSimulation(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
@@ -1535,12 +1535,12 @@ class TestBrachistochronePolynomialControlSimulation(unittest.TestCase):
         theta_imp = p.get_val('phase0.timeseries.polynomial_controls:theta')
         theta_exp = exp_out.get_val('phase0.timeseries.polynomial_controls:theta')
 
-        assert_rel_error(self, theta_exp[0], theta_imp[0])
-        assert_rel_error(self, theta_exp[-1], theta_imp[-1])
+        assert_near_equal(theta_exp[0], theta_imp[0])
+        assert_near_equal(theta_exp[-1], theta_imp[-1])
 
     def test_brachistochrone_polynomial_control_radau(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -1593,7 +1593,7 @@ class TestBrachistochronePolynomialControlSimulation(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
@@ -1601,12 +1601,12 @@ class TestBrachistochronePolynomialControlSimulation(unittest.TestCase):
         theta_imp = p.get_val('phase0.timeseries.polynomial_controls:theta')
         theta_exp = exp_out.get_val('phase0.timeseries.polynomial_controls:theta')
 
-        assert_rel_error(self, theta_exp[0], theta_imp[0])
-        assert_rel_error(self, theta_exp[-1], theta_imp[-1])
+        assert_near_equal(theta_exp[0], theta_imp[0])
+        assert_near_equal(theta_exp[-1], theta_imp[-1])
 
     def test_brachistochrone_polynomial_control_rungekutta(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -1662,7 +1662,7 @@ class TestBrachistochronePolynomialControlSimulation(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
         exp_out = phase.simulate()
@@ -1670,5 +1670,5 @@ class TestBrachistochronePolynomialControlSimulation(unittest.TestCase):
         theta_imp = p.get_val('phase0.timeseries.polynomial_controls:theta')
         theta_exp = exp_out.get_val('phase0.timeseries.polynomial_controls:theta')
 
-        assert_rel_error(self, theta_exp[0], theta_imp[0])
-        assert_rel_error(self, theta_exp[-1], theta_imp[-1])
+        assert_near_equal(theta_exp[0], theta_imp[0])
+        assert_near_equal(theta_exp[-1], theta_imp[-1])

--- a/dymos/examples/brachistochrone/test/test_path_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_path_constraints.py
@@ -5,7 +5,7 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
 
     def test_control_rate_path_constraint_gl(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -59,11 +59,11 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
     def test_control_rate2_path_constraint_gl(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -118,11 +118,11 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
     def test_control_rate_path_constraint_radau(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -177,11 +177,11 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
     def test_control_rate2_path_constraint_radau(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -237,4 +237,4 @@ class TestBrachistochronePathConstraints(unittest.TestCase):
         p.run_driver()
 
         # Test the results
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)

--- a/dymos/examples/brachistochrone/test/test_tandem_phases.py
+++ b/dymos/examples/brachistochrone/test/test_tandem_phases.py
@@ -8,7 +8,7 @@ import numpy as np
 import openmdao.api as om
 import dymos as dm
 
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class BrachistochroneArclengthODE(om.ExplicitComponent):
@@ -185,7 +185,7 @@ class TestTandemPhases(unittest.TestCase):
         p.run_driver()
 
         expected = np.sqrt((10-0)**2 + (10 - 5)**2)
-        assert_rel_error(self, p['phase1.timeseries.states:S'][-1], expected, tolerance=1.0E-3)
+        assert_near_equal(p['phase1.timeseries.states:S'][-1], expected, tolerance=1.0E-3)
 
     def test_tandem_phases_radau(self):
         self._run_transcription('radau-ps')

--- a/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
+++ b/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
@@ -8,7 +8,7 @@ class TestTwoPhaseCannonballForDocs(unittest.TestCase):
 
     def test_two_phase_cannonball_for_docs(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
 
         import dymos as dm
         from dymos.examples.cannonball.size_comp import CannonballSizeComp
@@ -139,8 +139,8 @@ class TestTwoPhaseCannonballForDocs(unittest.TestCase):
 
         dm.run_problem(p)
 
-        assert_rel_error(self, p.get_val('traj.descent.states:r')[-1],
-                         3183.25, tolerance=1.0E-2)
+        assert_near_equal(p.get_val('traj.descent.states:r')[-1],
+                          3183.25, tolerance=1.0E-2)
 
         exp_out = traj.simulate()
 

--- a/dymos/examples/double_integrator/doc/test_doc_double_integrator.py
+++ b/dymos/examples/double_integrator/doc/test_doc_double_integrator.py
@@ -18,7 +18,7 @@ class TestDoubleIntegratorForDocs(unittest.TestCase):
     def test_double_integrator_for_docs(self):
         import matplotlib.pyplot as plt
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.plotting import plot_results
         from dymos.examples.double_integrator.double_integrator_ode import DoubleIntegratorODE
@@ -77,11 +77,11 @@ class TestDoubleIntegratorForDocs(unittest.TestCase):
         x = p.get_val('traj.phase0.timeseries.states:x')
         v = p.get_val('traj.phase0.timeseries.states:v')
 
-        assert_rel_error(self, x[0], 0.0, tolerance=1.0E-4)
-        assert_rel_error(self, x[-1], 0.25, tolerance=1.0E-4)
+        assert_near_equal(x[0], 0.0, tolerance=1.0E-4)
+        assert_near_equal(x[-1], 0.25, tolerance=1.0E-4)
 
-        assert_rel_error(self, v[0], 0.0, tolerance=1.0E-4)
-        assert_rel_error(self, v[-1], 0.0, tolerance=1.0E-4)
+        assert_near_equal(v[0], 0.0, tolerance=1.0E-4)
+        assert_near_equal(v[-1], 0.0, tolerance=1.0E-4)
 
         #
         # Simulate the explicit solution and plot the results.

--- a/dymos/examples/double_integrator/test/test_double_integrator.py
+++ b/dymos/examples/double_integrator/test/test_double_integrator.py
@@ -5,7 +5,7 @@ import unittest
 from parameterized import parameterized
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 import dymos as dm
 from dymos.examples.double_integrator.double_integrator_ode import DoubleIntegratorODE
@@ -71,11 +71,11 @@ class TestDoubleIntegratorExample(unittest.TestCase):
             x = p.get_val('phase0.timeseries.states:x')
             v = p.get_val('phase0.timeseries.states:v')
 
-        assert_rel_error(self, x[0], 0.0, tolerance=tol)
-        assert_rel_error(self, x[-1], 0.25, tolerance=tol)
+        assert_near_equal(x[0], 0.0, tolerance=tol)
+        assert_near_equal(x[-1], 0.25, tolerance=tol)
 
-        assert_rel_error(self, v[0], 0.0, tolerance=tol)
-        assert_rel_error(self, v[-1], 0.0, tolerance=tol)
+        assert_near_equal(v[0], 0.0, tolerance=tol)
+        assert_near_equal(v[-1], 0.0, tolerance=tol)
 
     def test_ex_double_integrator_gl_compressed(self):
         p = double_integrator_direct_collocation('gauss-lobatto',
@@ -84,11 +84,11 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         x = p.get_val('traj.phase0.timeseries.states:x')
         v = p.get_val('traj.phase0.timeseries.states:v')
 
-        assert_rel_error(self, x[0], 0.0, tolerance=1.0E-4)
-        assert_rel_error(self, x[-1], 0.25, tolerance=1.0E-4)
+        assert_near_equal(x[0], 0.0, tolerance=1.0E-4)
+        assert_near_equal(x[-1], 0.25, tolerance=1.0E-4)
 
-        assert_rel_error(self, v[0], 0.0, tolerance=1.0E-4)
-        assert_rel_error(self, v[-1], 0.0, tolerance=1.0E-4)
+        assert_near_equal(v[0], 0.0, tolerance=1.0E-4)
+        assert_near_equal(v[-1], 0.0, tolerance=1.0E-4)
 
     def test_ex_double_integrator_gl_uncompressed(self):
         p = double_integrator_direct_collocation('gauss-lobatto',
@@ -97,11 +97,11 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         x = p.get_val('traj.phase0.timeseries.states:x')
         v = p.get_val('traj.phase0.timeseries.states:v')
 
-        assert_rel_error(self, x[0], 0.0, tolerance=1.0E-4)
-        assert_rel_error(self, x[-1], 0.25, tolerance=1.0E-4)
+        assert_near_equal(x[0], 0.0, tolerance=1.0E-4)
+        assert_near_equal(x[-1], 0.25, tolerance=1.0E-4)
 
-        assert_rel_error(self, v[0], 0.0, tolerance=1.0E-4)
-        assert_rel_error(self, v[-1], 0.0, tolerance=1.0E-4)
+        assert_near_equal(v[0], 0.0, tolerance=1.0E-4)
+        assert_near_equal(v[-1], 0.0, tolerance=1.0E-4)
 
     def test_ex_double_integrator_radau_compressed(self):
         p = double_integrator_direct_collocation('radau-ps',
@@ -110,11 +110,11 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         x = p.get_val('traj.phase0.timeseries.states:x')
         v = p.get_val('traj.phase0.timeseries.states:v')
 
-        assert_rel_error(self, x[0], 0.0, tolerance=1.0E-4)
-        assert_rel_error(self, x[-1], 0.25, tolerance=1.0E-4)
+        assert_near_equal(x[0], 0.0, tolerance=1.0E-4)
+        assert_near_equal(x[-1], 0.25, tolerance=1.0E-4)
 
-        assert_rel_error(self, v[0], 0.0, tolerance=1.0E-4)
-        assert_rel_error(self, v[-1], 0.0, tolerance=1.0E-4)
+        assert_near_equal(v[0], 0.0, tolerance=1.0E-4)
+        assert_near_equal(v[-1], 0.0, tolerance=1.0E-4)
 
     def test_ex_double_integrator_radau_uncompressed(self):
         p = double_integrator_direct_collocation('radau-ps',
@@ -123,11 +123,11 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         x = p.get_val('traj.phase0.timeseries.states:x')
         v = p.get_val('traj.phase0.timeseries.states:v')
 
-        assert_rel_error(self, x[0], 0.0, tolerance=1.0E-4)
-        assert_rel_error(self, x[-1], 0.25, tolerance=1.0E-4)
+        assert_near_equal(x[0], 0.0, tolerance=1.0E-4)
+        assert_near_equal(x[-1], 0.25, tolerance=1.0E-4)
 
-        assert_rel_error(self, v[0], 0.0, tolerance=1.0E-4)
-        assert_rel_error(self, v[-1], 0.0, tolerance=1.0E-4)
+        assert_near_equal(v[0], 0.0, tolerance=1.0E-4)
+        assert_near_equal(v[-1], 0.0, tolerance=1.0E-4)
 
     def test_ex_double_integrator_input_times_uncompressed(self):
         """

--- a/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
@@ -6,7 +6,7 @@ plt.switch_backend('Agg')
 plt.style.use('ggplot')
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 import dymos as dm
 from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
@@ -185,8 +185,8 @@ class TestFiniteBurnOrbitRaise(unittest.TestCase):
 
         dm.run_problem(p)
 
-        assert_rel_error(self, p.get_val('traj.burn2.states:deltav')[-1], 0.3995,
-                         tolerance=2.0E-3)
+        assert_near_equal(p.get_val('traj.burn2.states:deltav')[-1], 0.3995,
+                          tolerance=2.0E-3)
 
         #
         # Plot results

--- a/dymos/examples/finite_burn_orbit_raise/test/test_finite_burn_eom.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_finite_burn_eom.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 
-from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 
 from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
 
@@ -71,9 +71,9 @@ class TestFiniteBurnEOM(unittest.TestCase):
 
     def test_outputs(self):
         p = self.p
-        assert_rel_error(self, p['r_dot'], p['vr'])
-        assert_rel_error(self, p['theta_dot'], p['vt'] / p['r'])
-        assert_rel_error(self, p['at_dot'], p['accel']**2 / p['c'])
+        assert_near_equal(p['r_dot'], p['vr'])
+        assert_near_equal(p['theta_dot'], p['vt'] / p['r'])
+        assert_near_equal(p['at_dot'], p['accel']**2 / p['c'])
 
     def test_partials(self):
         cpd = self.p.check_partials(compact_print=False)

--- a/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
@@ -15,7 +15,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
         import matplotlib.pyplot as plt
 
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         from openmdao.utils.general_utils import set_pyoptsparse_opt
 
         import dymos as dm
@@ -183,10 +183,9 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self,
-                         p.get_val('traj.burn2.timeseries.states:deltav')[-1],
-                         0.3995,
-                         tolerance=2.0E-3)
+        assert_near_equal(p.get_val('traj.burn2.timeseries.states:deltav')[-1],
+                          0.3995,
+                          tolerance=2.0E-3)
 
         # Plot results
         exp_out = traj.simulate()

--- a/dymos/examples/hyper_sensitive/doc/test_doc_hyper_sensitive.py
+++ b/dymos/examples/hyper_sensitive/doc/test_doc_hyper_sensitive.py
@@ -35,7 +35,7 @@ class TestHyperSensitive(unittest.TestCase):
 
     def test_hyper_sensitive_for_docs(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.plotting import plot_results
         from dymos.examples.hyper_sensitive.hyper_sensitive_ode import HyperSensitiveODE
@@ -81,20 +81,17 @@ class TestHyperSensitive(unittest.TestCase):
         #
         ui, uf, J = solution()
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.controls:u')[0],
-                         ui,
-                         tolerance=1.5e-2)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.controls:u')[0],
+                          ui,
+                          tolerance=1.5e-2)
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.controls:u')[-1],
-                         uf,
-                         tolerance=1.5e-2)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.controls:u')[-1],
+                          uf,
+                          tolerance=1.5e-2)
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.states:xL')[-1],
-                         J,
-                         tolerance=1e-2)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.states:xL')[-1],
+                          J,
+                          tolerance=1e-2)
 
         #
         # Simulate the explicit solution and plot the results.

--- a/dymos/examples/hyper_sensitive/test/test_hyper_sensitive.py
+++ b/dymos/examples/hyper_sensitive/test/test_hyper_sensitive.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division, absolute_import
 import os
 import unittest
 from openmdao.api import Problem, Group, pyOptSparseDriver
-from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import set_pyoptsparse_opt, printoptions
 from dymos import Trajectory, GaussLobatto, Phase, Radau
 from dymos.examples.hyper_sensitive.hyper_sensitive_ode import HyperSensitiveODE
@@ -90,20 +90,17 @@ class TestHyperSensitive(unittest.TestCase):
         dm.run_problem(p, refine=True)
         ui, uf, J = self.solution()
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.controls:u')[0],
-                         ui,
-                         tolerance=1e-6)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.controls:u')[0],
+                          ui,
+                          tolerance=1e-6)
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.controls:u')[-1],
-                         uf,
-                         tolerance=1e-6)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.controls:u')[-1],
+                          uf,
+                          tolerance=1e-6)
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.states:xL')[-1],
-                         J,
-                         tolerance=1e-6)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.states:xL')[-1],
+                          J,
+                          tolerance=1e-6)
 
     def test_hyper_sensitive_gauss_lobatto(self):
         p = self.make_problem(transcription=GaussLobatto, optimizer='IPOPT')
@@ -112,17 +109,14 @@ class TestHyperSensitive(unittest.TestCase):
 
         ui, uf, J = self.solution()
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.controls:u')[0],
-                         ui,
-                         tolerance=1e-4)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.controls:u')[0],
+                          ui,
+                          tolerance=1e-4)
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.controls:u')[-1],
-                         uf,
-                         tolerance=1e-4)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.controls:u')[-1],
+                          uf,
+                          tolerance=1e-4)
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.states:xL')[-1],
-                         J,
-                         tolerance=1e-4)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.states:xL')[-1],
+                          J,
+                          tolerance=1e-4)

--- a/dymos/examples/min_time_climb/aero/test/test_kappa_comp.py
+++ b/dymos/examples/min_time_climb/aero/test/test_kappa_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_check_partials, assert_rel_error
+from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 
 from dymos.examples.min_time_climb.aero.kappa_comp import KappaComp
 
@@ -40,8 +40,8 @@ class TestKappaComp(unittest.TestCase):
         kappa_analtic_0 = 0.54 + 0.15 * (1.0 + np.tanh((M[idxs_0] - 0.9)/0.06))
         kappa_analtic_1 = 0.54 + 0.15 * (1.0 + np.tanh(0.25/0.06)) + 0.14 * (M[idxs_1] - 1.15)
 
-        assert_rel_error(self, kappa[idxs_0], kappa_analtic_0)
-        assert_rel_error(self, kappa[idxs_1], kappa_analtic_1)
+        assert_near_equal(kappa[idxs_0], kappa_analtic_0)
+        assert_near_equal(kappa[idxs_1], kappa_analtic_1)
 
     def test_partials(self):
 

--- a/dymos/examples/min_time_climb/doc/test_doc_min_time_climb.py
+++ b/dymos/examples/min_time_climb/doc/test_doc_min_time_climb.py
@@ -12,7 +12,7 @@ class TestMinTimeClimbForDocs(unittest.TestCase):
         import matplotlib.pyplot as plt
 
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
 
         import dymos as dm
         from dymos.examples.min_time_climb.min_time_climb_ode import MinTimeClimbODE
@@ -111,7 +111,7 @@ class TestMinTimeClimbForDocs(unittest.TestCase):
         #
         # Test the results
         #
-        assert_rel_error(self, p.get_val('traj.phase0.t_duration'), 321.0, tolerance=1.0E-1)
+        assert_near_equal(p.get_val('traj.phase0.t_duration'), 321.0, tolerance=1.0E-1)
 
         #
         # Get the explicitly simulated solution and plot the results

--- a/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
+++ b/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
@@ -1,7 +1,7 @@
 import unittest
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 import dymos as dm
 from dymos.examples.min_time_climb.min_time_climb_ode import MinTimeClimbODE
 from openmdao.utils.testing_utils import use_tempdirs
@@ -109,10 +109,10 @@ class TestMinTimeClimb(unittest.TestCase):
                            transcription='gauss-lobatto')
 
         # Check that time matches to within 1% of an externally verified solution.
-        assert_rel_error(self, p.get_val('traj.phase0.timeseries.time')[-1], 321.0, tolerance=0.02)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.time')[-1], 321.0, tolerance=0.02)
 
         # Verify that ODE output mach is added to the timeseries
-        assert_rel_error(self, p.get_val('traj.phase0.timeseries.mach')[-1], 1.0, tolerance=1.0E-2)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.mach')[-1], 1.0, tolerance=1.0E-2)
 
     @use_tempdirs
     def test_results_radau(self):
@@ -120,10 +120,10 @@ class TestMinTimeClimb(unittest.TestCase):
                            transcription='radau-ps')
 
         # Check that time matches to within 1% of an externally verified solution.
-        assert_rel_error(self, p.get_val('traj.phase0.timeseries.time')[-1], 321.0, tolerance=0.02)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.time')[-1], 321.0, tolerance=0.02)
 
         # Verify that ODE output mach is added to the timeseries
-        assert_rel_error(self, p.get_val('traj.phase0.timeseries.mach')[-1], 1.0, tolerance=1.0E-2)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.mach')[-1], 1.0, tolerance=1.0E-2)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/examples/shuttle_reentry/doc/test_doc_reentry.py
+++ b/dymos/examples/shuttle_reentry/doc/test_doc_reentry.py
@@ -16,7 +16,7 @@ class TestReentryForDocs(unittest.TestCase):
 
     def test_reentry(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.shuttle_reentry.shuttle_ode import ShuttleODE
         from dymos.examples.plotting import plot_results
@@ -85,12 +85,12 @@ class TestReentryForDocs(unittest.TestCase):
         dm.run_problem(p)
 
         # Check the validity of the solution
-        assert_rel_error(self, p.get_val('traj.phase0.timeseries.time')[-1], 2008.59,
-                         tolerance=1e-3)
-        assert_rel_error(self, p.get_val('traj.phase0.timeseries.states:theta', units='deg')[-1],
-                         34.1412, tolerance=1e-3)
-        # assert_rel_error(self, p.get_val('traj.phase0.timeseries.time')[-1], 2181.90371131, tolerance=1e-3)
-        # assert_rel_error(self, p.get_val('traj.phase0.timeseries.states:theta')[-1], .53440626, tolerance=1e-3)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.time')[-1], 2008.59,
+                          tolerance=1e-3)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.states:theta', units='deg')[-1],
+                          34.1412, tolerance=1e-3)
+        # assert_near_equal(p.get_val('traj.phase0.timeseries.time')[-1], 2181.90371131, tolerance=1e-3)
+        # assert_near_equal(p.get_val('traj.phase0.timeseries.states:theta')[-1], .53440626, tolerance=1e-3)
 
         # Run the simulation to check if the model is physically valid
         sim_out = traj.simulate()

--- a/dymos/examples/shuttle_reentry/test/test_reentry.py
+++ b/dymos/examples/shuttle_reentry/test/test_reentry.py
@@ -1,6 +1,6 @@
 import unittest
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 from dymos import Trajectory, GaussLobatto, Phase, Radau
 from dymos.examples.shuttle_reentry.shuttle_ode import ShuttleODE
@@ -87,56 +87,48 @@ class TestReentry(unittest.TestCase):
     def test_reentry_constrained_radau(self):
         p = self.make_problem(constrained=True, transcription=Radau, optimizer='SNOPT')
         p.run_driver()
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.time')[-1],
-                         expected_results['constrained']['time'],
-                         tolerance=1e-2)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.time')[-1],
+                          expected_results['constrained']['time'],
+                          tolerance=1e-2)
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.states:theta', units='deg')[-1],
-                         expected_results['constrained']['theta'],
-                         tolerance=1e-2)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.states:theta', units='deg')[-1],
+                          expected_results['constrained']['theta'],
+                          tolerance=1e-2)
 
     def test_reentry_constrained_gauss_lobatto(self):
         p = self.make_problem(constrained=True, transcription=GaussLobatto, optimizer='SNOPT')
         p.run_driver()
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.time')[-1],
-                         expected_results['constrained']['time'],
-                         tolerance=1e-2)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.time')[-1],
+                          expected_results['constrained']['time'],
+                          tolerance=1e-2)
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.states:theta', units='deg')[-1],
-                         expected_results['constrained']['theta'],
-                         tolerance=1e-2)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.states:theta', units='deg')[-1],
+                          expected_results['constrained']['theta'],
+                          tolerance=1e-2)
 
     def test_reentry_unconstrained_radau(self):
         p = self.make_problem(constrained=False, transcription=Radau, optimizer='SNOPT')
         p.run_driver()
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.time')[-1],
-                         expected_results['unconstrained']['time'],
-                         tolerance=1e-2)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.time')[-1],
+                          expected_results['unconstrained']['time'],
+                          tolerance=1e-2)
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.states:theta', units='deg')[-1],
-                         expected_results['unconstrained']['theta'],
-                         tolerance=1e-2)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.states:theta', units='deg')[-1],
+                          expected_results['unconstrained']['theta'],
+                          tolerance=1e-2)
 
     @unittest.skipIf(True, 'Gauss-Lobatto interpolation results in negative velocity error '
                            'in heating component.')
     def test_reentry_unconstrained_gauss_lobatto(self):
         p = self.make_problem(constrained=False, transcription=GaussLobatto, optimizer='SLSQP')
         p.run_driver()
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.time')[-1],
-                         expected_results['unconstrained']['time'],
-                         tolerance=1e-2)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.time')[-1],
+                          expected_results['unconstrained']['time'],
+                          tolerance=1e-2)
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.states:theta', units='deg')[-1],
-                         expected_results['unconstrained']['theta'],
-                         tolerance=1e-2)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.states:theta', units='deg')[-1],
+                          expected_results['unconstrained']['theta'],
+                          tolerance=1e-2)
 
 
 if __name__ == '___main__':

--- a/dymos/examples/ssto/doc/test_doc_ssto_earth.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_earth.py
@@ -10,7 +10,7 @@ class TestDocSSTOEarth(unittest.TestCase):
     def test_doc_ssto_earth(self):
         import matplotlib.pyplot as plt
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
 
         #
@@ -86,10 +86,10 @@ class TestDocSSTOEarth(unittest.TestCase):
         #
         # Check the results.
         #
-        assert_rel_error(self, p.get_val('traj.phase0.timeseries.time')[-1], 143, tolerance=0.05)
-        assert_rel_error(self, p.get_val('traj.phase0.timeseries.states:y')[-1], 1.85E5, 1e-4)
-        assert_rel_error(self, p.get_val('traj.phase0.timeseries.states:vx')[-1], 7796.6961, 1e-4)
-        assert_rel_error(self, p.get_val('traj.phase0.timeseries.states:vy')[-1], 0, 1e-4)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.time')[-1], 143, tolerance=0.05)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.states:y')[-1], 1.85E5, 1e-4)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.states:vx')[-1], 7796.6961, 1e-4)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.states:vy')[-1], 0, 1e-4)
         #
         # Get the explitly simulated results
         #

--- a/dymos/examples/ssto/doc/test_doc_ssto_linear_tangent_guidance.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_linear_tangent_guidance.py
@@ -12,7 +12,7 @@ class TestDocSSTOLinearTangentGuidance(unittest.TestCase):
         import numpy as np
         import matplotlib.pyplot as plt
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.plotting import plot_results
 
@@ -280,7 +280,7 @@ class TestDocSSTOLinearTangentGuidance(unittest.TestCase):
         #
         # Check the results.
         #
-        assert_rel_error(self, p.get_val('traj.phase0.timeseries.time')[-1], 481, tolerance=0.01)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.time')[-1], 481, tolerance=0.01)
 
         #
         # Get the explitly simulated results

--- a/dymos/examples/ssto/doc/test_doc_ssto_polynomial_control.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_polynomial_control.py
@@ -12,7 +12,7 @@ class TestDocSSTOPolynomialControl(unittest.TestCase):
         import numpy as np
         import matplotlib.pyplot as plt
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
 
         g = 1.61544  # lunar gravity, m/s**2
@@ -256,7 +256,7 @@ class TestDocSSTOPolynomialControl(unittest.TestCase):
         #
         # Check the results.
         #
-        assert_rel_error(self, p.get_val('traj.phase0.timeseries.time')[-1], 481, tolerance=0.01)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.time')[-1], 481, tolerance=0.01)
 
         #
         # Get the explitly simulated results

--- a/dymos/examples/ssto/test/test_simulate_root_trajectory.py
+++ b/dymos/examples/ssto/test/test_simulate_root_trajectory.py
@@ -17,7 +17,7 @@ class TestSSTOSimulateRootTrajectory(unittest.TestCase):
         import numpy as np
         import matplotlib.pyplot as plt
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
 
         g = 1.61544  # lunar gravity, m/s**2
@@ -261,7 +261,7 @@ class TestSSTOSimulateRootTrajectory(unittest.TestCase):
         #
         # Check the results.
         #
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 481, tolerance=0.01)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 481, tolerance=0.01)
 
         #
         # Get the explitly simulated results

--- a/dymos/models/atmosphere/test/test_atmos.py
+++ b/dymos/models/atmosphere/test/test_atmos.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 from dymos.models.atmosphere.atmos_1976 import USatm1976Comp
 
@@ -47,14 +47,14 @@ class TestAtmosphere(unittest.TestCase):
         p.setup()
         p.run_model()
 
-        assert_rel_error(self, p.get_val('atmos.temp', units='K'),
-                         reference[:, 1], tolerance=1.0E-2)
-        assert_rel_error(self, p.get_val('atmos.pres', units='Pa'),
-                         reference[:, 2], tolerance=1.0E-2)
-        assert_rel_error(self, p.get_val('atmos.rho', units='kg/m**3'),
-                         reference[:, 3], tolerance=1.0E-2)
-        assert_rel_error(self, p.get_val('atmos.sos', units='m/s'),
-                         reference[:, 4], tolerance=1.0E-2)
+        assert_near_equal(p.get_val('atmos.temp', units='K'),
+                          reference[:, 1], tolerance=1.0E-2)
+        assert_near_equal(p.get_val('atmos.pres', units='Pa'),
+                          reference[:, 2], tolerance=1.0E-2)
+        assert_near_equal(p.get_val('atmos.rho', units='kg/m**3'),
+                          reference[:, 3], tolerance=1.0E-2)
+        assert_near_equal(p.get_val('atmos.sos', units='m/s'),
+                          reference[:, 4], tolerance=1.0E-2)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/phase/test/test_phase.py
+++ b/dymos/phase/test/test_phase.py
@@ -6,7 +6,7 @@ import openmdao.api as om
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 import matplotlib.pyplot as plt
 plt.switch_backend('Agg')
@@ -335,7 +335,7 @@ class TestPhaseBase(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self, p['phase0.t_duration'], 10, tolerance=1.0E-3)
+        assert_near_equal(p['phase0.t_duration'], 10, tolerance=1.0E-3)
 
     def test_objective_design_parameter_radau(self):
         p = om.Problem(model=om.Group())
@@ -389,7 +389,7 @@ class TestPhaseBase(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self, p['phase0.t_duration'], 10, tolerance=1.0E-3)
+        assert_near_equal(p['phase0.t_duration'], 10, tolerance=1.0E-3)
 
     def test_control_boundary_constraint_gl(self):
         p = om.Problem(model=om.Group())
@@ -445,7 +445,7 @@ class TestPhaseBase(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self, p.get_val('phase0.timeseries.controls:theta', units='deg')[-1], 90.0)
+        assert_near_equal(p.get_val('phase0.timeseries.controls:theta', units='deg')[-1], 90.0)
 
     def test_control_rate_boundary_constraint_gl(self):
         p = om.Problem(model=om.Group())
@@ -520,8 +520,8 @@ class TestPhaseBase(unittest.TestCase):
                  p.get_val('phase0.timeseries.control_rates:theta_rate2'), 'go')
         plt.show()
 
-        assert_rel_error(self, p.get_val('phase0.timeseries.control_rates:theta_rate')[-1], 0,
-                         tolerance=1.0E-6)
+        assert_near_equal(p.get_val('phase0.timeseries.control_rates:theta_rate')[-1], 0,
+                          tolerance=1.0E-6)
 
     def test_control_rate2_boundary_constraint_gl(self):
         p = om.Problem(model=om.Group())
@@ -593,8 +593,8 @@ class TestPhaseBase(unittest.TestCase):
                  p.get_val('phase0.timeseries.control_rates:theta_rate2'), 'go')
         plt.show()
 
-        assert_rel_error(self, p.get_val('phase0.timeseries.control_rates:theta_rate2')[-1], 0,
-                         tolerance=1.0E-6)
+        assert_near_equal(p.get_val('phase0.timeseries.control_rates:theta_rate2')[-1], 0,
+                          tolerance=1.0E-6)
 
     def test_design_parameter_boundary_constraint(self):
         p = om.Problem(model=om.Group())
@@ -656,12 +656,12 @@ class TestPhaseBase(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self, p.get_val('phase0.timeseries.time')[-1], 1.8016,
-                         tolerance=1.0E-4)
-        assert_rel_error(self, p.get_val('phase0.timeseries.design_parameters:g')[0], 9.80665,
-                         tolerance=1.0E-6)
-        assert_rel_error(self, p.get_val('phase0.timeseries.design_parameters:g')[-1], 9.80665,
-                         tolerance=1.0E-6)
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016,
+                          tolerance=1.0E-4)
+        assert_near_equal(p.get_val('phase0.timeseries.design_parameters:g')[0], 9.80665,
+                          tolerance=1.0E-6)
+        assert_near_equal(p.get_val('phase0.timeseries.design_parameters:g')[-1], 9.80665,
+                          tolerance=1.0E-6)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/phase/test/test_set_time_options.py
+++ b/dymos/phase/test/test_set_time_options.py
@@ -3,7 +3,7 @@ import unittest
 import warnings
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
@@ -119,8 +119,8 @@ class TestPhaseTimeOptions(unittest.TestCase):
         p.model.linear_solver = om.DirectSolver()
         p.setup(check=True)
 
-        assert_rel_error(self, p['phase0.t_initial'], 0.01)
-        assert_rel_error(self, p['phase0.t_duration'], 1.9)
+        assert_near_equal(p['phase0.t_initial'], 0.01)
+        assert_near_equal(p['phase0.t_duration'], 1.9)
 
     def test_input_and_fixed_times_warns(self):
         """

--- a/dymos/phase/test/test_sized_input_parameters.py
+++ b/dymos/phase/test/test_sized_input_parameters.py
@@ -1,7 +1,7 @@
 import unittest
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 import dymos as dm
 from dymos.utils.lgl import lgl
@@ -75,7 +75,7 @@ class TestInputParameterConnections(unittest.TestCase):
 
         expected = np.broadcast_to(np.array([[1, 2], [3, 4]]),
                                    (p.model.phase0.options['transcription'].grid_data.num_nodes, 2, 2))
-        assert_rel_error(self, p.get_val('phase0.rhs_all.sum.m'), expected)
+        assert_near_equal(p.get_val('phase0.rhs_all.sum.m'), expected)
 
     def test_static_input_parameter_connections_radau(self):
 
@@ -135,7 +135,7 @@ class TestInputParameterConnections(unittest.TestCase):
         p.run_model()
 
         expected = np.array([[1, 2], [3, 4]])
-        assert_rel_error(self, p.get_val('phase0.rhs_all.sum.m'), expected)
+        assert_near_equal(p.get_val('phase0.rhs_all.sum.m'), expected)
 
     def test_dynamic_input_parameter_connections_gl(self):
 
@@ -198,11 +198,11 @@ class TestInputParameterConnections(unittest.TestCase):
 
         expected = np.broadcast_to(np.array([[1, 2], [3, 4]]),
                                    (gd.subset_num_nodes['state_disc'], 2, 2))
-        assert_rel_error(self, p.get_val('phase0.rhs_disc.sum.m'), expected)
+        assert_near_equal(p.get_val('phase0.rhs_disc.sum.m'), expected)
 
         expected = np.broadcast_to(np.array([[1, 2], [3, 4]]),
                                    (gd.subset_num_nodes['col'], 2, 2))
-        assert_rel_error(self, p.get_val('phase0.rhs_col.sum.m'), expected)
+        assert_near_equal(p.get_val('phase0.rhs_col.sum.m'), expected)
 
     def test_static_input_parameter_connections_gl(self):
 
@@ -262,8 +262,8 @@ class TestInputParameterConnections(unittest.TestCase):
         p.run_model()
 
         expected = np.array([[1, 2], [3, 4]])
-        assert_rel_error(self, p.get_val('phase0.rhs_disc.sum.m'), expected)
-        assert_rel_error(self, p.get_val('phase0.rhs_col.sum.m'), expected)
+        assert_near_equal(p.get_val('phase0.rhs_disc.sum.m'), expected)
+        assert_near_equal(p.get_val('phase0.rhs_col.sum.m'), expected)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/phase/test/test_time_targets.py
+++ b/dymos/phase/test/test_time_targets.py
@@ -4,7 +4,7 @@ import matplotlib
 matplotlib.use('Agg')
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 import numpy as np
 import dymos as dm
@@ -162,19 +162,19 @@ class TestPhaseTimeTargets(unittest.TestCase):
         time_phase_segends = np.reshape(time_phase_all[gd.subset_node_indices['segment_ends']],
                                         newshape=(gd.num_segments, 2))
 
-        assert_rel_error(self, p['phase0.rhs_disc.time_phase'][-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p['phase0.rhs_disc.time_phase'][-1], 1.8016, tolerance=1.0E-3)
 
-        assert_rel_error(self, p['phase0.rhs_disc.t_initial'], p['phase0.t_initial'])
-        assert_rel_error(self, p['phase0.rhs_col.t_initial'], p['phase0.t_initial'])
+        assert_near_equal(p['phase0.rhs_disc.t_initial'], p['phase0.t_initial'])
+        assert_near_equal(p['phase0.rhs_col.t_initial'], p['phase0.t_initial'])
 
-        assert_rel_error(self, p['phase0.rhs_disc.t_duration'], p['phase0.t_duration'])
-        assert_rel_error(self, p['phase0.rhs_col.t_duration'], p['phase0.t_duration'])
+        assert_near_equal(p['phase0.rhs_disc.t_duration'], p['phase0.t_duration'])
+        assert_near_equal(p['phase0.rhs_col.t_duration'], p['phase0.t_duration'])
 
-        assert_rel_error(self, p['phase0.rhs_disc.time_phase'], time_phase_disc)
-        assert_rel_error(self, p['phase0.rhs_col.time_phase'], time_phase_col)
+        assert_near_equal(p['phase0.rhs_disc.time_phase'], time_phase_disc)
+        assert_near_equal(p['phase0.rhs_col.time_phase'], time_phase_col)
 
-        assert_rel_error(self, p['phase0.rhs_disc.time'], time_disc)
-        assert_rel_error(self, p['phase0.rhs_col.time'], time_col)
+        assert_near_equal(p['phase0.rhs_disc.time'], time_disc)
+        assert_near_equal(p['phase0.rhs_col.time'], time_col)
 
         exp_out = p.model.phase0.simulate()
 
@@ -188,10 +188,10 @@ class TestPhaseTimeTargets(unittest.TestCase):
 
             # Since the phase has simulated, all times should be equal to their respective value
             # at the end of each segment.
-            assert_rel_error(self, t_initial_i, p['phase0.t_initial'])
-            assert_rel_error(self, t_duration_i, p['phase0.t_duration'])
-            assert_rel_error(self, time_phase_i, time_phase_segends[iseg, 1], tolerance=1.0E-12)
-            assert_rel_error(self, time_i, time_segends[iseg, 1], tolerance=1.0E-12)
+            assert_near_equal(t_initial_i, p['phase0.t_initial'])
+            assert_near_equal(t_duration_i, p['phase0.t_duration'])
+            assert_near_equal(time_phase_i, time_phase_segends[iseg, 1], tolerance=1.0E-12)
+            assert_near_equal(time_i, time_segends[iseg, 1], tolerance=1.0E-12)
 
     def test_radau(self):
         num_seg = 20
@@ -210,15 +210,15 @@ class TestPhaseTimeTargets(unittest.TestCase):
         time_phase_segends = np.reshape(time_phase_all[gd.subset_node_indices['segment_ends']],
                                         newshape=(gd.num_segments, 2))
 
-        assert_rel_error(self, p['phase0.rhs_all.time_phase'][-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(p['phase0.rhs_all.time_phase'][-1], 1.8016, tolerance=1.0E-3)
 
-        assert_rel_error(self, p['phase0.rhs_all.t_initial'], p['phase0.t_initial'])
+        assert_near_equal(p['phase0.rhs_all.t_initial'], p['phase0.t_initial'])
 
-        assert_rel_error(self, p['phase0.rhs_all.t_duration'], p['phase0.t_duration'])
+        assert_near_equal(p['phase0.rhs_all.t_duration'], p['phase0.t_duration'])
 
-        assert_rel_error(self, p['phase0.rhs_all.time_phase'], time_phase_all)
+        assert_near_equal(p['phase0.rhs_all.time_phase'], time_phase_all)
 
-        assert_rel_error(self, p['phase0.rhs_all.time'], time_all)
+        assert_near_equal(p['phase0.rhs_all.time'], time_all)
 
         exp_out = p.model.phase0.simulate()
 
@@ -232,10 +232,10 @@ class TestPhaseTimeTargets(unittest.TestCase):
 
             # Since the phase has simulated, all times should be equal to their respective value
             # at the end of each segment.
-            assert_rel_error(self, t_initial_i, p['phase0.t_initial'])
-            assert_rel_error(self, t_duration_i, p['phase0.t_duration'])
-            assert_rel_error(self, time_phase_i, time_phase_segends[iseg, 1], tolerance=1.0E-12)
-            assert_rel_error(self, time_i, time_segends[iseg, 1], tolerance=1.0E-12)
+            assert_near_equal(t_initial_i, p['phase0.t_initial'])
+            assert_near_equal(t_duration_i, p['phase0.t_duration'])
+            assert_near_equal(time_phase_i, time_phase_segends[iseg, 1], tolerance=1.0E-12)
+            assert_near_equal(time_i, time_segends[iseg, 1], tolerance=1.0E-12)
 
     def test_runge_kutta(self):
         num_seg = 20
@@ -256,29 +256,29 @@ class TestPhaseTimeTargets(unittest.TestCase):
 
         # Test the iteration ODE
 
-        assert_rel_error(self, p['phase0.rk_solve_group.ode.time_phase'][-1], 1.8016,
-                         tolerance=1.0E-3)
+        assert_near_equal(p['phase0.rk_solve_group.ode.time_phase'][-1], 1.8016,
+                          tolerance=1.0E-3)
 
-        assert_rel_error(self, p['phase0.rk_solve_group.ode.t_initial'], p['phase0.t_initial'])
+        assert_near_equal(p['phase0.rk_solve_group.ode.t_initial'], p['phase0.t_initial'])
 
-        assert_rel_error(self, p['phase0.rk_solve_group.ode.t_duration'], p['phase0.t_duration'])
+        assert_near_equal(p['phase0.rk_solve_group.ode.t_duration'], p['phase0.t_duration'])
 
-        assert_rel_error(self, p['phase0.rk_solve_group.ode.time_phase'], time_phase_all)
+        assert_near_equal(p['phase0.rk_solve_group.ode.time_phase'], time_phase_all)
 
-        assert_rel_error(self, p['phase0.rk_solve_group.ode.time'], time_all)
+        assert_near_equal(p['phase0.rk_solve_group.ode.time'], time_all)
 
         # Now test the final ODE
 
-        assert_rel_error(self, p['phase0.ode.time_phase'][-1], 1.8016,
-                         tolerance=1.0E-3)
+        assert_near_equal(p['phase0.ode.time_phase'][-1], 1.8016,
+                          tolerance=1.0E-3)
 
-        assert_rel_error(self, p['phase0.ode.t_initial'], p['phase0.t_initial'])
+        assert_near_equal(p['phase0.ode.t_initial'], p['phase0.t_initial'])
 
-        assert_rel_error(self, p['phase0.ode.t_duration'], p['phase0.t_duration'])
+        assert_near_equal(p['phase0.ode.t_duration'], p['phase0.t_duration'])
 
-        assert_rel_error(self, p['phase0.ode.time_phase'], time_phase_segends.ravel())
+        assert_near_equal(p['phase0.ode.time_phase'], time_phase_segends.ravel())
 
-        assert_rel_error(self, p['phase0.ode.time'], time_segends.ravel())
+        assert_near_equal(p['phase0.ode.time'], time_segends.ravel())
 
         exp_out = p.model.phase0.simulate()
 
@@ -292,10 +292,10 @@ class TestPhaseTimeTargets(unittest.TestCase):
 
             # Since the phase has simulated, all times should be equal to their respective value
             # at the end of each segment.
-            assert_rel_error(self, t_initial_i, p['phase0.t_initial'])
-            assert_rel_error(self, t_duration_i, p['phase0.t_duration'])
-            assert_rel_error(self, time_phase_i, time_phase_segends[iseg, 1], tolerance=1.0E-12)
-            assert_rel_error(self, time_i, time_segends[iseg, 1], tolerance=1.0E-12)
+            assert_near_equal(t_initial_i, p['phase0.t_initial'])
+            assert_near_equal(t_duration_i, p['phase0.t_duration'])
+            assert_near_equal(time_phase_i, time_phase_segends[iseg, 1], tolerance=1.0E-12)
+            assert_near_equal(time_i, time_segends[iseg, 1], tolerance=1.0E-12)
 
 
 if __name__ == "__main__":

--- a/dymos/phase/test/test_timeseries.py
+++ b/dymos/phase/test/test_timeseries.py
@@ -1,7 +1,7 @@
 import unittest
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
@@ -68,30 +68,25 @@ class TestTimeseriesOutput(unittest.TestCase):
         control_input_idxs = gd.subset_node_indices['control_input']
         col_idxs = gd.subset_node_indices['col']
 
-        assert_rel_error(self,
-                         p.get_val('phase0.time'),
-                         p.get_val('phase0.timeseries.time')[:, 0])
+        assert_near_equal(p.get_val('phase0.time'),
+                          p.get_val('phase0.timeseries.time')[:, 0])
 
-        assert_rel_error(self,
-                         p.get_val('phase0.time_phase'),
-                         p.get_val('phase0.timeseries.time_phase')[:, 0])
+        assert_near_equal(p.get_val('phase0.time_phase'),
+                          p.get_val('phase0.timeseries.time_phase')[:, 0])
 
         for state in ('x', 'y', 'v'):
-            assert_rel_error(self,
-                             p.get_val('phase0.states:{0}'.format(state)),
-                             p.get_val('phase0.timeseries.states:'
-                                       '{0}'.format(state))[state_input_idxs])
+            assert_near_equal(p.get_val('phase0.states:{0}'.format(state)),
+                              p.get_val('phase0.timeseries.states:'
+                                        '{0}'.format(state))[state_input_idxs])
 
-            assert_rel_error(self,
-                             p.get_val('phase0.state_interp.state_col:{0}'.format(state)),
-                             p.get_val('phase0.timeseries.states:'
-                                       '{0}'.format(state))[col_idxs])
+            assert_near_equal(p.get_val('phase0.state_interp.state_col:{0}'.format(state)),
+                              p.get_val('phase0.timeseries.states:'
+                                        '{0}'.format(state))[col_idxs])
 
         for control in ('theta',):
-            assert_rel_error(self,
-                             p.get_val('phase0.controls:{0}'.format(control)),
-                             p.get_val('phase0.timeseries.controls:'
-                                       '{0}'.format(control))[control_input_idxs])
+            assert_near_equal(p.get_val('phase0.controls:{0}'.format(control)),
+                              p.get_val('phase0.timeseries.controls:'
+                                        '{0}'.format(control))[control_input_idxs])
 
         for dp in ('g',):
             for i in range(gd.subset_num_nodes['all']):
@@ -99,9 +94,8 @@ class TestTimeseriesOutput(unittest.TestCase):
                     with self.assertRaises(KeyError):
                         p.get_val('phase0.timeseries.design_parameters:{0}'.format(dp))
                 else:
-                    assert_rel_error(self,
-                                     p.get_val('phase0.design_parameters:{0}'.format(dp))[0, :],
-                                     p.get_val('phase0.timeseries.design_parameters:{0}'.format(dp))[i])
+                    assert_near_equal(p.get_val('phase0.design_parameters:{0}'.format(dp))[0, :],
+                                      p.get_val('phase0.timeseries.design_parameters:{0}'.format(dp))[i])
 
         # call simulate to test SolveIVP transcription
         exp_out = phase.simulate()
@@ -173,25 +167,21 @@ class TestTimeseriesOutput(unittest.TestCase):
         state_input_idxs = gd.subset_node_indices['state_input']
         control_input_idxs = gd.subset_node_indices['control_input']
 
-        assert_rel_error(self,
-                         p.get_val('phase0.time'),
-                         p.get_val('phase0.timeseries.time')[:, 0])
+        assert_near_equal(p.get_val('phase0.time'),
+                          p.get_val('phase0.timeseries.time')[:, 0])
 
-        assert_rel_error(self,
-                         p.get_val('phase0.time_phase'),
-                         p.get_val('phase0.timeseries.time_phase')[:, 0])
+        assert_near_equal(p.get_val('phase0.time_phase'),
+                          p.get_val('phase0.timeseries.time_phase')[:, 0])
 
         for state in ('x', 'y', 'v'):
-            assert_rel_error(self,
-                             p.get_val('phase0.states:{0}'.format(state)),
-                             p.get_val('phase0.timeseries.states:'
-                                       '{0}'.format(state))[state_input_idxs])
+            assert_near_equal(p.get_val('phase0.states:{0}'.format(state)),
+                              p.get_val('phase0.timeseries.states:'
+                                        '{0}'.format(state))[state_input_idxs])
 
         for control in ('theta',):
-            assert_rel_error(self,
-                             p.get_val('phase0.controls:{0}'.format(control)),
-                             p.get_val('phase0.timeseries.controls:'
-                                       '{0}'.format(control))[control_input_idxs])
+            assert_near_equal(p.get_val('phase0.controls:{0}'.format(control)),
+                              p.get_val('phase0.timeseries.controls:'
+                                        '{0}'.format(control))[control_input_idxs])
 
         for dp in ('g',):
             for i in range(gd.subset_num_nodes['all']):
@@ -199,10 +189,9 @@ class TestTimeseriesOutput(unittest.TestCase):
                     with self.assertRaises(KeyError):
                         p.get_val('phase0.timeseries.design_parameters:{0}'.format(dp))
                 else:
-                    assert_rel_error(self,
-                                     p.get_val('phase0.design_parameters:{0}'.format(dp))[0, :],
-                                     p.get_val('phase0.timeseries.design_parameters:'
-                                               '{0}'.format(dp))[i])
+                    assert_near_equal(p.get_val('phase0.design_parameters:{0}'.format(dp))[0, :],
+                                      p.get_val('phase0.timeseries.design_parameters:'
+                                                '{0}'.format(dp))[i])
 
         # call simulate to test SolveIVP transcription
         exp_out = phase.simulate()

--- a/dymos/test/test_load_case.py
+++ b/dymos/test/test_load_case.py
@@ -86,7 +86,7 @@ class TestLoadCase(unittest.TestCase):
 
     def test_load_case_unchanged_grid(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
 
         p = setup_problem(dm.GaussLobatto(num_segments=10))
@@ -112,12 +112,12 @@ class TestLoadCase(unittest.TestCase):
         outputs = dict([(o[0], o[1]) for o in case.list_outputs(units=True, shape=True,
                                                                 out_stream=None)])
 
-        assert_rel_error(self, p['phase0.controls:theta'],
-                         outputs['phase0.control_group.indep_controls.controls:theta']['value'])
+        assert_near_equal(p['phase0.controls:theta'],
+                          outputs['phase0.control_group.indep_controls.controls:theta']['value'])
 
     def test_load_case_lgl_to_radau(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
 
         p = setup_problem(dm.GaussLobatto(num_segments=10))
@@ -145,13 +145,13 @@ class TestLoadCase(unittest.TestCase):
         time_val = outputs['phase0.timeseries.time']['value']
         theta_val = outputs['phase0.timeseries.controls:theta']['value']
 
-        assert_rel_error(self, q['phase0.timeseries.controls:theta'],
-                         q.model.phase0.interpolate(xs=time_val, ys=theta_val, nodes='all'),
-                         tolerance=1.0E-3)
+        assert_near_equal(q['phase0.timeseries.controls:theta'],
+                          q.model.phase0.interpolate(xs=time_val, ys=theta_val, nodes='all'),
+                          tolerance=1.0E-3)
 
     def test_load_case_radau_to_lgl(self):
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
 
         p = setup_problem(dm.Radau(num_segments=20))
@@ -179,14 +179,14 @@ class TestLoadCase(unittest.TestCase):
         time_val = outputs['phase0.timeseries.time']['value']
         theta_val = outputs['phase0.timeseries.controls:theta']['value']
 
-        assert_rel_error(self, q['phase0.timeseries.controls:theta'],
-                         q.model.phase0.interpolate(xs=time_val, ys=theta_val, nodes='all'),
-                         tolerance=1.0E-2)
+        assert_near_equal(q['phase0.timeseries.controls:theta'],
+                          q.model.phase0.interpolate(xs=time_val, ys=theta_val, nodes='all'),
+                          tolerance=1.0E-2)
 
     def test_load_case_rk4_to_lgl(self):
         import openmdao.api as om
         import dymos as dm
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
 
         p = setup_problem(dm.RungeKutta(num_segments=50))
 
@@ -213,14 +213,14 @@ class TestLoadCase(unittest.TestCase):
         time_val = outputs['phase0.timeseries.time']['value']
         theta_val = outputs['phase0.timeseries.controls:theta']['value']
 
-        assert_rel_error(self, q['phase0.timeseries.controls:theta'],
-                         q.model.phase0.interpolate(xs=time_val, ys=theta_val, nodes='all'),
-                         tolerance=1.0E-1)
+        assert_near_equal(q['phase0.timeseries.controls:theta'],
+                          q.model.phase0.interpolate(xs=time_val, ys=theta_val, nodes='all'),
+                          tolerance=1.0E-1)
 
     def test_load_case_lgl_to_rk4(self):
         import openmdao.api as om
         import dymos as dm
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
         from scipy.interpolate import interp1d
         import numpy as np
 
@@ -259,9 +259,9 @@ class TestLoadCase(unittest.TestCase):
         q_theta = q_theta[nodup]
         fq_theta = interp1d(q_time, q_theta, kind='cubic', bounds_error=False, fill_value='extrapolate')
 
-        assert_rel_error(self, fq_theta(time_val),
-                         theta_val,
-                         tolerance=1.0E-2)
+        assert_near_equal(fq_theta(time_val),
+                          theta_val,
+                          tolerance=1.0E-2)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/test/test_run_problem.py
+++ b/dymos/test/test_run_problem.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division, absolute_import
 import os
 import unittest
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 import dymos as dm
 import numpy as np
 
@@ -73,20 +73,17 @@ class TestRunProblem(unittest.TestCase):
         J = 0.5 * (c1 ** 2 * (1 + sqrt_two) * np.exp(2 * val) + c2 ** 2 * (1 - sqrt_two) * np.exp(-2 * val) -
                    (1 + sqrt_two) * c1 ** 2 - (1 - sqrt_two) * c2 ** 2)
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.controls:u')[0],
-                         ui,
-                         tolerance=5e-4)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.controls:u')[0],
+                          ui,
+                          tolerance=5e-4)
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.controls:u')[-1],
-                         uf,
-                         tolerance=5e-4)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.controls:u')[-1],
+                          uf,
+                          tolerance=5e-4)
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.states:xL')[-1],
-                         J,
-                         tolerance=5e-4)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.states:xL')[-1],
+                          J,
+                          tolerance=5e-4)
 
     def test_run_HS_problem_gl(self):
         p = om.Problem(model=om.Group())
@@ -141,20 +138,17 @@ class TestRunProblem(unittest.TestCase):
         J = 0.5 * (c1 ** 2 * (1 + sqrt_two) * np.exp(2 * val) + c2 ** 2 * (1 - sqrt_two) * np.exp(-2 * val) -
                    (1 + sqrt_two) * c1 ** 2 - (1 - sqrt_two) * c2 ** 2)
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.controls:u')[0],
-                         ui,
-                         tolerance=1e-2)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.controls:u')[0],
+                          ui,
+                          tolerance=1e-2)
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.controls:u')[-1],
-                         uf,
-                         tolerance=1e-2)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.controls:u')[-1],
+                          uf,
+                          tolerance=1e-2)
 
-        assert_rel_error(self,
-                         p.get_val('traj.phase0.timeseries.states:xL')[-1],
-                         J,
-                         tolerance=5e-4)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.states:xL')[-1],
+                          J,
+                          tolerance=5e-4)
 
     def test_run_brachistochrone_problem(self):
         p = om.Problem(model=om.Group())

--- a/dymos/trajectory/test/test_trajectory.py
+++ b/dymos/trajectory/test/test_trajectory.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 import dymos as dm
 from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
@@ -156,7 +156,7 @@ class TestTrajectory(unittest.TestCase):
         burn1_accel = self.p.get_val('burn1.states:accel')
         burn2_accel = self.p.get_val('burn2.states:accel')
         accel_link_error = self.p.get_val('linkages.burn1|burn2_accel')
-        assert_rel_error(self, accel_link_error, burn2_accel[0]-burn1_accel[-1])
+        assert_near_equal(accel_link_error, burn2_accel[0]-burn1_accel[-1])
 
 
 class TestInvalidLinkages(unittest.TestCase):

--- a/dymos/transcriptions/common/test/test_continuity_comp.py
+++ b/dymos/transcriptions/common/test/test_continuity_comp.py
@@ -6,7 +6,7 @@ from parameterized import parameterized
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_check_partials, assert_rel_error
+from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 
 from dymos.transcriptions.grid_data import GridData
 from dymos.transcriptions.common import GaussLobattoContinuityComp, RadauPSContinuityComp
@@ -131,9 +131,8 @@ class TestContinuityComp(unittest.TestCase):
                 xpectd = self.p[state][segment_end_idxs, ...][2::2, ...] - \
                     self.p[state][segment_end_idxs, ...][1:-1:2, ...]
 
-                assert_rel_error(self,
-                                 self.p['cnty_comp.defect_states:{0}'.format(state)],
-                                 xpectd.reshape((num_seg - 1,) + state_options[state]['shape']))
+                assert_near_equal(self.p['cnty_comp.defect_states:{0}'.format(state)],
+                                  xpectd.reshape((num_seg - 1,) + state_options[state]['shape']))
 
         for ctrl in ('u', 'v'):
 
@@ -141,9 +140,8 @@ class TestContinuityComp(unittest.TestCase):
                 self.p[ctrl][segment_end_idxs, ...][1:-1:2, ...]
 
             if compressed != 'compressed':
-                assert_rel_error(self,
-                                 self.p['cnty_comp.defect_controls:{0}'.format(ctrl)],
-                                 xpectd.reshape((num_seg-1,) + control_options[ctrl]['shape']))
+                assert_near_equal(self.p['cnty_comp.defect_controls:{0}'.format(ctrl)],
+                                  xpectd.reshape((num_seg-1,) + control_options[ctrl]['shape']))
 
         np.set_printoptions(linewidth=1024)
         cpd = self.p.check_partials(method='cs', out_stream=None)

--- a/dymos/transcriptions/pseudospectral/components/test/test_control_endpoint_defect_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_control_endpoint_defect_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_check_partials, assert_rel_error
+from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 
 from dymos.transcriptions.pseudospectral.components import ControlEndpointDefectComp
 from dymos.transcriptions.grid_data import GridData
@@ -51,10 +51,9 @@ class TestControlEndpointDefectComp(unittest.TestCase):
         u_poly = np.poly1d(u_coefs.ravel())
         u_interp = u_poly(1.0)
         u_given = self.p['controls:u'][-1]
-        assert_rel_error(self,
-                         np.ravel(self.p['endpoint_defect_comp.control_endpoint_defects:u']),
-                         np.ravel(u_given - u_interp),
-                         tolerance=1.0E-12)
+        assert_near_equal(np.ravel(self.p['endpoint_defect_comp.control_endpoint_defects:u']),
+                          np.ravel(u_given - u_interp),
+                          tolerance=1.0E-12)
 
     def test_partials(self):
         cpd = self.p.check_partials(compact_print=False, method='cs')

--- a/dymos/transcriptions/pseudospectral/components/test/test_gauss_lobatto_interleave_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_gauss_lobatto_interleave_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_check_partials, assert_rel_error
+from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 
 from dymos.transcriptions.pseudospectral.components import GaussLobattoInterleaveComp
 from dymos.transcriptions.grid_data import GridData
@@ -80,21 +80,17 @@ class TestGaussLobattoInterleaveComp(unittest.TestCase):
         u_all = self.p.get_val('interleave_comp.all_values:u')
         v_all = self.p.get_val('interleave_comp.all_values:v')
 
-        assert_rel_error(self,
-                         u_all[self.grid_data.subset_node_indices['state_disc'], ...],
-                         u_disc)
+        assert_near_equal(u_all[self.grid_data.subset_node_indices['state_disc'], ...],
+                          u_disc)
 
-        assert_rel_error(self,
-                         v_all[self.grid_data.subset_node_indices['state_disc'], ...],
-                         v_disc)
+        assert_near_equal(v_all[self.grid_data.subset_node_indices['state_disc'], ...],
+                          v_disc)
 
-        assert_rel_error(self,
-                         u_all[self.grid_data.subset_node_indices['col'], ...],
-                         u_col)
+        assert_near_equal(u_all[self.grid_data.subset_node_indices['col'], ...],
+                          u_col)
 
-        assert_rel_error(self,
-                         v_all[self.grid_data.subset_node_indices['col'], ...],
-                         v_col)
+        assert_near_equal(v_all[self.grid_data.subset_node_indices['col'], ...],
+                          v_col)
 
     def test_partials(self):
         cpd = self.p.check_partials(compact_print=True, method='cs', out_stream=None)

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 from dymos.transcriptions.runge_kutta.components.runge_kutta_state_continuity_comp import \
     RungeKuttaStateContinuityComp
@@ -56,21 +56,21 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         expected_resids[1:, ...] = dy_given - dy_computed
 
         op_dict = dict([op for op in outputs])
-        assert_rel_error(self, op_dict['continuity_comp.states:y']['resids'], expected_resids)
+        assert_near_equal(op_dict['continuity_comp.states:y']['resids'], expected_resids)
 
         # Test the partials
         cpd = p.check_partials(method='cs', out_stream=None)
 
         J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
         J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
         J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
 
         J_fd[0, 0] = -1.0
 
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
     def test_continuity_comp_connected_scalar_no_iteration_fwd(self):
         num_seg = 4
@@ -122,7 +122,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         expected_resids[1:, ...] = dy_given - dy_computed
 
         op_dict = dict([op for op in outputs])
-        assert_rel_error(self, op_dict['continuity_comp.states:y']['resids'], expected_resids)
+        assert_near_equal(op_dict['continuity_comp.states:y']['resids'], expected_resids)
 
         # Test the partials
         cpd = p.check_partials(method='cs')
@@ -135,7 +135,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
 
         J_fd[0, 0] = -1.0
 
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
     def test_continuity_comp_scalar_nonlinearblockgs_fwd(self):
         num_seg = 4
@@ -182,21 +182,21 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         expected_resids = np.zeros((num_seg + 1, 1))
 
         op_dict = dict([op for op in outputs])
-        assert_rel_error(self, op_dict['continuity_comp.states:y']['resids'], expected_resids)
+        assert_near_equal(op_dict['continuity_comp.states:y']['resids'], expected_resids)
 
         # Test the partials
         cpd = p.check_partials(method='cs', out_stream=None)
 
         J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
         J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
         J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
 
         J_fd[0, 0] = -1.0
 
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
     def test_continuity_comp_connected_scalar_nonlinearblockgs_fwd(self):
         num_seg = 4
@@ -248,21 +248,21 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         expected_resids = np.zeros((num_seg + 1, 1))
 
         op_dict = dict([op for op in outputs])
-        assert_rel_error(self, op_dict['continuity_comp.states:y']['resids'], expected_resids)
+        assert_near_equal(op_dict['continuity_comp.states:y']['resids'], expected_resids)
 
         # Test the partials
         cpd = p.check_partials(method='cs', out_stream=None)
 
         J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
         J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
         J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
 
         J_fd[0, 0] = -1.0
 
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
     def test_continuity_comp_scalar_newton_fwd(self):
         num_seg = 4
@@ -301,21 +301,21 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         expected_resids = np.zeros((num_seg + 1, 1))
 
         op_dict = dict([op for op in outputs])
-        assert_rel_error(self, op_dict['continuity_comp.states:y']['resids'], expected_resids)
+        assert_near_equal(op_dict['continuity_comp.states:y']['resids'], expected_resids)
 
         # Test the partials
         cpd = p.check_partials(method='cs', out_stream=None)
 
         J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
         J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
         J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
 
         J_fd[0, 0] = -1.0
 
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
     def test_continuity_comp_vector_no_iteration_fwd(self):
         num_seg = 2
@@ -359,14 +359,14 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         expected_resids[1:, ...] = dy_given - dy_computed
 
         op_dict = dict([op for op in outputs])
-        assert_rel_error(self, op_dict['continuity_comp.states:y']['resids'], expected_resids)
+        assert_near_equal(op_dict['continuity_comp.states:y']['resids'], expected_resids)
 
         # Test the partials
         cpd = p.check_partials(method='cs')
 
         J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
         J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
         J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
@@ -374,7 +374,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         size = np.prod(state_options['y']['shape'])
         J_fd[:size, :size] = -np.eye(size)
 
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
     def test_continuity_comp_vector_nonlinearblockgs_fwd(self):
         num_seg = 2
@@ -409,14 +409,14 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         expected_resids = np.zeros((num_seg + 1, 2))
 
         op_dict = dict([op for op in outputs])
-        assert_rel_error(self, op_dict['continuity_comp.states:y']['resids'], expected_resids)
+        assert_near_equal(op_dict['continuity_comp.states:y']['resids'], expected_resids)
 
         # Test the partials
         cpd = p.check_partials(method='cs', out_stream=None)
 
         J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
         J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
         J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
@@ -424,7 +424,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         size = np.prod(state_options['y']['shape'])
         J_fd[:size, :size] = -np.eye(size)
 
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
     def test_continuity_comp_connected_vector_nonlinearblockgs_fwd(self):
         num_seg = 2
@@ -464,14 +464,14 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         expected_resids = np.zeros((num_seg + 1, 2))
 
         op_dict = dict([op for op in outputs])
-        assert_rel_error(self, op_dict['continuity_comp.states:y']['resids'], expected_resids)
+        assert_near_equal(op_dict['continuity_comp.states:y']['resids'], expected_resids)
 
         # Test the partials
         cpd = p.check_partials(method='cs', out_stream=None)
 
         J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
         J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
         J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
@@ -479,7 +479,7 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         size = np.prod(state_options['y']['shape'])
         J_fd[:size, :size] = -np.eye(size)
 
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
     def test_continuity_comp_vector_newton_fwd(self):
         num_seg = 2
@@ -514,14 +514,14 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         expected_resids = np.zeros((num_seg + 1, 2))
 
         op_dict = dict([op for op in outputs])
-        assert_rel_error(self, op_dict['continuity_comp.states:y']['resids'], expected_resids)
+        assert_near_equal(op_dict['continuity_comp.states:y']['resids'], expected_resids)
 
         # Test the partials
         cpd = p.check_partials(method='cs', out_stream=None)
 
         J_fwd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
         J_fd = cpd['continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
         J_fwd = cpd['continuity_comp']['states:y', 'states:y']['J_fwd']
         J_fd = cpd['continuity_comp']['states:y', 'states:y']['J_fd']
@@ -529,4 +529,4 @@ class TestRungeKuttaContinuityComp(unittest.TestCase):
         size = np.prod(state_options['y']['shape'])
         J_fd[:size, :size] = -np.eye(size)
 
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_iter_group.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_iter_group.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 from dymos.transcriptions.runge_kutta.components import RungeKuttaStateContinuityIterGroup
 from dymos.transcriptions.runge_kutta.test.rk_test_ode import TestODE
@@ -87,22 +87,22 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
         expected_resids = np.zeros((num_seg + 1, 1))
 
         op_dict = dict([op for op in outputs])
-        assert_rel_error(self, op_dict['cnty_iter_group.continuity_comp.states:y']['resids'],
-                         expected_resids)
+        assert_near_equal(op_dict['cnty_iter_group.continuity_comp.states:y']['resids'],
+                          expected_resids)
 
         # Test the partials
         cpd = p.check_partials(method='cs', out_stream=None)
 
         J_fwd = cpd['cnty_iter_group.continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
         J_fd = cpd['cnty_iter_group.continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
         J_fwd = cpd['cnty_iter_group.continuity_comp']['states:y', 'states:y']['J_fwd']
         J_fd = cpd['cnty_iter_group.continuity_comp']['states:y', 'states:y']['J_fd']
 
         J_fd[0, 0] = -1.0
 
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
     def test_continuity_comp_newtonsolver(self):
         num_seg = 4
@@ -157,19 +157,19 @@ class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
         expected_resids = np.zeros((num_seg + 1, 1))
 
         op_dict = dict([op for op in outputs])
-        assert_rel_error(self, op_dict['cnty_iter_group.continuity_comp.states:y']['resids'],
-                         expected_resids)
+        assert_near_equal(op_dict['cnty_iter_group.continuity_comp.states:y']['resids'],
+                          expected_resids)
 
         # Test the partials
         cpd = p.check_partials(method='cs', out_stream=None)
 
         J_fwd = cpd['cnty_iter_group.continuity_comp']['states:y', 'state_integrals:y']['J_fwd']
         J_fd = cpd['cnty_iter_group.continuity_comp']['states:y', 'state_integrals:y']['J_fd']
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)
 
         J_fwd = cpd['cnty_iter_group.continuity_comp']['states:y', 'states:y']['J_fwd']
         J_fd = cpd['cnty_iter_group.continuity_comp']['states:y', 'states:y']['J_fd']
 
         J_fd[0, 0] = -1.0
 
-        assert_rel_error(self, J_fwd, J_fd)
+        assert_near_equal(J_fwd, J_fd)

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_k_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_k_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 
 from dymos.transcriptions.runge_kutta.components.runge_kutta_k_comp import RungeKuttaKComp
 
@@ -73,7 +73,7 @@ class TestRKKComp(unittest.TestCase):
                               [1.301349949091673],
                               [1.154084459568063]]])
 
-        assert_rel_error(self, p.get_val('c.k:y'), expected, tolerance=1.0E-9)
+        assert_near_equal(p.get_val('c.k:y'), expected, tolerance=1.0E-9)
 
         p.model.list_outputs(print_arrays=True)
 
@@ -122,7 +122,7 @@ class TestRKKComp(unittest.TestCase):
                               [1.232116699218750, 1.301349949091673],
                               [1.328623453776042, 1.154084459568063]]])
 
-        assert_rel_error(self, p.get_val('c.k:y'), expected, tolerance=1.0E-9)
+        assert_near_equal(p.get_val('c.k:y'), expected, tolerance=1.0E-9)
 
         cpd = p.check_partials(method='cs', out_stream=None)
         assert_check_partials(cpd)
@@ -174,7 +174,7 @@ class TestRKKComp(unittest.TestCase):
                               [[1.09765625, 1.385139703750610],
                                [1.328623453776042, 1.154084459568063]]]])
 
-        assert_rel_error(self, p.get_val('c.k:y'), expected, tolerance=1.0E-9)
+        assert_near_equal(p.get_val('c.k:y'), expected, tolerance=1.0E-9)
 
         cpd = p.check_partials(method='cs', out_stream=None)
         assert_check_partials(cpd)

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_state_advance_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_state_advance_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 
 from dymos.transcriptions.runge_kutta.components.runge_kutta_state_advance_comp import \
     RungeKuttaStateAdvanceComp
@@ -53,13 +53,12 @@ class TestRKStateAdvanceComp(unittest.TestCase):
 
         p.run_model()
 
-        assert_rel_error(self,
-                         p.get_val('c.final_states:y'),
-                         np.array([[1.425130208333333],
-                                   [2.639602661132812],
-                                   [4.006818970044454],
-                                   [5.301605229265987]]),
-                         tolerance=1.0E-9)
+        assert_near_equal(p.get_val('c.final_states:y'),
+                          np.array([[1.425130208333333],
+                                    [2.639602661132812],
+                                    [4.006818970044454],
+                                    [5.301605229265987]]),
+                          tolerance=1.0E-9)
 
         np.set_printoptions(linewidth=1024)
         cpd = p.check_partials(method='cs', out_stream=None)
@@ -92,11 +91,10 @@ class TestRKStateAdvanceComp(unittest.TestCase):
 
         p.run_model()
 
-        assert_rel_error(test_case=self,
-                         actual=p.get_val('c.final_states:y'),
-                         desired=[[1.425130208333333, 2.639602661132812],
-                                  [4.006818970044454, 5.301605229265987]],
-                         tolerance=1.0E-9)
+        assert_near_equal(actual=p.get_val('c.final_states:y'),
+                          desired=[[1.425130208333333, 2.639602661132812],
+                                   [4.006818970044454, 5.301605229265987]],
+                          tolerance=1.0E-9)
 
         np.set_printoptions(linewidth=1024)
         cpd = p.check_partials(method='cs', out_stream=None)
@@ -138,10 +136,9 @@ class TestRKStateAdvanceComp(unittest.TestCase):
 
         p.run_model()
 
-        assert_rel_error(self,
-                         p.get_val('c.final_states:y'),
-                         [[[1.425130208333333, 2.639602661132812],
-                          [4.006818970044454, 5.301605229265987]]])
+        assert_near_equal(p.get_val('c.final_states:y'),
+                          [[[1.425130208333333, 2.639602661132812],
+                           [4.006818970044454, 5.301605229265987]]])
 
         np.set_printoptions(linewidth=1024)
         cpd = p.check_partials(method='cs', out_stream=None)

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_state_predict_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_state_predict_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 
 from dymos.transcriptions.runge_kutta.components.runge_kutta_state_predict_comp import \
     RungeKuttaStatePredictComp
@@ -76,7 +76,7 @@ class TestRKStatePredictComp(unittest.TestCase):
                              [4.665199898183346],
                              [5.308168919136127]])
 
-        assert_rel_error(self, p.get_val('c.predicted_states:y'), expected)
+        assert_near_equal(p.get_val('c.predicted_states:y'), expected)
 
         cpd = p.check_partials(method='cs', out_stream=None)
         assert_check_partials(cpd)
@@ -136,7 +136,7 @@ class TestRKStatePredictComp(unittest.TestCase):
                              [3.323853492736816],
                              [4.020279407501221]])
 
-        assert_rel_error(self, p.get_val('c.predicted_states:y'), expected)
+        assert_near_equal(p.get_val('c.predicted_states:y'), expected)
 
         cpd = p.check_partials(method='cs', out_stream=None)
         assert_check_partials(cpd)
@@ -185,7 +185,7 @@ class TestRKStatePredictComp(unittest.TestCase):
                              [2.026733398437500, 4.665199898183346],
                              [2.657246907552083, 5.308168919136127]])
 
-        assert_rel_error(self, p.get_val('c.predicted_states:y'), expected)
+        assert_near_equal(p.get_val('c.predicted_states:y'), expected)
 
         cpd = p.check_partials(method='cs', out_stream=None)
         assert_check_partials(cpd)
@@ -228,19 +228,18 @@ class TestRKStatePredictComp(unittest.TestCase):
 
         p.model.list_outputs(print_arrays=True)
 
-        assert_rel_error(self,
-                         p.get_val('c.predicted_states:y'),
-                         [[[0.5, 1.425130208333333],
-                           [2.639602661132812, 4.006818970044454]],
+        assert_near_equal(p.get_val('c.predicted_states:y'),
+                          [[[0.5, 1.425130208333333],
+                            [2.639602661132812, 4.006818970044454]],
 
-                          [[0.875, 1.968912760416667],
-                           [3.299503326416016, 4.696023712555567]],
+                           [[0.875, 1.968912760416667],
+                            [3.299503326416016, 4.696023712555567]],
 
-                          [[0.953125, 2.0267333984375],
-                           [3.323853492736816, 4.665199898183346]],
+                           [[0.953125, 2.0267333984375],
+                            [3.323853492736816, 4.665199898183346]],
 
-                          [[1.4453125, 2.657246907552083],
-                           [4.020279407501221, 5.308168919136127]]])
+                           [[1.4453125, 2.657246907552083],
+                            [4.020279407501221, 5.308168919136127]]])
 
         np.set_printoptions(linewidth=1024)
         cpd = p.check_partials(method='cs', out_stream=None)

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_stepsize_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_stepsize_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 
 from dymos.transcriptions.runge_kutta.components.runge_kutta_stepsize_comp import RungeKuttaStepsizeComp
 
@@ -33,7 +33,7 @@ class TestRKStepsizeComp(unittest.TestCase):
 
         expected = np.array([0.5, 0.5, 0.5, 0.5])
 
-        assert_rel_error(self, p.get_val('c.h'), expected, tolerance=1.0E-9)
+        assert_near_equal(p.get_val('c.h'), expected, tolerance=1.0E-9)
 
         cpd = p.check_partials(method='cs', out_stream=None)
         assert_check_partials(cpd)
@@ -61,7 +61,7 @@ class TestRKStepsizeComp(unittest.TestCase):
 
         expected = np.array([2.0, 2.0, 1.0, 0.5])
 
-        assert_rel_error(self, p.get_val('c.h'), expected, tolerance=1.0E-9)
+        assert_near_equal(p.get_val('c.h'), expected, tolerance=1.0E-9)
 
         cpd = p.check_partials(method='cs', out_stream=None)
         assert_check_partials(cpd)

--- a/dymos/transcriptions/runge_kutta/test/test_rk4_simple_integration.py
+++ b/dymos/transcriptions/runge_kutta/test/test_rk4_simple_integration.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 import dymos as dm
 from dymos.transcriptions.runge_kutta.test.rk_test_ode import TestODE, _test_ode_solution
@@ -32,7 +32,7 @@ class TestRK4SimpleIntegration(unittest.TestCase):
         p.run_model()
 
         expected = _test_ode_solution(p['phase0.ode.y'], p['phase0.ode.t'])
-        assert_rel_error(self, p['phase0.ode.y'], expected, tolerance=1.0E-3)
+        assert_near_equal(p['phase0.ode.y'], expected, tolerance=1.0E-3)
 
     def test_simple_integration_forward_connected_initial(self):
 
@@ -61,7 +61,7 @@ class TestRK4SimpleIntegration(unittest.TestCase):
         p.run_model()
 
         expected = _test_ode_solution(p['traj.phase0.ode.y'], p['traj.phase0.ode.t'])
-        assert_rel_error(self, p['traj.phase0.ode.y'], expected, tolerance=1.0E-3)
+        assert_near_equal(p['traj.phase0.ode.y'], expected, tolerance=1.0E-3)
 
     def test_simple_integration_forward_connected_initial_fixed_initial(self):
 
@@ -103,7 +103,7 @@ class TestRK4SimpleIntegration(unittest.TestCase):
         p.run_model()
 
         expected = np.atleast_2d(_test_ode_solution(p['phase0.ode.y'], p['phase0.timeseries.time']))
-        assert_rel_error(self, p['phase0.timeseries.states:y'], expected, tolerance=1.0E-3)
+        assert_near_equal(p['phase0.timeseries.states:y'], expected, tolerance=1.0E-3)
 
     def test_simple_integration_backward_connected_initial(self):
 
@@ -131,7 +131,7 @@ class TestRK4SimpleIntegration(unittest.TestCase):
         p.run_model()
 
         expected = np.atleast_2d(_test_ode_solution(p['phase0.ode.y'], p['phase0.timeseries.time']))
-        assert_rel_error(self, p['phase0.timeseries.states:y'], expected, tolerance=1.0E-3)
+        assert_near_equal(p['phase0.timeseries.states:y'], expected, tolerance=1.0E-3)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/transcriptions/solve_ivp/components/test/test_segment_simulation_comp.py
+++ b/dymos/transcriptions/solve_ivp/components/test/test_segment_simulation_comp.py
@@ -1,7 +1,7 @@
 import unittest
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 from dymos.transcriptions.solve_ivp.components.segment_simulation_comp import SegmentSimulationComp
 from dymos.transcriptions.runge_kutta.test.rk_test_ode import TestODE
@@ -41,7 +41,6 @@ class TestSegmentSimulationComp(unittest.TestCase):
 
         p.run_model()
 
-        assert_rel_error(self,
-                         p.get_val('segment_0.states:y', units='m')[-1, ...],
-                         1.425639364649936,
-                         tolerance=1.0E-6)
+        assert_near_equal(p.get_val('segment_0.states:y', units='m')[-1, ...],
+                          1.425639364649936,
+                          tolerance=1.0E-6)


### PR DESCRIPTION
### Summary

Change instances of assert_rel_error to assert_near_zero from the OpenMDAO API to avoid deprecation warnings.

### Related Issues

- Resolves #316

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
