### PR TITLE
Issue deprecation warning if targets for states/controls/parameters are not explicitly given

### DIFF
--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -8,6 +8,7 @@ from scipy import interpolate
 
 import openmdao.api as om
 from openmdao.core.system import System
+from openmdao.utils.general_utils import warn_deprecation
 import dymos as dm
 
 from .options import ControlOptionsDictionary, DesignParameterOptionsDictionary, \
@@ -49,7 +50,6 @@ class Phase(om.Group):
     """
 
     def __init__(self, from_phase=None, **kwargs):
-
         _kwargs = kwargs.copy()
 
         # These are the options which will be set at setup time.
@@ -65,7 +65,6 @@ class Phase(om.Group):
         # Dictionaries of variable options that are set by the user via the API
         # These will be applied over any defaults specified by decorators on the ODE
         if from_phase is None:
-
             self._initial_boundary_constraints = {}
             self._final_boundary_constraints = {}
             self._path_constraints = {}
@@ -132,6 +131,9 @@ class Phase(om.Group):
         targets : str or Sequence of str
             The path to the targets of the state variable in the ODE system.  If given
             this will override the value given by the @declare_state decorator on the ODE.
+            In the future, if left _unspecified (the default), the phase variable will try to connect to an ODE input
+            of the same name. Currently _unspecified is the same as None, but a deprecation warning is issued.
+            Set targets to None to prevent this (the old default behavior).
         val :  ndarray
             The default value of the state at the state discretization nodes of the phase.
         fix_initial : bool(False)
@@ -203,6 +205,9 @@ class Phase(om.Group):
         targets : str or Sequence of str
             The path to the targets of the state variable in the ODE system.  If given
             this will override the value given by the @declare_state decorator on the ODE.
+            In the future, if left _unspecified (the default), the phase variable will try to connect to an ODE input
+            of the same name. Currently _unspecified is the same as None, but a deprecation warning is issued.
+            Set targets to None to prevent this (the old default behavior).
         val :  ndarray
             The default value of the state at the state discretization nodes of the phase.
         fix_initial : bool(False)
@@ -245,7 +250,13 @@ class Phase(om.Group):
         if rate_source is not _unspecified:
             self.state_options[name]['rate_source'] = rate_source
 
-        if targets is not _unspecified:
+        if not targets:  # handle None to explicitly do nothing
+            pass
+        elif targets is _unspecified:  # [default] was the same as None
+            warn_deprecation("The default behavior of 'targets=_unspecified' is changing. "
+                             "It is currently equivalent to targets=None', but in the future it will try to "
+                             "automatically connect to ODE inputs. Set targets=None to retain the old behavior.")
+        elif targets is not _unspecified:  # and not None
             if isinstance(targets, str):
                 self.state_options[name]['targets'] = (targets,)
             else:
@@ -357,6 +368,9 @@ class Phase(om.Group):
             This option is invalid if opt=False.
         targets : Sequence of str or None
             Targets in the ODE to which this control is connected.
+            In the future, if left _unspecified (the default), the phase control will try to connect to an ODE input
+            of the same name. Currently _unspecified is the same as None, but a deprecation warning is issued.
+            Set targets to None to prevent this (the old default behavior).
         rate_targets : Sequence of str or None
             The targets in the ODE to which the control rate is connected.
         rate2_targets : Sequence of str or None
@@ -451,6 +465,9 @@ class Phase(om.Group):
             This option is invalid if opt=False.
         targets : Sequence of str or None
             Targets in the ODE to which this control is connected.
+            In the future, if left _unspecified (the default), the phase control will try to connect to an ODE input
+            of the same name. Currently _unspecified is the same as None, but a deprecation warning is issued.
+            Set targets to None to prevent this (the old default behavior).
         rate_targets : Sequence of str or None
             The targets in the ODE to which the control rate is connected.
         rate2_targets : Sequence of str or None
@@ -512,7 +529,13 @@ class Phase(om.Group):
         if desc is not _unspecified:
             self.control_options[name]['desc'] = desc
 
-        if targets is not _unspecified:
+        if not targets:  # handle None to explicitly do nothing
+            pass
+        elif targets is _unspecified:  # [default] was the same as None
+            warn_deprecation("The default behavior of 'targets=_unspecified' is changing. "
+                             "It is currently equivalent to targets=None', but in the future it will try to "
+                             "automatically connect to ODE inputs. Set targets=None to retain the old behavior.")
+        elif targets is not _unspecified:
             if isinstance(targets, str):
                 self.control_options[name]['targets'] = (targets,)
             else:
@@ -807,6 +830,9 @@ class Phase(om.Group):
             The unit-reference value of the design parameter for the optimizer.
         targets : Sequence of str or None
             Targets in the ODE to which this parameter is connected.
+            In the future, if left _unspecified (the default), the phase parameter will try to connect to an ODE input
+            of the same name. Currently _unspecified is the same as None, but a deprecation warning is issued.
+            Set targets to None to prevent this (the old default behavior).
         shape : Sequence of int
             The shape of the design parameter.
         dynamic : bool
@@ -862,6 +888,9 @@ class Phase(om.Group):
             The unit-reference value of the design parameter for the optimizer.
         targets : Sequence of str or None
             Targets in the ODE to which this parameter is connected.
+            In the future, if left _unspecified (the default), the phase parameter will try to connect to an ODE input
+            of the same name. Currently _unspecified is the same as None, but a deprecation warning is issued.
+            Set targets to None to prevent this (the old default behavior).
         shape : Sequence of int
             The shape of the design parameter.
         dynamic : bool
@@ -879,7 +908,13 @@ class Phase(om.Group):
         if desc is not _unspecified:
             self.design_parameter_options[name]['desc'] = desc
 
-        if targets is not _unspecified:
+        if not targets:  # handle None to explicitly do nothing
+            pass
+        elif targets is _unspecified:  # [default] was the same as None
+            warn_deprecation("The default behavior of 'targets=_unspecified' is changing. "
+                             "It is currently equivalent to targets=None', but in the future it will try to "
+                             "automatically connect to ODE inputs. Set targets=None to retain the old behavior.")
+        elif targets is not _unspecified:
             if isinstance(targets, str):
                 self.design_parameter_options[name]['targets'] = (targets,)
             else:

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -250,7 +250,7 @@ class Phase(om.Group):
         if rate_source is not _unspecified:
             self.state_options[name]['rate_source'] = rate_source
 
-        if not targets:  # handle None to explicitly do nothing
+        if targets is None:  # handle None to explicitly do nothing
             pass
         elif targets is _unspecified:  # [default] was the same as None
             warn_deprecation("The default behavior of 'targets=_unspecified' is changing. "
@@ -529,7 +529,7 @@ class Phase(om.Group):
         if desc is not _unspecified:
             self.control_options[name]['desc'] = desc
 
-        if not targets:  # handle None to explicitly do nothing
+        if targets is None:  # handle None to explicitly do nothing
             pass
         elif targets is _unspecified:  # [default] was the same as None
             warn_deprecation("The default behavior of 'targets=_unspecified' is changing. "
@@ -908,7 +908,7 @@ class Phase(om.Group):
         if desc is not _unspecified:
             self.design_parameter_options[name]['desc'] = desc
 
-        if not targets:  # handle None to explicitly do nothing
+        if targets is None:  # handle None to explicitly do nothing
             pass
         elif targets is _unspecified:  # [default] was the same as None
             warn_deprecation("The default behavior of 'targets=_unspecified' is changing. "


### PR DESCRIPTION
### Summary

Issue deprecation warnings about the changing default behavior for targets=_unspecified in preparation for issue #318

### Related Issues

- Resolves #

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
