### PR TITLE
Phase connections and promotions moved to configure

### DIFF
--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -16,9 +16,7 @@ from .options import ControlOptionsDictionary, DesignParameterOptionsDictionary,
     PolynomialControlOptionsDictionary, GridRefinementOptionsDictionary
 
 from ..transcriptions.transcription_base import TranscriptionBase
-
-
-_unspecified = object()
+from ..utils.misc import _unspecified
 
 
 class Phase(om.Group):
@@ -253,11 +251,11 @@ class Phase(om.Group):
         if targets is None:  # handle None to explicitly do nothing
             pass
         elif targets is _unspecified:  # [default] was the same as None
+            # TODO: remove deprecation when this is working as described
             warn_deprecation("The default behavior of 'targets=_unspecified' is changing. "
                              "It is currently equivalent to targets=None', but in the future it will try to "
                              "automatically connect to ODE inputs. Set targets=None to retain the old behavior.")
-            # optional target should be connected only if ODE input exists (checked in configure, or setup?)
-            self.state_options[name]['targets'] = ('unspecified:{0}'.format(name),)
+            pass  # optional target should be connected only if ODE input exists (checked in configure)
         elif targets is not _unspecified:  # and not None
             if isinstance(targets, str):
                 self.state_options[name]['targets'] = (targets,)
@@ -1571,10 +1569,10 @@ class Phase(om.Group):
         # check that unspecified options exist in ODE or delete them
         for k, v in self.state_options.items():
             t = v['targets']
-            if t is not None and t[0].startswith('unspecified:'):
-                print('handle ', self.state_options[k]['targets'])
+            if t is _unspecified:
+                print('handle ODE check for ', k)
                 if False:  # TODO: if ODE input exists (how to check?) replace with real target
-                    self.state_options[k]['targets'] = (t[0][len('unspecified:'):],)
+                    self.state_options[k]['targets'] = (k,)
                 else:
                     self.state_options[k]['targets'] = None  # else remove the target
 

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -256,6 +256,8 @@ class Phase(om.Group):
             warn_deprecation("The default behavior of 'targets=_unspecified' is changing. "
                              "It is currently equivalent to targets=None', but in the future it will try to "
                              "automatically connect to ODE inputs. Set targets=None to retain the old behavior.")
+            # optional target should be connected only if ODE input exists (checked in configure, or setup?)
+            self.state_options[name]['targets'] = ('unspecified:{0}'.format(name),)
         elif targets is not _unspecified:  # and not None
             if isinstance(targets, str):
                 self.state_options[name]['targets'] = (targets,)
@@ -1534,10 +1536,8 @@ class Phase(om.Group):
         # Finalize the variables if it hasn't happened already.
         # If this phase exists within a Trajectory, the trajectory will finalize them during setup.
         transcription = self.options['transcription']
-
         transcription.setup_time(self)
 
-        # The control interpolation comp to which we'll connect controls
         if self.control_options:
             transcription.setup_controls(self)
 
@@ -1560,10 +1560,53 @@ class Phase(om.Group):
         transcription.setup_path_constraints(self)
         transcription.setup_endpoint_conditions(self)
         transcription.setup_objective(self)
-
         transcription.setup_timeseries_outputs(self)
-
         transcription.setup_solvers(self)
+
+    def configure(self):
+        # can't check ODE inputs in setup, soon you will be able to check them for children in configure
+        # need to move connect calls in transcription.setup_controls below to configure so that they
+        # can be skipped for non-ODE unspecified targets
+
+        # check that unspecified options exist in ODE or delete them
+        for k, v in self.state_options.items():
+            t = v['targets']
+            if t is not None and t[0].startswith('unspecified:'):
+                print('handle ', self.state_options[k]['targets'])
+                if False:  # TODO: if ODE input exists (how to check?) replace with real target
+                    self.state_options[k]['targets'] = (t[0][len('unspecified:'):],)
+                else:
+                    self.state_options[k]['targets'] = None  # else remove the target
+
+        # Finalize the variables if it hasn't happened already.
+        # If this phase exists within a Trajectory, the trajectory will finalize them during setup.
+        transcription = self.options['transcription']
+        transcription.configure_time(self)
+
+        # The control interpolation comp to which we'll connect controls
+        if self.control_options:
+            transcription.configure_controls(self)
+
+        if self.polynomial_control_options:
+            transcription.configure_polynomial_controls(self)
+
+        if self.design_parameter_options:
+            transcription.configure_design_parameters(self)
+
+        if self.input_parameter_options:
+            transcription.configure_input_parameters(self)
+
+        transcription.configure_states(self)
+        transcription.configure_ode(self)
+        transcription.configure_defects(self)
+
+        transcription.configure_boundary_constraints('initial', self)
+        transcription.configure_boundary_constraints('final', self)
+        transcription.configure_path_constraints(self)
+        transcription.configure_endpoint_conditions(self)
+        transcription.configure_objective(self)
+        transcription.configure_timeseries_outputs(self)
+        transcription.configure_solvers(self)
 
     def check_time_options(self):
         """

--- a/dymos/transcriptions/pseudospectral/pseudospectral_base.py
+++ b/dymos/transcriptions/pseudospectral/pseudospectral_base.py
@@ -151,9 +151,6 @@ class PseudospectralBase(TranscriptionBase):
                                      indices=desvar_indices)
 
     def configure_states(self, phase):
-        self.any_solved_segs = False
-        self.any_connected_opt_segs = False
-
         if self.any_solved_segs or self.any_connected_opt_segs:
             for name, options in phase.state_options.items():
                 if options['solve_segments']:

--- a/dymos/transcriptions/pseudospectral/pseudospectral_base.py
+++ b/dymos/transcriptions/pseudospectral/pseudospectral_base.py
@@ -53,12 +53,6 @@ class PseudospectralBase(TranscriptionBase):
         if self.any_solved_segs or self.any_connected_opt_segs:
             indep = StateIndependentsComp(grid_data=grid_data,
                                           state_options=phase.state_options)
-
-            for name, options in phase.state_options.items():
-                if options['solve_segments']:
-                    phase.connect('collocation_constraint.defects:{0}'.format(name),
-                                  'indep_states.defects:{0}'.format(name))
-
         else:
             indep = om.IndepVarComp()
 
@@ -156,18 +150,31 @@ class PseudospectralBase(TranscriptionBase):
                                      ref=coerce_desvar_option('ref'),
                                      indices=desvar_indices)
 
+    def configure_states(self, phase):
+        self.any_solved_segs = False
+        self.any_connected_opt_segs = False
+
+        if self.any_solved_segs or self.any_connected_opt_segs:
+            for name, options in phase.state_options.items():
+                if options['solve_segments']:
+                    phase.connect('collocation_constraint.defects:{0}'.format(name),
+                                  'indep_states.defects:{0}'.format(name))
+
     def setup_ode(self, phase):
         grid_data = self.grid_data
         transcription = grid_data.transcription
         time_units = phase.time_options['units']
-        map_input_indices_to_disc = grid_data.input_maps['state_input_to_disc']
-        num_input_nodes = grid_data.subset_num_nodes['state_input']
 
         phase.add_subsystem('state_interp',
                             subsys=StateInterpComp(grid_data=grid_data,
                                                    state_options=phase.state_options,
                                                    time_units=time_units,
                                                    transcription=transcription))
+
+    def configure_ode(self, phase):
+        grid_data = self.grid_data
+        map_input_indices_to_disc = grid_data.input_maps['state_input_to_disc']
+        num_input_nodes = grid_data.subset_num_nodes['state_input']
 
         phase.connect('dt_dstau', 'state_interp.dt_dstau',
                       src_indices=grid_data.subset_node_indices['col'])
@@ -260,6 +267,33 @@ class PseudospectralBase(TranscriptionBase):
 
         phase.add_subsystem(name='final_conditions', subsys=fc_comp, promotes_outputs=['*'])
 
+        for state_name, options in phase.state_options.items():
+            jump_comp.add_output('initial_jump:{0}'.format(state_name),
+                                 val=np.zeros(options['shape']),
+                                 units=options['units'],
+                                 desc='discontinuity in {0} at the '
+                                      'start of the phase'.format(state_name))
+
+            jump_comp.add_output('final_jump:{0}'.format(state_name),
+                                 val=np.zeros(options['shape']),
+                                 units=options['units'],
+                                 desc='discontinuity in {0} at the '
+                                      'end of the phase'.format(state_name))
+
+        for control_name, options in phase.control_options.items():
+            jump_comp.add_output('initial_jump:{0}'.format(control_name),
+                                 val=np.zeros(options['shape']),
+                                 units=options['units'],
+                                 desc='discontinuity in {0} at the '
+                                      'start of the phase'.format(control_name))
+
+            jump_comp.add_output('final_jump:{0}'.format(control_name),
+                                 val=np.zeros(options['shape']),
+                                 units=options['units'],
+                                 desc='discontinuity in {0} at the '
+                                      'end of the phase'.format(control_name))
+
+    def configure_endpoint_conditions(self, phase):
         phase.connect('time', 'initial_conditions.initial_value:time')
         phase.connect('time', 'final_conditions.final_value:time')
 
@@ -272,18 +306,6 @@ class PseudospectralBase(TranscriptionBase):
         for state_name, options in phase.state_options.items():
             size = np.prod(options['shape'])
             ar = np.arange(size)
-
-            jump_comp.add_output('initial_jump:{0}'.format(state_name),
-                                 val=np.zeros(options['shape']),
-                                 units=options['units'],
-                                 desc='discontinuity in {0} at the '
-                                      'start of the phase'.format(state_name))
-
-            jump_comp.add_output('final_jump:{0}'.format(state_name),
-                                 val=np.zeros(options['shape']),
-                                 units=options['units'],
-                                 desc='discontinuity in {0} at the '
-                                      'end of the phase'.format(state_name))
 
             phase.connect('states:{0}'.format(state_name),
                           'initial_conditions.initial_value:{0}'.format(state_name))
@@ -301,18 +323,6 @@ class PseudospectralBase(TranscriptionBase):
         for control_name, options in phase.control_options.items():
             size = np.prod(options['shape'])
             ar = np.arange(size)
-
-            jump_comp.add_output('initial_jump:{0}'.format(control_name),
-                                 val=np.zeros(options['shape']),
-                                 units=options['units'],
-                                 desc='discontinuity in {0} at the '
-                                      'start of the phase'.format(control_name))
-
-            jump_comp.add_output('final_jump:{0}'.format(control_name),
-                                 val=np.zeros(options['shape']),
-                                 units=options['units'],
-                                 desc='discontinuity in {0} at the '
-                                      'end of the phase'.format(control_name))
 
             phase.connect('control_values:{0}'.format(control_name),
                           'initial_conditions.initial_value:{0}'.format(control_name))
@@ -336,6 +346,9 @@ class PseudospectralBase(TranscriptionBase):
             newton.options['iprint'] = -1
             newton.linesearch = om.BoundsEnforceLS()
             phase.linear_solver = om.DirectSolver()
+
+    def configure_solvers(self, phase):
+        pass
 
     def _get_boundary_constraint_src(self, var, loc, phase):
         # Determine the path to the variable which we will be constraining

--- a/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
+++ b/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
@@ -27,6 +27,8 @@ class Radau(PseudospectralBase):
     def setup_time(self, phase):
         super(Radau, self).setup_time(phase)
 
+    def configure_time(self, phase):
+
         if phase.time_options['targets']:
             phase.connect('time',
                           ['rhs_all.{0}'.format(t) for t in phase.time_options['targets']],
@@ -71,8 +73,10 @@ class Radau(PseudospectralBase):
     def setup_polynomial_controls(self, phase):
         super(Radau, self).setup_polynomial_controls(phase)
 
-        for name, options in phase.polynomial_control_options.items():
+    def configure_polynomial_controls(self, phase):
+        super(Radau, self).configure_polynomial_controls(phase)
 
+        for name, options in phase.polynomial_control_options.items():
             if phase.polynomial_control_options[name]['targets']:
                 targets = phase.polynomial_control_options[name]['targets']
 
@@ -94,14 +98,18 @@ class Radau(PseudospectralBase):
 
         ODEClass = phase.options['ode_class']
         grid_data = self.grid_data
-        num_input_nodes = grid_data.subset_num_nodes['state_input']
-
-        map_input_indices_to_disc = grid_data.input_maps['state_input_to_disc']
 
         kwargs = phase.options['ode_init_kwargs']
         phase.add_subsystem('rhs_all',
                             subsys=ODEClass(num_nodes=grid_data.subset_num_nodes['all'],
                                             **kwargs))
+
+    def configure_ode(self, phase):
+        super(Radau, self).configure_ode(phase)
+
+        grid_data = self.grid_data
+        num_input_nodes = grid_data.subset_num_nodes['state_input']
+        map_input_indices_to_disc = grid_data.input_maps['state_input_to_disc']
 
         for name, options in phase.state_options.items():
             size = np.prod(options['shape'])
@@ -122,8 +130,17 @@ class Radau(PseudospectralBase):
 
     def setup_defects(self, phase):
         super(Radau, self).setup_defects(phase)
-        grid_data = self.grid_data
 
+        grid_data = self.grid_data
+        if grid_data.num_segments > 1:
+            phase.add_subsystem('continuity_comp',
+                                RadauPSContinuityComp(grid_data=grid_data,
+                                                      state_options=phase.state_options,
+                                                      control_options=phase.control_options,
+                                                      time_units=phase.time_options['units']),
+                                promotes_inputs=['t_duration'])
+
+    def configure_defects(self, phase):
         for name, options in phase.state_options.items():
             phase.connect('state_interp.staterate_col:{0}'.format(name),
                           'collocation_constraint.f_approx:{0}'.format(name))
@@ -133,14 +150,6 @@ class Radau(PseudospectralBase):
             phase.connect(rate_src,
                           'collocation_constraint.f_computed:{0}'.format(name),
                           src_indices=src_idxs, flat_src_indices=True)
-
-        if grid_data.num_segments > 1:
-            phase.add_subsystem('continuity_comp',
-                                RadauPSContinuityComp(grid_data=grid_data,
-                                                      state_options=phase.state_options,
-                                                      control_options=phase.control_options,
-                                                      time_units=phase.time_options['units']),
-                                promotes_inputs=['t_duration'])
 
     def setup_path_constraints(self, phase):
         """
@@ -170,15 +179,11 @@ class Radau(PseudospectralBase):
                 constraint_kwargs['shape'] = (1,)
                 constraint_kwargs['units'] = time_units if con_units is None else con_units
                 constraint_kwargs['linear'] = True
-                phase.connect(src_name='time',
-                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
 
             elif var_type == 'time_phase':
                 constraint_kwargs['shape'] = (1,)
                 constraint_kwargs['units'] = time_units if con_units is None else con_units
                 constraint_kwargs['linear'] = True
-                phase.connect(src_name='time_phase',
-                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
 
             elif var_type == 'state':
                 state_shape = phase.state_options[var]['shape']
@@ -186,10 +191,6 @@ class Radau(PseudospectralBase):
                 constraint_kwargs['shape'] = state_shape
                 constraint_kwargs['units'] = state_units if con_units is None else con_units
                 constraint_kwargs['linear'] = False
-                src_idxs = get_src_indices_by_row(gd.input_maps['state_input_to_disc'], state_shape)
-                phase.connect(src_name='states:{0}'.format(var),
-                              tgt_name='path_constraints.all_values:{0}'.format(con_name),
-                              src_indices=src_idxs, flat_src_indices=True)
 
             elif var_type == 'indep_control':
                 control_shape = phase.control_options[var]['shape']
@@ -198,10 +199,6 @@ class Radau(PseudospectralBase):
                 constraint_kwargs['shape'] = control_shape
                 constraint_kwargs['units'] = control_units if con_units is None else con_units
                 constraint_kwargs['linear'] = True
-                constraint_path = 'control_values:{0}'.format(var)
-
-                phase.connect(src_name=constraint_path,
-                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
 
             elif var_type == 'input_control':
                 control_shape = phase.control_options[var]['shape']
@@ -210,10 +207,6 @@ class Radau(PseudospectralBase):
                 constraint_kwargs['shape'] = control_shape
                 constraint_kwargs['units'] = control_units if con_units is None else con_units
                 constraint_kwargs['linear'] = True
-                constraint_path = 'control_values:{0}'.format(var)
-
-                phase.connect(src_name=constraint_path,
-                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
 
             elif var_type == 'indep_polynomial_control':
                 control_shape = phase.polynomial_control_options[var]['shape']
@@ -221,10 +214,6 @@ class Radau(PseudospectralBase):
                 constraint_kwargs['shape'] = control_shape
                 constraint_kwargs['units'] = control_units if con_units is None else con_units
                 constraint_kwargs['linear'] = False
-                constraint_path = 'polynomial_control_values:{0}'.format(var)
-
-                phase.connect(src_name=constraint_path,
-                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
 
             elif var_type == 'input_polynomial_control':
                 control_shape = phase.polynomial_control_options[var]['shape']
@@ -232,10 +221,6 @@ class Radau(PseudospectralBase):
                 constraint_kwargs['shape'] = control_shape
                 constraint_kwargs['units'] = control_units if con_units is None else con_units
                 constraint_kwargs['linear'] = False
-                constraint_path = 'polynomial_control_values:{0}'.format(var)
-
-                phase.connect(src_name=constraint_path,
-                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
 
             elif var_type == 'control_rate':
                 control_name = var[:-5]
@@ -244,9 +229,6 @@ class Radau(PseudospectralBase):
                 constraint_kwargs['shape'] = control_shape
                 constraint_kwargs['units'] = get_rate_units(control_units, time_units, deriv=1) \
                     if con_units is None else con_units
-                constraint_path = 'control_rates:{0}_rate'.format(control_name)
-                phase.connect(src_name=constraint_path,
-                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
 
             elif var_type == 'control_rate2':
                 control_name = var[:-6]
@@ -255,9 +237,6 @@ class Radau(PseudospectralBase):
                 constraint_kwargs['shape'] = control_shape
                 constraint_kwargs['units'] = get_rate_units(control_units, time_units, deriv=2) \
                     if con_units is None else con_units
-                constraint_path = 'control_rates:{0}_rate2'.format(control_name)
-                phase.connect(src_name=constraint_path,
-                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
 
             elif var_type == 'polynomial_control_rate':
                 control_name = var[:-5]
@@ -266,9 +245,6 @@ class Radau(PseudospectralBase):
                 constraint_kwargs['shape'] = control_shape
                 constraint_kwargs['units'] = get_rate_units(control_units, time_units, deriv=1) \
                     if con_units is None else con_units
-                constraint_path = 'polynomial_control_rates:{0}_rate'.format(control_name)
-                phase.connect(src_name=constraint_path,
-                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
 
             elif var_type == 'polynomial_control_rate2':
                 control_name = var[:-6]
@@ -277,9 +253,6 @@ class Radau(PseudospectralBase):
                 constraint_kwargs['shape'] = control_shape
                 constraint_kwargs['units'] = get_rate_units(control_units, time_units, deriv=2) \
                     if con_units is None else con_units
-                constraint_path = 'polynomial_control_rates:{0}_rate2'.format(control_name)
-                phase.connect(src_name=constraint_path,
-                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
 
             else:
                 # Failed to find variable, assume it is in the ODE
@@ -289,17 +262,90 @@ class Radau(PseudospectralBase):
                     options['shape'] = (1,)
                     constraint_kwargs['shape'] = (1,)
 
-                phase.connect(src_name='rhs_all.{0}'.format(var),
+            path_comp._add_path_constraint(con_name, var_type, **constraint_kwargs)
+
+    def configure_path_constraints(self, phase):
+        gd = self.grid_data
+
+        for var, options in phase._path_constraints.items():
+            constraint_kwargs = options.copy()
+            con_name = constraint_kwargs.pop('constraint_name')
+
+            # Determine the path to the variable which we will be constraining
+            # This is more complicated for path constraints since, for instance,
+            # a single state variable has two sources which must be connected to
+            # the path component.
+            var_type = phase.classify_var(var)
+
+            if var_type == 'time':
+                phase.connect(src_name='time',
                               tgt_name='path_constraints.all_values:{0}'.format(con_name))
 
-            path_comp._add_path_constraint(con_name, var_type, **constraint_kwargs)
+            elif var_type == 'time_phase':
+                phase.connect(src_name='time_phase',
+                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
+
+            elif var_type == 'state':
+                state_shape = phase.state_options[var]['shape']
+                src_idxs = get_src_indices_by_row(gd.input_maps['state_input_to_disc'], state_shape)
+                phase.connect(src_name='states:{0}'.format(var),
+                              tgt_name='path_constraints.all_values:{0}'.format(con_name),
+                              src_indices=src_idxs, flat_src_indices=True)
+
+            elif var_type == 'indep_control':
+                constraint_path = 'control_values:{0}'.format(var)
+                phase.connect(src_name=constraint_path,
+                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
+
+            elif var_type == 'input_control':
+                constraint_path = 'control_values:{0}'.format(var)
+                phase.connect(src_name=constraint_path,
+                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
+
+            elif var_type == 'indep_polynomial_control':
+                constraint_path = 'polynomial_control_values:{0}'.format(var)
+                phase.connect(src_name=constraint_path,
+                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
+
+            elif var_type == 'input_polynomial_control':
+                constraint_path = 'polynomial_control_values:{0}'.format(var)
+                phase.connect(src_name=constraint_path,
+                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
+
+            elif var_type == 'control_rate':
+                control_name = var[:-5]
+                constraint_path = 'control_rates:{0}_rate'.format(control_name)
+                phase.connect(src_name=constraint_path,
+                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
+
+            elif var_type == 'control_rate2':
+                control_name = var[:-6]
+                constraint_path = 'control_rates:{0}_rate2'.format(control_name)
+                phase.connect(src_name=constraint_path,
+                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
+
+            elif var_type == 'polynomial_control_rate':
+                control_name = var[:-5]
+                constraint_path = 'polynomial_control_rates:{0}_rate'.format(control_name)
+                phase.connect(src_name=constraint_path,
+                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
+
+            elif var_type == 'polynomial_control_rate2':
+                control_name = var[:-6]
+                constraint_path = 'polynomial_control_rates:{0}_rate2'.format(control_name)
+                phase.connect(src_name=constraint_path,
+                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
+
+            else:
+                # Failed to find variable, assume it is in the ODE
+                phase.connect(src_name='rhs_all.{0}'.format(var),
+                              tgt_name='path_constraints.all_values:{0}'.format(con_name))
 
     def setup_timeseries_outputs(self, phase):
         gd = self.grid_data
         time_units = phase.time_options['units']
 
         for name, options in phase._timeseries.items():
-
             if options['transcription'] is None:
                 ogd = None
             else:
@@ -313,32 +359,21 @@ class Radau(PseudospectralBase):
             timeseries_comp._add_timeseries_output('time',
                                                    var_class=phase.classify_var('time'),
                                                    units=time_units)
-            phase.connect(src_name='time', tgt_name='{0}.input_values:time'.format(name))
 
             timeseries_comp._add_timeseries_output('time_phase',
                                                    var_class=phase.classify_var('time_phase'),
                                                    units=time_units)
-            phase.connect(src_name='time_phase', tgt_name='{0}.input_values:time_phase'.format(name))
 
             for state_name, options in phase.state_options.items():
                 timeseries_comp._add_timeseries_output('states:{0}'.format(state_name),
                                                        var_class=phase.classify_var(state_name),
                                                        shape=options['shape'],
                                                        units=options['units'])
-                src_rows = gd.input_maps['state_input_to_disc']
-                src_idxs = get_src_indices_by_row(src_rows, options['shape'])
-                phase.connect(src_name='states:{0}'.format(state_name),
-                              tgt_name='{0}.input_values:states:{1}'.format(name, state_name),
-                              src_indices=src_idxs, flat_src_indices=True)
 
-                rate_src, src_idxs = self.get_rate_source_path(state_name, 'all', phase)
                 timeseries_comp._add_timeseries_output('state_rates:{0}'.format(state_name),
                                                        var_class=phase.classify_var(options['rate_source']),
                                                        shape=options['shape'],
                                                        units=get_rate_units(options['units'], time_units))
-                phase.connect(src_name=rate_src,
-                              tgt_name='{0}.input_values:state_rates:{1}'.format(name, state_name),
-                              src_indices=src_idxs, flat_src_indices=True)
 
             for control_name, options in phase.control_options.items():
                 control_units = options['units']
@@ -346,21 +381,14 @@ class Radau(PseudospectralBase):
                                                        var_class=phase.classify_var(control_name),
                                                        shape=options['shape'],
                                                        units=control_units)
-                src_rows = gd.subset_node_indices['all']
-                src_idxs = get_src_indices_by_row(src_rows, options['shape'])
-                phase.connect(src_name='control_values:{0}'.format(control_name),
-                              tgt_name='{0}.input_values:controls:{1}'.format(name, control_name),
-                              src_indices=src_idxs, flat_src_indices=True)
 
-                # # Control rates
+                # Control rates
                 timeseries_comp._add_timeseries_output('control_rates:{0}_rate'.format(control_name),
                                                        var_class=phase.classify_var(control_name),
                                                        shape=options['shape'],
                                                        units=get_rate_units(control_units,
                                                                             time_units,
                                                                             deriv=1))
-                phase.connect(src_name='control_rates:{0}_rate'.format(control_name),
-                              tgt_name='{0}.input_values:control_rates:{1}_rate'.format(name, control_name))
 
                 # Control second derivatives
                 timeseries_comp._add_timeseries_output('control_rates:{0}_rate2'.format(control_name),
@@ -369,8 +397,6 @@ class Radau(PseudospectralBase):
                                                        units=get_rate_units(control_units,
                                                                             time_units,
                                                                             deriv=2))
-                phase.connect(src_name='control_rates:{0}_rate2'.format(control_name),
-                              tgt_name='{0}.input_values:control_rates:{1}_rate2'.format(name, control_name))
 
             for control_name, options in phase.polynomial_control_options.items():
                 control_units = options['units']
@@ -378,23 +404,14 @@ class Radau(PseudospectralBase):
                                                        var_class=phase.classify_var(control_name),
                                                        shape=options['shape'],
                                                        units=control_units)
-                src_rows = gd.subset_node_indices['all']
-                src_idxs = get_src_indices_by_row(src_rows, options['shape'])
-                phase.connect(src_name='polynomial_control_values:{0}'.format(control_name),
-                              tgt_name='{0}.input_values:'
-                                       'polynomial_controls:{1}'.format(name, control_name),
-                              src_indices=src_idxs, flat_src_indices=True)
 
-                # # Control rates
+                # Control rates
                 timeseries_comp._add_timeseries_output('polynomial_control_rates:{0}_rate'.format(control_name),
                                                        var_class=phase.classify_var(control_name),
                                                        shape=options['shape'],
                                                        units=get_rate_units(control_units,
                                                                             time_units,
                                                                             deriv=1))
-                phase.connect(src_name='polynomial_control_rates:{0}_rate'.format(control_name),
-                              tgt_name='{0}.input_values:polynomial_control_rates:'
-                                       '{1}_rate'.format(name, control_name))
 
                 # Control second derivatives
                 timeseries_comp._add_timeseries_output('polynomial_control_rates:'
@@ -404,9 +421,6 @@ class Radau(PseudospectralBase):
                                                        units=get_rate_units(control_units,
                                                                             time_units,
                                                                             deriv=2))
-                phase.connect(src_name='polynomial_control_rates:{0}_rate2'.format(control_name),
-                              tgt_name='{0}.input_values:polynomial_control_rates:'
-                                       '{1}_rate2'.format(name, control_name))
 
             for param_name, options in phase.design_parameter_options.items():
                 if options['include_timeseries']:
@@ -416,6 +430,93 @@ class Radau(PseudospectralBase):
                                                            shape=options['shape'],
                                                            units=units)
 
+            for param_name, options in phase.input_parameter_options.items():
+                if options['include_timeseries']:
+                    units = options['units']
+                    timeseries_comp._add_timeseries_output('input_parameters:{0}'.format(param_name),
+                                                           var_class=phase.classify_var(param_name),
+                                                           shape=options['shape'],
+                                                           units=units)
+
+            for var, options in phase._timeseries[name]['outputs'].items():
+                output_name = options['output_name']
+
+                # Determine the path to the variable which we will be constraining
+                # This is more complicated for path constraints since, for instance,
+                # a single state variable has two sources which must be connected to
+                # the path component.
+                var_type = phase.classify_var(var)
+
+                # Ignore any variables that we've already added (states, times, controls, etc)
+                if var_type != 'ode':
+                    continue
+
+                # Assume scalar shape here if None, but check config will warn that it's inferred.
+                if options['shape'] is None:
+                    options['shape'] = (1,)
+
+                kwargs = options.copy()
+                kwargs.pop('output_name', None)
+                timeseries_comp._add_timeseries_output(output_name, var_type, **kwargs)
+
+    def configure_timeseries_outputs(self, phase):
+        gd = self.grid_data
+        time_units = phase.time_options['units']
+
+        for name, options in phase._timeseries.items():
+            phase.connect(src_name='time', tgt_name='{0}.input_values:time'.format(name))
+
+            phase.connect(src_name='time_phase', tgt_name='{0}.input_values:time_phase'.format(name))
+
+            for state_name, options in phase.state_options.items():
+                src_rows = gd.input_maps['state_input_to_disc']
+                src_idxs = get_src_indices_by_row(src_rows, options['shape'])
+                phase.connect(src_name='states:{0}'.format(state_name),
+                              tgt_name='{0}.input_values:states:{1}'.format(name, state_name),
+                              src_indices=src_idxs, flat_src_indices=True)
+
+                rate_src, src_idxs = self.get_rate_source_path(state_name, 'all', phase)
+                phase.connect(src_name=rate_src,
+                              tgt_name='{0}.input_values:state_rates:{1}'.format(name, state_name),
+                              src_indices=src_idxs, flat_src_indices=True)
+
+            for control_name, options in phase.control_options.items():
+                control_units = options['units']
+                src_rows = gd.subset_node_indices['all']
+                src_idxs = get_src_indices_by_row(src_rows, options['shape'])
+                phase.connect(src_name='control_values:{0}'.format(control_name),
+                              tgt_name='{0}.input_values:controls:{1}'.format(name, control_name),
+                              src_indices=src_idxs, flat_src_indices=True)
+
+                # Control rates
+                phase.connect(src_name='control_rates:{0}_rate'.format(control_name),
+                              tgt_name='{0}.input_values:control_rates:{1}_rate'.format(name, control_name))
+
+                # Control second derivatives
+                phase.connect(src_name='control_rates:{0}_rate2'.format(control_name),
+                              tgt_name='{0}.input_values:control_rates:{1}_rate2'.format(name, control_name))
+
+            for control_name, options in phase.polynomial_control_options.items():
+                control_units = options['units']
+                src_rows = gd.subset_node_indices['all']
+                src_idxs = get_src_indices_by_row(src_rows, options['shape'])
+                phase.connect(src_name='polynomial_control_values:{0}'.format(control_name),
+                              tgt_name='{0}.input_values:'
+                                       'polynomial_controls:{1}'.format(name, control_name),
+                              src_indices=src_idxs, flat_src_indices=True)
+
+                # Control rates
+                phase.connect(src_name='polynomial_control_rates:{0}_rate'.format(control_name),
+                              tgt_name='{0}.input_values:polynomial_control_rates:'
+                                       '{1}_rate'.format(name, control_name))
+
+                # Control second derivatives
+                phase.connect(src_name='polynomial_control_rates:{0}_rate2'.format(control_name),
+                              tgt_name='{0}.input_values:polynomial_control_rates:'
+                                       '{1}_rate2'.format(name, control_name))
+
+            for param_name, options in phase.design_parameter_options.items():
+                if options['include_timeseries']:
                     src_idxs_raw = np.zeros(gd.subset_num_nodes['all'], dtype=int)
                     src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
 
@@ -425,12 +526,6 @@ class Radau(PseudospectralBase):
 
             for param_name, options in phase.input_parameter_options.items():
                 if options['include_timeseries']:
-                    units = options['units']
-                    timeseries_comp._add_timeseries_output('input_parameters:{0}'.format(param_name),
-                                                           var_class=phase.classify_var(param_name),
-                                                           shape=options['shape'],
-                                                           units=units)
-
                     src_idxs_raw = np.zeros(gd.subset_num_nodes['all'], dtype=int)
                     src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
 
@@ -458,10 +553,6 @@ class Radau(PseudospectralBase):
                 # Failed to find variable, assume it is in the ODE
                 phase.connect(src_name='rhs_all.{0}'.format(var),
                               tgt_name='{0}.input_values:{1}'.format(name, output_name))
-
-                kwargs = options.copy()
-                kwargs.pop('output_name', None)
-                timeseries_comp._add_timeseries_output(output_name, var_type, **kwargs)
 
     def get_rate_source_path(self, state_name, nodes, phase):
         gd = self.grid_data

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -80,6 +80,12 @@ class SolveIVP(TranscriptionBase):
 
         phase.add_subsystem('time', time_comp, promotes=['*'])
 
+    def configure_time(self, phase):
+        time_options = phase.time_options
+        num_seg = self.grid_data.num_segments
+        grid_data = self.grid_data
+        output_nodes_per_seg = self.options['output_nodes_per_seg']
+
         for i in range(num_seg):
             phase.connect('t_initial', 'segment_{0}.t_initial'.format(i))
             phase.connect('t_duration', 'segment_{0}.t_duration'.format(i))
@@ -113,8 +119,6 @@ class SolveIVP(TranscriptionBase):
         """
         Add an IndepVarComp for the states and setup the states as design variables.
         """
-        num_seg = self.grid_data.num_segments
-
         indep_states_ivc = phase.add_subsystem('indep_states', om.IndepVarComp(),
                                                promotes_outputs=['*'])
 
@@ -123,6 +127,10 @@ class SolveIVP(TranscriptionBase):
                                         val=np.ones(((1,) + options['shape'])),
                                         units=options['units'])
 
+    def configure_states(self, phase):
+        num_seg = self.grid_data.num_segments
+
+        for state_name, options in phase.state_options.items():
             # Connect the initial state to the first segment
             src_idxs = get_src_indices_by_row([0], options['shape'])
 
@@ -194,8 +202,10 @@ class SolveIVP(TranscriptionBase):
         phase.add_subsystem('ode', phase.options['ode_class'](num_nodes=num_output_nodes,
                                                               **phase.options['ode_init_kwargs']))
 
+    def configure_ode(self, phase):
+        pass
+
     def setup_controls(self, phase):
-        grid_data = self.grid_data
         output_nodes_per_seg = self.options['output_nodes_per_seg']
 
         phase._check_control_options()
@@ -210,6 +220,11 @@ class SolveIVP(TranscriptionBase):
                                 subsys=control_group,
                                 promotes=['controls:*', 'control_values:*', 'control_values_all:*',
                                           'control_rates:*'])
+
+    def configure_controls(self, phase):
+        grid_data = self.grid_data
+
+        if phase.control_options:
             phase.connect('dt_dstau', 'control_group.dt_dstau')
 
         for name, options in phase.control_options.items():
@@ -292,26 +307,42 @@ class SolveIVP(TranscriptionBase):
         """
         pass
 
+    def configure_defects(self, phase):
+        pass
+
     def setup_objective(self, phase):
+        pass
+
+    def configure_objective(self, phase):
         pass
 
     def setup_endpoint_conditions(self, phase):
         pass
 
+    def configure_endpoint_conditions(self, phase):
+        pass
+
     def setup_path_constraints(self, phase):
+        pass
+
+    def configure_path_constraints(self, phase):
         pass
 
     def setup_boundary_constraints(self, loc, phase):
         pass
 
+    def configure_boundary_constraints(self, loc, phase):
+        pass
+
     def setup_solvers(self, phase):
+        pass
+
+    def configure_solvers(self, phase):
         pass
 
     def setup_timeseries_outputs(self, phase):
         gd = self.grid_data
-        num_seg = gd.num_segments
         time_units = phase.time_options['units']
-        output_nodes_per_seg = self.options['output_nodes_per_seg']
 
         timeseries_comp = \
             SolveIVPTimeseriesOutputComp(input_grid_data=gd,
@@ -323,20 +354,15 @@ class SolveIVP(TranscriptionBase):
                                                var_class='time',
                                                units=time_units)
 
-        phase.connect(src_name='time', tgt_name='timeseries.all_values:time')
-
         timeseries_comp._add_timeseries_output('time_phase',
                                                var_class=phase.classify_var('time_phase'),
                                                units=time_units)
-        phase.connect(src_name='time_phase', tgt_name='timeseries.all_values:time_phase')
 
         for name, options in phase.state_options.items():
             timeseries_comp._add_timeseries_output('states:{0}'.format(name),
                                                    var_class=phase.classify_var(name),
                                                    shape=options['shape'],
                                                    units=options['units'])
-            phase.connect(src_name='state_mux_comp.states:{0}'.format(name),
-                          tgt_name='timeseries.all_values:states:{0}'.format(name))
 
         for name, options in phase.control_options.items():
             control_units = options['units']
@@ -345,9 +371,6 @@ class SolveIVP(TranscriptionBase):
                                                    shape=options['shape'],
                                                    units=control_units)
 
-            phase.connect(src_name='control_values:{0}'.format(name),
-                          tgt_name='timeseries.all_values:controls:{0}'.format(name))
-
             # # Control rates
             timeseries_comp._add_timeseries_output('control_rates:{0}_rate'.format(name),
                                                    var_class=phase.classify_var(name),
@@ -355,8 +378,6 @@ class SolveIVP(TranscriptionBase):
                                                    units=get_rate_units(control_units,
                                                                         time_units,
                                                                         deriv=1))
-            phase.connect(src_name='control_rates:{0}_rate'.format(name),
-                          tgt_name='timeseries.all_values:control_rates:{0}_rate'.format(name))
 
             # Control second derivatives
             timeseries_comp._add_timeseries_output('control_rates:{0}_rate2'.format(name),
@@ -365,8 +386,6 @@ class SolveIVP(TranscriptionBase):
                                                    units=get_rate_units(control_units,
                                                                         time_units,
                                                                         deriv=2))
-            phase.connect(src_name='control_rates:{0}_rate2'.format(name),
-                          tgt_name='timeseries.all_values:control_rates:{0}_rate2'.format(name))
 
         for name, options in phase.polynomial_control_options.items():
             control_units = options['units']
@@ -374,9 +393,6 @@ class SolveIVP(TranscriptionBase):
                                                    var_class=phase.classify_var(name),
                                                    shape=options['shape'],
                                                    units=control_units)
-            src_rows = gd.subset_node_indices['segment_ends']
-            phase.connect(src_name='polynomial_control_values:{0}'.format(name),
-                          tgt_name='timeseries.all_values:polynomial_controls:{0}'.format(name))
 
             # Polynomial control rates
             timeseries_comp._add_timeseries_output('polynomial_control_rates:{0}_rate'.format(name),
@@ -385,9 +401,6 @@ class SolveIVP(TranscriptionBase):
                                                    units=get_rate_units(control_units,
                                                                         time_units,
                                                                         deriv=1))
-            phase.connect(src_name='polynomial_control_rates:{0}_rate'.format(name),
-                          tgt_name='timeseries.all_values:polynomial_control_rates'
-                                   ':{0}_rate'.format(name))
 
             # Polynomial control second derivatives
             timeseries_comp._add_timeseries_output('polynomial_control_rates:'
@@ -397,9 +410,6 @@ class SolveIVP(TranscriptionBase):
                                                    units=get_rate_units(control_units,
                                                                         time_units,
                                                                         deriv=2))
-            phase.connect(src_name='polynomial_control_rates:{0}_rate2'.format(name),
-                          tgt_name='timeseries.all_values:polynomial_control_rates'
-                                   ':{0}_rate2'.format(name))
 
         for name, options in phase.design_parameter_options.items():
             if options['include_timeseries']:
@@ -409,6 +419,77 @@ class SolveIVP(TranscriptionBase):
                                                        shape=options['shape'],
                                                        units=units)
 
+        for name, options in phase.input_parameter_options.items():
+            if options['include_timeseries']:
+                units = options['units']
+                timeseries_comp._add_timeseries_output('input_parameters:{0}'.format(name),
+                                                       var_class=phase.classify_var(name),
+                                                       shape=options['shape'],
+                                                       units=units)
+
+        for var, options in phase._timeseries['timeseries']['outputs'].items():
+            output_name = options['output_name']
+
+            # Determine the path to the variable which we will be constraining
+            # This is more complicated for path constraints since, for instance,
+            # a single state variable has two sources which must be connected to
+            # the path component.
+            var_type = phase.classify_var(var)
+
+            # Ignore any variables that we've already added (states, times, controls, etc)
+            if var_type != 'ode':
+                continue
+
+            kwargs = options.copy()
+            kwargs.pop('output_name', None)
+            timeseries_comp._add_timeseries_output(output_name, var_type, **kwargs)
+
+    def configure_timeseries_outputs(self, phase):
+        gd = self.grid_data
+        num_seg = gd.num_segments
+        time_units = phase.time_options['units']
+        output_nodes_per_seg = self.options['output_nodes_per_seg']
+
+        timeseries_comp = \
+            SolveIVPTimeseriesOutputComp(input_grid_data=gd,
+                                         output_nodes_per_seg=self.options['output_nodes_per_seg'])
+
+        phase.connect(src_name='time', tgt_name='timeseries.all_values:time')
+
+        phase.connect(src_name='time_phase', tgt_name='timeseries.all_values:time_phase')
+
+        for name, options in phase.state_options.items():
+            phase.connect(src_name='state_mux_comp.states:{0}'.format(name),
+                          tgt_name='timeseries.all_values:states:{0}'.format(name))
+
+        for name, options in phase.control_options.items():
+            phase.connect(src_name='control_values:{0}'.format(name),
+                          tgt_name='timeseries.all_values:controls:{0}'.format(name))
+
+            # Control rates
+            phase.connect(src_name='control_rates:{0}_rate'.format(name),
+                          tgt_name='timeseries.all_values:control_rates:{0}_rate'.format(name))
+
+            # Control second derivatives
+            phase.connect(src_name='control_rates:{0}_rate2'.format(name),
+                          tgt_name='timeseries.all_values:control_rates:{0}_rate2'.format(name))
+
+        for name, options in phase.polynomial_control_options.items():
+            phase.connect(src_name='polynomial_control_values:{0}'.format(name),
+                          tgt_name='timeseries.all_values:polynomial_controls:{0}'.format(name))
+
+            # Polynomial control rates
+            phase.connect(src_name='polynomial_control_rates:{0}_rate'.format(name),
+                          tgt_name='timeseries.all_values:polynomial_control_rates'
+                                   ':{0}_rate'.format(name))
+
+            # Polynomial control second derivatives
+            phase.connect(src_name='polynomial_control_rates:{0}_rate2'.format(name),
+                          tgt_name='timeseries.all_values:polynomial_control_rates'
+                                   ':{0}_rate2'.format(name))
+
+        for name, options in phase.design_parameter_options.items():
+            if options['include_timeseries']:
                 if output_nodes_per_seg is None:
                     src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
                 else:
@@ -421,12 +502,6 @@ class SolveIVP(TranscriptionBase):
 
         for name, options in phase.input_parameter_options.items():
             if options['include_timeseries']:
-                units = options['units']
-                timeseries_comp._add_timeseries_output('input_parameters:{0}'.format(name),
-                                                       var_class=phase.classify_var(name),
-                                                       shape=options['shape'],
-                                                       units=units)
-
                 if output_nodes_per_seg is None:
                     src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
                 else:
@@ -454,10 +529,6 @@ class SolveIVP(TranscriptionBase):
             # Failed to find variable, assume it is in the RHS
             phase.connect(src_name='ode.{0}'.format(var),
                           tgt_name='timeseries.all_values:{0}'.format(output_name))
-
-            kwargs = options.copy()
-            kwargs.pop('output_name', None)
-            timeseries_comp._add_timeseries_output(output_name, var_type, **kwargs)
 
     def get_parameter_connections(self, name, phase):
         """

--- a/dymos/utils/misc.py
+++ b/dymos/utils/misc.py
@@ -2,6 +2,8 @@ import sys
 
 import numpy as np
 
+_unspecified = object()
+
 
 def get_rate_units(units, time_units, deriv=1):
     """


### PR DESCRIPTION
### Summary

This is the first part of #318: States, controls, and parameters try to connect to inputs of their name in the ODE by default. 

Checking to see if a name is in the ODE must be done after setup completes, and changing targets must be done before connect is called. This merge request move all connect calls out of setup routines and into configure, so that a future ODE check check can be at the beginning of configure. 

A lot of code is moved around, but there should be no change in behavior.

### Related Issues

- Resolves #

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
