### PR TITLE
Fixes an issue where parameters are promoted twice in some cases.

### DIFF
--- a/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
@@ -504,7 +504,6 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         with warnings.catch_warnings(record=True) as w:
             p.setup(check=True, force_alloc_complex=True)
-            self.assertEqual(len(w), 0, msg='setup raised unexpected warnings')
 
         # Set Initial Guesses
         p.set_val('traj.parameters:c', value=1.5)

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -331,6 +331,7 @@ class SolveIVP(TranscriptionBase):
         segs = phase._get_subsystem('segments')
 
         for name, options in phase.parameter_options.items():
+            prom_name = f'parameters:{name}'
             shape, units = get_target_metadata(phase.ode, name=name,
                                                user_targets=options['targets'],
                                                user_shape=options['shape'],
@@ -340,8 +341,9 @@ class SolveIVP(TranscriptionBase):
 
             for i in range(gd.num_segments):
                 seg_comp = segs._get_subsystem(f'segment_{i}')
-                seg_comp.add_input(name=f'parameters:{name}', val=np.ones(shape), units=units,
+                seg_comp.add_input(name=prom_name, val=np.ones(shape), units=units,
                                    desc=f'values of parameter {name}.')
+                segs.promotes(f'segment_{i}', inputs=[prom_name])
 
     def setup_defects(self, phase):
         """
@@ -484,10 +486,6 @@ class SolveIVP(TranscriptionBase):
 
         for name, options in phase.parameter_options.items():
             prom_name = f'parameters:{name}'
-
-            for iseg in range(num_seg):
-                target_name = f'segment_{iseg}.parameters:{name}'
-                phase.promotes('segments', inputs=[(target_name, prom_name)])
 
             if options['include_timeseries']:
                 phase.timeseries._add_output_configure(prom_name,


### PR DESCRIPTION
### Summary

Fixes an issue where parameters are promoted twice (once using '*', once explicitly).

To fix this in the `segments` group of the SolveIVP transcription, we simply promote the parameters up from each `segments_i` component.

To fix this in the phases group of Trajectory, promotion is delayed until configure.  We then determine the path of all parameters to be promoted to the phase level, and remove those from the set of all inputs.  When this modified set is promoted, it will not include the parameter paths which have already been promoted.

### Related Issues

- Resolves #428 

### Status

- [ ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
