### PR TITLE
run_problem now automatically attaches a problem recorder and saves results when complete

### DIFF
--- a/dymos/examples/aircraft_steady_flight/doc/test_doc_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/doc/test_doc_aircraft_steady_flight.py
@@ -5,9 +5,11 @@ import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
 from openmdao.utils.general_utils import set_pyoptsparse_opt
+from openmdao.utils.testing_utils import use_tempdirs
 from dymos.utils.doc_utils import save_for_docs
 
 
+@use_tempdirs
 class TestSteadyAircraftFlightForDocs(unittest.TestCase):
 
     @classmethod
@@ -31,7 +33,8 @@ class TestSteadyAircraftFlightForDocs(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()
-        p.driver.options['optimizer'] = 'SLSQP'
+        _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
+        p.driver.options['optimizer'] = optimizer
         p.driver.declare_coloring()
 
         num_seg = 15

--- a/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
@@ -3,6 +3,7 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos.examples.aircraft_steady_flight.aircraft_ode import AircraftODE
@@ -15,6 +16,7 @@ except:
     MBI = None
 
 
+@use_tempdirs
 class TestAircraftCruise(unittest.TestCase):
 
     def test_cruise_results_gl(self):

--- a/dymos/examples/aircraft_steady_flight/test/test_ex_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_ex_aircraft_steady_flight.py
@@ -3,6 +3,7 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.general_utils import set_pyoptsparse_opt
+from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.assert_utils import assert_near_equal
 
 import dymos as dm
@@ -108,6 +109,7 @@ def ex_aircraft_steady_flight(optimizer='SLSQP', solve_segments=False,
     return p
 
 
+@use_tempdirs
 class TestExSteadyAircraftFlight(unittest.TestCase):
 
     @classmethod

--- a/dymos/examples/battery_multibranch/test/test_multibranch_trajectory.py
+++ b/dymos/examples/battery_multibranch/test/test_multibranch_trajectory.py
@@ -6,6 +6,7 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos.examples.battery_multibranch.battery_multibranch_ode import BatteryODE
@@ -14,6 +15,7 @@ from dymos.utils.lgl import lgl
 optimizer = os.environ.get('DYMOS_DEFAULT_OPT', 'SLSQP')
 
 
+@use_tempdirs
 class TestBatteryBranchingPhases(unittest.TestCase):
 
     def test_optimizer_defects(self):
@@ -371,6 +373,7 @@ class TestBatteryBranchingPhases(unittest.TestCase):
         assert_near_equal(soc1m[-1], 0.18625395, 1e-6)
 
 
+@use_tempdirs
 class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
 
     def test_constraint_linkages_rk(self):

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
@@ -9,9 +9,11 @@ plt.style.use('ggplot')
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
 
+from openmdao.utils.testing_utils import use_tempdirs
 from dymos.utils.doc_utils import save_for_docs
 
 
+@use_tempdirs
 class TestBrachistochroneForDocs(unittest.TestCase):
 
     def tearDown(self):

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_tandem_phases.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_tandem_phases.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 import openmdao.api as om
 from dymos.utils.doc_utils import save_for_docs
+from openmdao.utils.testing_utils import use_tempdirs
 
 
 class BrachistochroneArclengthODE(om.ExplicitComponent):
@@ -43,6 +44,7 @@ class BrachistochroneArclengthODE(om.ExplicitComponent):
             (np.sqrt(1 + cot_theta**2))
 
 
+@use_tempdirs
 class TestBrachistochroneTandemPhases(unittest.TestCase):
 
     @save_for_docs

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_implicit_recorder.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_implicit_recorder.py
@@ -3,6 +3,7 @@ import unittest
 from openmdao.utils.testing_utils import use_tempdirs
 
 
+@use_tempdirs
 class TestBrachistochroneRecordingExample(unittest.TestCase):
 
     @classmethod
@@ -11,7 +12,6 @@ class TestBrachistochroneRecordingExample(unittest.TestCase):
             if os.path.exists(filename):
                 os.remove(filename)
 
-    @use_tempdirs
     def test_brachistochrone_recording(self):
         import matplotlib
         matplotlib.use('Agg')

--- a/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
+++ b/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
@@ -3,9 +3,11 @@ import unittest
 import matplotlib.pyplot as plt
 plt.switch_backend('Agg')
 
+from openmdao.utils.testing_utils import use_tempdirs
 from dymos.utils.doc_utils import save_for_docs
 
 
+@use_tempdirs
 class TestTwoPhaseCannonballForDocs(unittest.TestCase):
 
     @save_for_docs

--- a/dymos/examples/double_integrator/doc/test_doc_double_integrator.py
+++ b/dymos/examples/double_integrator/doc/test_doc_double_integrator.py
@@ -6,9 +6,11 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
+from openmdao.utils.testing_utils import use_tempdirs
 from dymos.utils.doc_utils import save_for_docs
 
 
+@use_tempdirs
 class TestDoubleIntegratorForDocs(unittest.TestCase):
 
     @classmethod

--- a/dymos/examples/hyper_sensitive/doc/test_doc_hyper_sensitive.py
+++ b/dymos/examples/hyper_sensitive/doc/test_doc_hyper_sensitive.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 matplotlib.use('Agg')
 plt.style.use('ggplot')
 
+from openmdao.utils.testing_utils import use_tempdirs
 from dymos.utils.doc_utils import save_for_docs
 
 
@@ -28,6 +29,7 @@ def solution():
     return ui, uf, J
 
 
+@use_tempdirs
 class TestHyperSensitive(unittest.TestCase):
 
     @classmethod

--- a/dymos/examples/min_time_climb/doc/test_doc_min_time_climb.py
+++ b/dymos/examples/min_time_climb/doc/test_doc_min_time_climb.py
@@ -5,9 +5,11 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
+from openmdao.utils.testing_utils import use_tempdirs
 from dymos.utils.doc_utils import save_for_docs
 
 
+@use_tempdirs
 class TestMinTimeClimbForDocs(unittest.TestCase):
 
     @save_for_docs

--- a/dymos/examples/shuttle_reentry/doc/test_doc_reentry.py
+++ b/dymos/examples/shuttle_reentry/doc/test_doc_reentry.py
@@ -6,9 +6,11 @@ plt.switch_backend('Agg')
 plt.style.use('ggplot')
 import numpy as np
 
+from openmdao.utils.testing_utils import use_tempdirs
 from dymos.utils.doc_utils import save_for_docs
 
 
+@use_tempdirs
 class TestReentryForDocs(unittest.TestCase):
 
     def tearDown(self):
@@ -28,7 +30,9 @@ class TestReentryForDocs(unittest.TestCase):
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()
         p.driver.declare_coloring()
-        p.driver.options['optimizer'] = 'SLSQP'
+        p.driver.options['optimizer'] = 'IPOPT'
+        p.driver.opt_settings['print_level'] = 5
+        p.driver.opt_settings['max_iter'] = 500
 
         # Instantiate the trajectory and add a phase to it
         traj = p.model.add_subsystem('traj', dm.Trajectory())

--- a/dymos/examples/ssto/doc/test_doc_ssto_earth.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_earth.py
@@ -5,9 +5,11 @@ plt.switch_backend('Agg')
 plt.style.use('ggplot')
 
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 from dymos.utils.doc_utils import save_for_docs
 
 
+@use_tempdirs
 class TestDocSSTOEarth(unittest.TestCase):
 
     @save_for_docs

--- a/dymos/examples/ssto/doc/test_doc_ssto_linear_tangent_guidance.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_linear_tangent_guidance.py
@@ -5,9 +5,11 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
+from openmdao.utils.testing_utils import use_tempdirs
 from dymos.utils.doc_utils import save_for_docs
 
 
+@use_tempdirs
 class TestDocSSTOLinearTangentGuidance(unittest.TestCase):
 
     @save_for_docs

--- a/dymos/examples/ssto/doc/test_doc_ssto_polynomial_control.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_polynomial_control.py
@@ -5,9 +5,11 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
+from openmdao.utils.testing_utils import use_tempdirs
 from dymos.utils.doc_utils import save_for_docs
 
 
+@use_tempdirs
 class TestDocSSTOPolynomialControl(unittest.TestCase):
 
     @save_for_docs

--- a/dymos/examples/vanderpol/doc/test_doc_vanderpol.py
+++ b/dymos/examples/vanderpol/doc/test_doc_vanderpol.py
@@ -5,9 +5,11 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
+from openmdao.utils.testing_utils import use_tempdirs
 from dymos.utils.doc_utils import save_for_docs
 
 
+@use_tempdirs
 class TestVanderpolForDocs(unittest.TestCase):
     def tearDown(self):
         for filename in ['total_coloring.pkl', 'SLSQP.out', 'SNOPT_print.out', 'SNOPT_summary.out']:

--- a/dymos/examples/vanderpol/test/test_vanderpol.py
+++ b/dymos/examples/vanderpol/test/test_vanderpol.py
@@ -50,7 +50,6 @@ class TestVanderpolExample(unittest.TestCase):
         assert_almost_equal(p.get_val('traj.phase0.timeseries.controls:u')[-1, ...], np.zeros(1), decimal=4)
 
 
-@use_tempdirs
 class TestVanderpolExampleMPI(unittest.TestCase):
 
     N_PROCS = 4
@@ -64,7 +63,7 @@ class TestVanderpolExampleMPI(unittest.TestCase):
         """
         p = vanderpol(transcription='gauss-lobatto', num_segments=75, delay=True,
                       use_pyoptsparse=True, optimizer='IPOPT')
-        dm.run_problem(p)  # find optimal control solution to stop oscillation
+        p.run_driver()  # find optimal control solution to stop oscillation
 
         if SHOW_PLOTS:
             vanderpol_dymos_plots(p)

--- a/dymos/examples/water_rocket/doc/test_doc_water_rocket.py
+++ b/dymos/examples/water_rocket/doc/test_doc_water_rocket.py
@@ -8,6 +8,7 @@ import numpy as np
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import set_pyoptsparse_opt
+from openmdao.utils.testing_utils import use_tempdirs
 
 from dymos.examples.water_rocket.phases import (new_water_rocket_trajectory,
                                                 set_sane_initial_guesses)
@@ -15,6 +16,7 @@ from dymos.examples.water_rocket.phases import (new_water_rocket_trajectory,
 from dymos.utils.doc_utils import save_for_docs
 
 
+@use_tempdirs
 class TestWaterRocketForDocs(unittest.TestCase):
 
     @save_for_docs

--- a/dymos/run_problem.py
+++ b/dymos/run_problem.py
@@ -86,13 +86,14 @@ def run_problem(problem, refine_method='hp', refine_iteration_limit=0, run_drive
         If True, perform a simulation of Trajectories found in the Problem after the driver
         has been run and grid refinement is complete.
     """
-    problem.add_recorder(om.SqliteRecorder('dymos_solution.db'))
+    if 'dymos_solution.db' not in [rec._filepath for rec in iter(problem._rec_mgr)]:
+        problem.add_recorder(om.SqliteRecorder('dymos_solution.db'))
 
     problem.final_setup()  # make sure command line option hook has a chance to run
 
     if restart is not None:
         cr = om.CaseReader(restart)
-        system_cases = cr.list_cases('root')
+        system_cases = cr.list_cases('problem')
         case = cr.get_case(system_cases[-1])
         load_case(problem, case)
 

--- a/dymos/run_problem.py
+++ b/dymos/run_problem.py
@@ -28,20 +28,6 @@ def modify_problem(problem, restart=None, reset_grid=False):
     reset_grid: Boolean
         Flag to trigger a grid reset.
     """
-    # record variables to database when running driver under hook
-    # pre-hook is important, because recording initialization is skipped if final_setup has run once
-    save_db = os.getcwd() + '/dymos_solution.db'
-
-    try:
-        os.remove(save_db)
-    except FileNotFoundError:
-        pass  # OK if old database is not present to be deleted
-
-    print('adding recorder at:', save_db)
-    problem.add_recorder(om.SqliteRecorder(save_db))
-    problem.recording_options['includes'] = ['*']
-    problem.recording_options['record_inputs'] = True
-
     # if opts.get('reset_grid'):  # TODO: implement this option
     #     pass
 
@@ -100,6 +86,8 @@ def run_problem(problem, refine_method='hp', refine_iteration_limit=0, run_drive
         If True, perform a simulation of Trajectories found in the Problem after the driver
         has been run and grid refinement is complete.
     """
+    problem.add_recorder(om.SqliteRecorder('dymos_solution.db'))
+
     problem.final_setup()  # make sure command line option hook has a chance to run
 
     if restart is not None:

--- a/dymos/test/test_load_case.py
+++ b/dymos/test/test_load_case.py
@@ -131,7 +131,7 @@ class TestLoadCase(unittest.TestCase):
         dm.load_case(p, case)
 
         # Run the model to ensure we find the same output values as those that we recorded
-        p.run_driver()
+        p.run_model()
 
         outputs = dict([(o[0], o[1]) for o in case.list_outputs(units=True, shape=True,
                                                                 out_stream=None)])
@@ -162,7 +162,7 @@ class TestLoadCase(unittest.TestCase):
         dm.load_case(q, case)
 
         # Run the model to ensure we find the same output values as those that we recorded
-        q.run_driver()
+        q.run_model()
 
         outputs = dict([(o[0], o[1]) for o in case.list_outputs(units=True, shape=True,
                                                                 out_stream=None)])
@@ -196,7 +196,7 @@ class TestLoadCase(unittest.TestCase):
         dm.load_case(q, case)
 
         # Run the model to ensure we find the same output values as those that we recorded
-        q.run_driver()
+        q.run_model()
 
         outputs = dict([(o[0], o[1]) for o in case.list_outputs(units=True, shape=True,
                                                                 out_stream=None)])
@@ -230,7 +230,7 @@ class TestLoadCase(unittest.TestCase):
         dm.load_case(q, case)
 
         # Run the model to ensure we find the same output values as those that we recorded
-        q.run_driver()
+        q.run_model()
 
         outputs = dict([(o[0], o[1]) for o in case.list_outputs(units=True, shape=True,
                                                                 out_stream=None)])
@@ -266,7 +266,7 @@ class TestLoadCase(unittest.TestCase):
         dm.load_case(q, case)
 
         # Run the model to ensure we find the same output values as those that we recorded
-        q.run_driver()
+        q.run_model()
 
         outputs = dict([(o[0], o[1]) for o in case.list_outputs(units=True, shape=True,
                                                                 out_stream=None)])

--- a/dymos/test/test_load_case.py
+++ b/dymos/test/test_load_case.py
@@ -52,15 +52,6 @@ def setup_problem(trans=dm.GaussLobatto(num_segments=10), polynomial_control=Fal
 
     p.model.linear_solver = om.DirectSolver()
 
-    # Recording
-    rec = om.SqliteRecorder('brachistochrone_solution.db')
-    p.driver.recording_options['record_desvars'] = True
-    p.driver.recording_options['record_responses'] = True
-    p.driver.recording_options['record_objectives'] = True
-    p.driver.recording_options['record_constraints'] = True
-    p.model.recording_options['record_metadata'] = True
-    p.model.add_recorder(rec)
-
     p.setup()
 
     p['phase0.t_initial'] = 0.0
@@ -94,12 +85,12 @@ class TestLoadCase(unittest.TestCase):
         p = setup_problem(dm.GaussLobatto(num_segments=10))
 
         # Solve for the optimal trajectory
-        p.run_driver()
+        dm.run_problem(p)
 
         # Load the solution
-        cr = om.CaseReader('brachistochrone_solution.db')
-        system_cases = cr.list_cases('root')
-        case = cr.get_case(system_cases[-1])
+        cr = om.CaseReader('dymos_solution.db')
+        cases = cr.list_cases('problem')
+        case = cr.get_case(cases[-1])
 
         # Initialize the system with values from the case.
         # We unnecessarily call setup again just to make sure we obliterate the previous solution
@@ -125,12 +116,12 @@ class TestLoadCase(unittest.TestCase):
         p = setup_problem(dm.GaussLobatto(num_segments=10), polynomial_control=True)
 
         # Solve for the optimal trajectory
-        p.run_driver()
+        dm.run_problem(p)
 
         # Load the solution
-        cr = om.CaseReader('brachistochrone_solution.db')
-        system_cases = cr.list_cases('root')
-        case = cr.get_case(system_cases[-1])
+        cr = om.CaseReader('dymos_solution.db')
+        cases = cr.list_cases('problem')
+        case = cr.get_case(cases[-1])
 
         # Initialize the system with values from the case.
         # We unnecessarily call setup again just to make sure we obliterate the previous solution
@@ -157,12 +148,12 @@ class TestLoadCase(unittest.TestCase):
         p = setup_problem(dm.GaussLobatto(num_segments=10))
 
         # Solve for the optimal trajectory
-        p.run_driver()
+        dm.run_problem(p)
 
         # Load the solution
-        cr = om.CaseReader('brachistochrone_solution.db')
-        system_cases = cr.list_cases('root')
-        case = cr.get_case(system_cases[-1])
+        cr = om.CaseReader('dymos_solution.db')
+        cases = cr.list_cases('problem')
+        case = cr.get_case(cases[-1])
 
         # create a problem with a different transcription with a different number of variables
         q = setup_problem(dm.Radau(num_segments=20))
@@ -191,12 +182,12 @@ class TestLoadCase(unittest.TestCase):
         p = setup_problem(dm.Radau(num_segments=20))
 
         # Solve for the optimal trajectory
-        p.run_driver()
+        dm.run_problem(p)
 
         # Load the solution
-        cr = om.CaseReader('brachistochrone_solution.db')
-        system_cases = cr.list_cases('root')
-        case = cr.get_case(system_cases[-1])
+        cr = om.CaseReader('dymos_solution.db')
+        cases = cr.list_cases('problem')
+        case = cr.get_case(cases[-1])
 
         # create a problem with a different transcription with a different number of variables
         q = setup_problem(dm.GaussLobatto(num_segments=50))
@@ -225,12 +216,12 @@ class TestLoadCase(unittest.TestCase):
         p = setup_problem(dm.RungeKutta(num_segments=50))
 
         # Solve for the optimal trajectory
-        p.run_driver()
+        dm.run_problem(p)
 
         # Load the solution
-        cr = om.CaseReader('brachistochrone_solution.db')
-        system_cases = cr.list_cases('root')
-        case = cr.get_case(system_cases[-1])
+        cr = om.CaseReader('dymos_solution.db')
+        cases = cr.list_cases('problem')
+        case = cr.get_case(cases[-1])
 
         # create a problem with a different transcription with a different number of variables
         q = setup_problem(dm.GaussLobatto(num_segments=10))
@@ -261,12 +252,12 @@ class TestLoadCase(unittest.TestCase):
         p = setup_problem(dm.GaussLobatto(num_segments=20))
 
         # Solve for the optimal trajectory
-        p.run_driver()
+        dm.run_problem(p)
 
         # Load the solution
-        cr = om.CaseReader('brachistochrone_solution.db')
-        system_cases = cr.list_cases('root')
-        case = cr.get_case(system_cases[-1])
+        cr = om.CaseReader('dymos_solution.db')
+        cases = cr.list_cases('problem')
+        case = cr.get_case(cases[-1])
 
         # create a problem with a different transcription with a different number of variables
         q = setup_problem(dm.RungeKutta(num_segments=50))

--- a/dymos/test/test_run_problem.py
+++ b/dymos/test/test_run_problem.py
@@ -217,11 +217,8 @@ class TestRunProblem(unittest.TestCase):
         # create a new problem for restart to simulate a different command line execution
         q = vanderpol(transcription='gauss-lobatto', num_segments=75)
 
-        # Call modify_problem with simulation restart database
-        # modify_problem(q, restart='vanderpol_simulation.sql')
-
         # # Run the model
-        run_problem(q, restart='vanderpol_simulation.sql')
+        run_problem(q, restart='vanderpol_simulation.sql', run_driver=False)
 
         #  The solution should look like the explicit time history for the states and controls.
         DO_PLOTS = False

--- a/dymos/test/test_upgrade_guide.py
+++ b/dymos/test/test_upgrade_guide.py
@@ -5,8 +5,10 @@ import openmdao.api as om
 import dymos as dm
 
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 
+@use_tempdirs
 class TestUpgrade_0_16_0(unittest.TestCase):
 
     def test_parameters(self):

--- a/dymos/trajectory/test/test_trajectory.py
+++ b/dymos/trajectory/test/test_trajectory.py
@@ -105,8 +105,6 @@ class TestTrajectory(unittest.TestCase):
         # Finish Problem Setup
         p.model.linear_solver = om.DirectSolver()
 
-        p.model.add_recorder(om.SqliteRecorder('test_trajectory_rec.db'))
-
         p.setup(check=True)
 
         # Set Initial Guesses
@@ -247,8 +245,6 @@ class TestInvalidLinkages(unittest.TestCase):
         # Finish Problem Setup
         p.model.linear_solver = om.DirectSolver()
 
-        p.model.add_recorder(om.SqliteRecorder('test_trajectory_rec.db'))
-
         with self.assertRaises(ValueError) as e:
             p.setup(check=True)
 
@@ -339,11 +335,6 @@ class TestInvalidLinkages(unittest.TestCase):
                          vars=['time', 'r', 'theta', 'vr', 'vt', 'deltav'])
 
         traj.link_phases(phases=['burn1', 'foo'], vars=['u1', 'u1'])
-
-        # Finish Problem Setup
-        p.model.linear_solver = om.DirectSolver()
-
-        p.model.add_recorder(om.SqliteRecorder('test_trajectory_rec.db'))
 
         with self.assertRaises(ValueError) as e:
             p.setup(check=True)

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -935,8 +935,8 @@ class Trajectory(om.Group):
 
         if record_file is not None:
             rec = om.SqliteRecorder(record_file)
-            sim_prob.model.recording_options['includes'] = ['*.timeseries.*']
-            sim_prob.model.add_recorder(rec)
+            sim_prob.recording_options['includes'] = ['*.timeseries.*']
+            sim_prob.add_recorder(rec)
 
         sim_prob.setup()
 
@@ -972,5 +972,6 @@ class Trajectory(om.Group):
         print('\nSimulating trajectory {0}'.format(self.pathname))
         sim_prob.run_model()
         print('Done simulating trajectory {0}'.format(self.pathname))
+        sim_prob.record('final')
 
         return sim_prob

--- a/dymos/utils/command_line.py
+++ b/dymos/utils/command_line.py
@@ -3,6 +3,7 @@ import argparse
 import sys
 import os
 from dymos.run_problem import modify_problem, run_problem
+import openmdao.api as om
 from unittest.mock import patch
 
 
@@ -99,6 +100,7 @@ def dymos_cmd(argv=None):
             self._pre_hooks_enabled = False
 
             modify_problem(prob, restart=opts['restart'])
+            prob.add_recorder(om.SqliteRecorder('dymos_solution.db'))
             self._post_hooks_enabled = True
 
         def _post_final_setup(self, prob):
@@ -120,8 +122,8 @@ def dymos_cmd(argv=None):
 
     globals_dict = _simple_exec(args.script, user_args)  # run the script
 
-    if not sys.argv[0].endswith('dymos'):  # suppress printing return value when running from command line
-        return globals_dict  # return globals for possible checking in unit tests
+    # if not sys.argv[0].endswith('dymos'):  # suppress printing return value when running from command line
+    #     return globals_dict  # return globals for possible checking in unit tests
 
 
 if __name__ == '__main__':

--- a/dymos/utils/test/test_command_line.py
+++ b/dymos/utils/test/test_command_line.py
@@ -81,19 +81,14 @@ class TestCommandLine(unittest.TestCase):
         print('test_ex_brachistochrone_no_solve')
         with patch.object(sys, 'argv', self.base_args + ['--no_solve']):
             command_line.dymos_cmd()
-
-        self.assertTrue(os.path.exists('dymos_solution.db'))
-        cr = om.CaseReader('dymos_solution.db')
-        self.assertTrue(len(cr.list_cases()) == 1)
+        self.assertFalse(os.path.exists('dymos_solution.db'))
 
     def test_ex_brachistochrone_simulate(self):
         print('test_ex_brachistochrone_simulate')
         with patch.object(sys, 'argv', self.base_args + ['--simulate']):
             command_line.dymos_cmd()
-
+        self.assertTrue(os.path.exists('dymos_solution.db'))
         self.assertTrue(os.path.exists('dymos_simulation.db'))
-
-        self._assert_correct_solution()
 
     @unittest.skipIf(True, reason='grid resetting not yet implemented')
     def test_ex_brachistochrone_reset_grid(self):


### PR DESCRIPTION
### Summary

The dymos.run_problem convenience function now attaches a problem recorder that saves to `'dymos_solution.db'` if not already present.  The recorder in the command line interface saves to the same one.  Unfortunately, the way the CLI currently works, we couldn't just _only_ add the recorder in run_problem, due to the way the hooks work.

### Related Issues

- Resolves #435 

### Status

- [ ] Ready for merge

### Backwards incompatibilities

`Trajectory.simulate` now uses a Problem recorder to save the final results of the simulation.
This means that the results of the simulation are now obtained using
```
sim = om.CaseReader('dymos_simulation.db').get_case('final')
```
instead of
```
sim = om.CaseReader('dymos_simulation.db').get_case(-1)
```

### New Dependencies

None
