### PR TITLE
Fix command line tests due to updates in the case recorder and reader in OpenMDAO.

### DIFF
--- a/dymos/utils/test/test_command_line.py
+++ b/dymos/utils/test/test_command_line.py
@@ -53,7 +53,7 @@ class TestCommandLine(unittest.TestCase):
 
         self.assertTrue(os.path.exists('dymos_solution.db'))
         cr = om.CaseReader('dymos_solution.db')
-        self.assertTrue(len(cr.list_cases()) == 0)  # no case recorded
+        self.assertTrue(len(cr.list_cases()) == 1)
 
     def test_ex_brachistochrone_iteration(self):
         print('test_ex_brachistochrone_iteration')
@@ -82,12 +82,9 @@ class TestCommandLine(unittest.TestCase):
         with patch.object(sys, 'argv', self.base_args + ['--no_solve']):
             command_line.dymos_cmd()
 
-        # Until the problem recorder is fixed, the driver recorder shouldn't be
-        # invoked by this test, and thus we won't get a dymos_solution.db file
-
         self.assertTrue(os.path.exists('dymos_solution.db'))
         cr = om.CaseReader('dymos_solution.db')
-        self.assertTrue(len(cr.list_cases()) == 0)  # no case recorded
+        self.assertTrue(len(cr.list_cases()) == 1)
 
     def test_ex_brachistochrone_simulate(self):
         print('test_ex_brachistochrone_simulate')


### PR DESCRIPTION
### Summary

Fixes command line tests so that they test for the correct number of cases present when using option `--no_solve`.

### Related Issues

- Resolves #330

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
