### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,10 +43,10 @@ integrated.
 
     class BrachistochroneEOM(ExplicitComponent):
         def initialize(self):
-            self.metadata.declare('num_nodes', types=int)
+            self.options.declare('num_nodes', types=int)
 
         def setup(self):
-            nn = self.metadata['num_nodes']
+            nn = self.options['num_nodes']
 
             # Inputs
             self.add_input('v',
@@ -85,7 +85,7 @@ integrated.
                             units='m/s')
 
             # Setup partials
-            arange = np.arange(self.metadata['num_nodes'])
+            arange = np.arange(self.options['num_nodes'])
 
             self.declare_partials(of='vdot', wrt='g', rows=arange, cols=arange, val=1.0)
             self.declare_partials(of='vdot', wrt='theta', rows=arange, cols=arange, val=1.0)


### PR DESCRIPTION
With `mdao.__version__ == '3.1.1-dev'` I get an AttributeError  as ExplicitComponent object has no attribute 'metadata'. Changing the examples to `self.options.declare` seems to be the correct fix.  For the OpenMDAO change see https://github.com/OpenMDAO/OpenMDAO/pull/606

### Summary

Summary of PR.

### Related Issues

- Resolves #

### Status

- [x] Ready for merge

### Backwards incompatibilities

OpenMDAO prior to https://github.com/OpenMDAO/OpenMDAO/commit/41981fd24d1d97e988caa8496128f16c5294cf86

### New Dependencies

None
