### PR TITLE
Grid Refinement Fix

### DIFF
--- a/dymos/test/test_run_problem.py
+++ b/dymos/test/test_run_problem.py
@@ -20,7 +20,6 @@ class TestRunProblem(unittest.TestCase):
             if os.path.exists(filename):
                 os.remove(filename)
 
-    @unittest.skip("temporary skip while test is being fixed")
     def test_run_HS_problem_radau(self):
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()


### PR DESCRIPTION
### Summary

Changed interpolation of 2nd derivative to be done at segment level rather than phase level. This fixed an issue where the interpolation could run into singularity errors.

Modified the tolerances when merging segments or reducing their order. This should prevent cyclic behavior where segments are repeatedly merged and then split again.

### Related Issues

- Resolves #393 

### Status

- [X] Ready for merge

