### PR TITLE
Wildcard units

### DIFF
--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -1258,7 +1258,8 @@ class Phase(om.Group):
         self._path_constraints[name]['units'] = units
         self.add_timeseries_output(name, output_name=constraint_name, units=units, shape=shape)
 
-    def add_timeseries_output(self, name, output_name=None, units=None, shape=None, timeseries='timeseries'):
+    def add_timeseries_output(self, name, output_name=None, units=None, shape=None,
+                              timeseries='timeseries', _unit_dict={}):
         r"""
         Add a variable to the timeseries outputs of the phase.
 
@@ -1291,7 +1292,7 @@ class Phase(om.Group):
                 elif type(units) is list:  # allow matching list for units
                     u = units[i]
 
-                self.add_timeseries_output(n, output_name, u, shape, timeseries)
+                self.add_timeseries_output(n, output_name, u, shape, timeseries, units if type(units) is dict else {})
             return
 
         if output_name is None:
@@ -1303,9 +1304,16 @@ class Phase(om.Group):
         if name not in self._timeseries[timeseries]['outputs']:
             self._timeseries[timeseries]['outputs'][name] = {}
             self._timeseries[timeseries]['outputs'][name]['output_name'] = output_name
+            self._timeseries[timeseries]['outputs'][name]['timeseries_units'] = {}
 
         self._timeseries[timeseries]['outputs'][name]['units'] = units
         self._timeseries[timeseries]['outputs'][name]['shape'] = shape
+        for k, v in _unit_dict.items():
+            existing = self._timeseries[timeseries]['outputs'][name]['timeseries_units']
+            if k in existing and existing[k] != v:
+                raise ValueError('Unit mismatch in add_timeseries_output unit dictionary')
+            else:
+                existing[k] = v  # save for ODE wildcard matching
 
     def add_timeseries(self, name, transcription, subset='all'):
         r"""

--- a/dymos/transcriptions/pseudospectral/gauss_lobatto.py
+++ b/dymos/transcriptions/pseudospectral/gauss_lobatto.py
@@ -468,6 +468,7 @@ class GaussLobatto(PseudospectralBase):
             for var, options in phase._timeseries[timeseries_name]['outputs'].items():
                 output_name = options['output_name']
                 units = options.get('units', None)
+                timeseries_units = options.get('timeseries_units', None)
 
                 if '*' in var:  # match outputs from the ODE
                     ode_outputs = {opts['prom_name']: opts for (k, opts) in
@@ -480,6 +481,9 @@ class GaussLobatto(PseudospectralBase):
                     if '*' in var:
                         output_name = v.split('.')[-1]
                         units = ode_outputs[v]['units']
+                        # check for timeseries_units override of ODE units
+                        if v in timeseries_units:
+                            units = timeseries_units[v]
 
                     # Determine the path to the variable which we will be constraining
                     # This is more complicated for path constraints since, for instance,

--- a/dymos/transcriptions/pseudospectral/gauss_lobatto.py
+++ b/dymos/transcriptions/pseudospectral/gauss_lobatto.py
@@ -479,6 +479,7 @@ class GaussLobatto(PseudospectralBase):
                 for v in matches:
                     if '*' in var:
                         output_name = v.split('.')[-1]
+                        units = ode_outputs[v]['units']
 
                     # Determine the path to the variable which we will be constraining
                     # This is more complicated for path constraints since, for instance,
@@ -492,7 +493,7 @@ class GaussLobatto(PseudospectralBase):
 
                     try:
                         shape, units = get_source_metadata(phase.rhs_disc, src=v,
-                                                           user_units=options['units'],
+                                                           user_units=units,
                                                            user_shape=options['shape'])
                     except ValueError:
                         raise ValueError(f'Timeseries output {v} is not a known variable in'

--- a/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
+++ b/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
@@ -358,6 +358,7 @@ class Radau(PseudospectralBase):
             for var, options in phase._timeseries[timeseries_name]['outputs'].items():
                 output_name = options['output_name']
                 units = options.get('units', None)
+                timeseries_units = options.get('timeseries_units', None)
 
                 if '*' in var:  # match outputs from the ODE
                     ode_outputs = {opts['prom_name']: opts for (k, opts) in
@@ -370,6 +371,9 @@ class Radau(PseudospectralBase):
                     if '*' in var:
                         output_name = v.split('.')[-1]
                         units = ode_outputs[v]['units']
+                        # check for timeseries_units override of ODE units
+                        if v in timeseries_units:
+                            units = timeseries_units[v]
 
                     # Determine the path to the variable which we will be constraining
                     # This is more complicated for path constraints since, for instance,

--- a/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
+++ b/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
@@ -357,6 +357,7 @@ class Radau(PseudospectralBase):
 
             for var, options in phase._timeseries[timeseries_name]['outputs'].items():
                 output_name = options['output_name']
+                units = options.get('units', None)
 
                 if '*' in var:  # match outputs from the ODE
                     ode_outputs = {opts['prom_name']: opts for (k, opts) in
@@ -368,6 +369,7 @@ class Radau(PseudospectralBase):
                 for v in matches:
                     if '*' in var:
                         output_name = v.split('.')[-1]
+                        units = ode_outputs[v]['units']
 
                     # Determine the path to the variable which we will be constraining
                     # This is more complicated for path constraints since, for instance,
@@ -381,7 +383,7 @@ class Radau(PseudospectralBase):
 
                     try:
                         shape, units = get_source_metadata(phase.rhs_all, src=v,
-                                                           user_units=options['units'],
+                                                           user_units=units,
                                                            user_shape=options['shape'])
                     except ValueError:
                         raise ValueError(f'Timeseries output {v} is not a known variable in'

--- a/dymos/transcriptions/runge_kutta/runge_kutta.py
+++ b/dymos/transcriptions/runge_kutta/runge_kutta.py
@@ -791,6 +791,7 @@ class RungeKutta(TranscriptionBase):
 
             for var, options in timeseries_options['outputs'].items():
                 output_name = options['output_name']
+                units = options.get('units', None)
 
                 if '*' in var:  # match outputs from the ODE
                     ode_outputs = {opts['prom_name']: opts for (k, opts) in
@@ -802,6 +803,7 @@ class RungeKutta(TranscriptionBase):
                 for v in matches:
                     if '*' in var:
                         output_name = v.split('.')[-1]
+                        units = ode_outputs[v]['units']
 
                     # Determine the path to the variable which we will be constraining
                     # This is more complicated for path constraints since, for instance,
@@ -815,7 +817,7 @@ class RungeKutta(TranscriptionBase):
 
                     try:
                         shape, units = get_source_metadata(phase.ode, src=v,
-                                                           user_units=options['units'],
+                                                           user_units=units,
                                                            user_shape=options['shape'])
                     except ValueError:
                         raise ValueError(f'Timeseries output {v} is not a known variable in'

--- a/dymos/transcriptions/runge_kutta/runge_kutta.py
+++ b/dymos/transcriptions/runge_kutta/runge_kutta.py
@@ -792,6 +792,7 @@ class RungeKutta(TranscriptionBase):
             for var, options in timeseries_options['outputs'].items():
                 output_name = options['output_name']
                 units = options.get('units', None)
+                timeseries_units = options.get('timeseries_units', None)
 
                 if '*' in var:  # match outputs from the ODE
                     ode_outputs = {opts['prom_name']: opts for (k, opts) in
@@ -804,6 +805,9 @@ class RungeKutta(TranscriptionBase):
                     if '*' in var:
                         output_name = v.split('.')[-1]
                         units = ode_outputs[v]['units']
+                        # check for timeseries_units override of ODE units
+                        if v in timeseries_units:
+                            units = timeseries_units[v]
 
                     # Determine the path to the variable which we will be constraining
                     # This is more complicated for path constraints since, for instance,

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -477,6 +477,7 @@ class SolveIVP(TranscriptionBase):
 
         for var, options in phase._timeseries['timeseries']['outputs'].items():
             output_name = options['output_name']
+            units = options.get('units', None)
 
             if '*' in var:  # match outputs from the ODE
                 ode_outputs = {opts['prom_name']: opts for (k, opts) in
@@ -488,6 +489,7 @@ class SolveIVP(TranscriptionBase):
             for v in matches:
                 if '*' in var:
                     output_name = v.split('.')[-1]
+                    units = ode_outputs[v]['units']
 
                 # Determine the path to the variable which we will be constraining
                 # This is more complicated for path constraints since, for instance,
@@ -500,7 +502,7 @@ class SolveIVP(TranscriptionBase):
                     continue
 
                 shape, units = get_source_metadata(phase.ode, src=v, user_shape=options['shape'],
-                                                   user_units=options['units'])
+                                                   user_units=units)
 
                 try:
                     timeseries_comp._add_output_configure(output_name, shape=shape, units=units, desc='')

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -478,6 +478,7 @@ class SolveIVP(TranscriptionBase):
         for var, options in phase._timeseries['timeseries']['outputs'].items():
             output_name = options['output_name']
             units = options.get('units', None)
+            timeseries_units = options.get('timeseries_units', None)
 
             if '*' in var:  # match outputs from the ODE
                 ode_outputs = {opts['prom_name']: opts for (k, opts) in
@@ -490,6 +491,9 @@ class SolveIVP(TranscriptionBase):
                 if '*' in var:
                     output_name = v.split('.')[-1]
                     units = ode_outputs[v]['units']
+                    # check for timeseries_units override of ODE units
+                    if v in timeseries_units:
+                        units = timeseries_units[v]
 
                 # Determine the path to the variable which we will be constraining
                 # This is more complicated for path constraints since, for instance,


### PR DESCRIPTION
### Summary

This PR fixes the missing units for add_time_series_output calls with wildcards, and it fixes a bad interaction between mixing wildcards and units dictionaries.

### Related Issues

- Resolves #395

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
