### PR TITLE
updated JOSS paper citation for pyoptsparse

### DIFF
--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -119,17 +119,20 @@ eprint = {https://arc.aiaa.org/doi/pdf/10.2514/6.2018-3884},
 year = {2018}
 }
 
-@article{Perez2012a,
-	Author = {Ruben E. Perez and Peter W. Jansen and Joaquim R. R. A. Martins},
-	Doi = {10.1007/s00158-011-0666-3},
-	Journal = {Structural and Multidisciplinary Optimization},
-	Month = {January},
-	Number = {1},
-	Pages = {101--118},
-	Title = {{pyOpt}: A {Python}-Based Object-Oriented Framework for Nonlinear Constrained Optimization},
-	Volume = {45},
-	Year = {2012},
-	Annote = {10.1007/s00158-011-0666-3}}
+@article{Wu_pyoptsparse_2020,
+    author = {Neil Wu and Gaetan Kenway and Charles A. Mader and John Jasa and
+     Joaquim R. R. A. Martins},
+    title = {{pyOptSparse:} A {Python} framework for large-scale constrained
+     nonlinear optimization of sparse systems},
+    journal = {Journal of Open Source Software},
+    volume = {5},
+    number = {54},
+    month = {October},
+    year = {2020},
+    pages = {2564},
+    doi = {10.21105/joss.02564},
+    publisher = {The Open Journal},
+}
 
 @article {GilMS05,
  AUTHOR = {Gill, Philip E. and Murray, Walter and Saunders, Michael A.},

--- a/joss/paper.md
+++ b/joss/paper.md
@@ -76,7 +76,7 @@ This means that switching transcriptions requires very minor code changes - typi
 Dymos does not ship with its own built in optimizer. 
 It relies on whatever optimizers you have available in your OpenMDAO installation. 
 OpenMDAO ships with an interface to the optimizers in SciPy [@2020SciPy-NMeth], 
-and an additional wrapper for the pyoptsparse [@Perez2012a] library which has more powerful optimizer options such as SNOPT [@GilMS05] and IPOPT [@wachter2006].
+and an additional wrapper for the pyoptsparse [@Wu_pyoptsparse_2020] library which has more powerful optimizer options such as SNOPT [@GilMS05] and IPOPT [@wachter2006].
 OpenMDAO also allows users to integrate their own optimizer of choice, which Dymos can then seamlessly use with without any additional modifications.
 For simple problems, Scipy's SLSQP optimizer generally works fine.
 On more challenging optimal-control problems, higher quality optimizers are important for getting good performance.


### PR DESCRIPTION
### Summary

Updated the JOSS citation from pyopt to the recently published pyoptsparse paper.

### Related Issues

None

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
