### PR TITLE
fix for change to problem_meta

### DIFF
--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -1910,7 +1910,7 @@ class Phase(om.Group):
         # Assign parameter values
         meta = phs._problem_meta
         prom2abs = meta['prom2abs']
-        conns = meta['connections']
+        conns = meta['model_ref']()._conn_global_abs_in2out
         pname = '{0}parameters:{1}'
         for name in phs.parameter_options:
 

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -737,7 +737,7 @@ class Trajectory(om.Group):
         # Assign trajectory parameter values
         meta = self._problem_meta
         prom2abs = meta['prom2abs']
-        conns = meta['connections']
+        conns = meta['model_ref']()._conn_global_abs_in2out
         param_names = [key for key in self.parameter_options.keys()]
         for name in param_names:
             prom_path = f'traj.parameters:{name}'


### PR DESCRIPTION
### Summary

Dymos was accessing an internal OpenMDAO data structure called _prob_meta that got modified as part of PR #1660.  This update makes dymos compatible with those changes.

### Status

- Should NOT be merged until PR#1660 is merged into OpenMDAO master.

### Backwards incompatibilities

None except what's mentioned above.

### New Dependencies

None
