### PR TITLE
run_problem now adds a recorder if not already present

### DIFF
--- a/dymos/examples/aircraft_steady_flight/doc/test_doc_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/doc/test_doc_aircraft_steady_flight.py
@@ -6,8 +6,10 @@ plt.style.use('ggplot')
 
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 from dymos.utils.doc_utils import save_for_docs
+from openmdao.utils.testing_utils import use_tempdirs
 
 
+@use_tempdirs
 class TestSteadyAircraftFlightForDocs(unittest.TestCase):
 
     @classmethod

--- a/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
@@ -3,6 +3,7 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos.examples.aircraft_steady_flight.aircraft_ode import AircraftODE
@@ -15,6 +16,7 @@ except:
     MBI = None
 
 
+@use_tempdirs
 class TestAircraftCruise(unittest.TestCase):
 
     def test_cruise_results_gl(self):

--- a/dymos/examples/aircraft_steady_flight/test/test_aircraft_ode.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_aircraft_ode.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from dymos.examples.aircraft_steady_flight.aircraft_ode import AircraftODE
 
@@ -14,6 +15,7 @@ except:
 
 
 @unittest.skipIf(MBI is None, 'MBI not available')
+@use_tempdirs
 class TestAircraftODEGroup(unittest.TestCase):
 
     @classmethod

--- a/dymos/examples/aircraft_steady_flight/test/test_ex_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_ex_aircraft_steady_flight.py
@@ -4,6 +4,7 @@ import unittest
 import openmdao.api as om
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos.utils.lgl import lgl
@@ -108,6 +109,7 @@ def ex_aircraft_steady_flight(optimizer='SLSQP', solve_segments=False,
     return p
 
 
+@use_tempdirs
 class TestExSteadyAircraftFlight(unittest.TestCase):
 
     @classmethod

--- a/dymos/examples/battery_multibranch/doc/test_multibranch_trajectory_for_docs.py
+++ b/dymos/examples/battery_multibranch/doc/test_multibranch_trajectory_for_docs.py
@@ -6,9 +6,11 @@ import unittest
 import matplotlib
 matplotlib.use('Agg')
 
+from openmdao.utils.testing_utils import use_tempdirs
 from dymos.utils.doc_utils import save_for_docs
 
 
+@use_tempdirs
 class TestBatteryBranchingPhasesForDocs(unittest.TestCase):
 
     @save_for_docs

--- a/dymos/examples/battery_multibranch/test/test_multibranch_trajectory.py
+++ b/dymos/examples/battery_multibranch/test/test_multibranch_trajectory.py
@@ -6,6 +6,7 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos.examples.battery_multibranch.battery_multibranch_ode import BatteryODE
@@ -14,6 +15,7 @@ from dymos.utils.lgl import lgl
 optimizer = os.environ.get('DYMOS_DEFAULT_OPT', 'SLSQP')
 
 
+@use_tempdirs
 class TestBatteryBranchingPhases(unittest.TestCase):
 
     def test_optimizer_defects(self):
@@ -371,6 +373,7 @@ class TestBatteryBranchingPhases(unittest.TestCase):
         assert_near_equal(soc1m[-1], 0.18625395, 1e-6)
 
 
+@use_tempdirs
 class TestBatteryBranchingPhasesRungeKutta(unittest.TestCase):
 
     def test_constraint_linkages_rk(self):

--- a/dymos/examples/battery_multibranch/test/test_multibranch_trajectory_rk_ivp.py
+++ b/dymos/examples/battery_multibranch/test/test_multibranch_trajectory_rk_ivp.py
@@ -5,11 +5,13 @@ in a simple electrical system.
 import unittest
 
 import openmdao.api as om
+from openmdao.utils.testing_utils import use_tempdirs
 import dymos as dm
 
 from dymos.examples.battery_multibranch.battery_multibranch_ode import BatteryODE
 
 
+@use_tempdirs
 class TestBatteryRKIVP(unittest.TestCase):
 
     def test_dynamic_params(self):

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
@@ -9,9 +9,11 @@ plt.style.use('ggplot')
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
 
+from openmdao.utils.testing_utils import use_tempdirs
 from dymos.utils.doc_utils import save_for_docs
 
 
+@use_tempdirs
 class TestBrachistochroneForDocs(unittest.TestCase):
 
     def tearDown(self):

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_static_gravity.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_static_gravity.py
@@ -7,8 +7,10 @@ import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
 from dymos.utils.doc_utils import save_for_docs
+from openmdao.utils.testing_utils import use_tempdirs
 
 
+@use_tempdirs
 class TestBrachistochroneStaticGravity(unittest.TestCase):
 
     def tearDown(self):
@@ -131,14 +133,14 @@ class TestBrachistochroneStaticGravity(unittest.TestCase):
         #
         # Solve for the optimal trajectory
         #
-        dm.run_problem(p)
+        dm.run_problem(p, simulate=True)
 
         # Test the results
         assert_near_equal(p.get_val('traj.phase0.timeseries.time')[-1], 1.8016,
                           tolerance=1.0E-3)
 
         # Generate the explicitly simulated trajectory
-        exp_out = traj.simulate()
+        exp_out = om.CaseReader('dymos_simulation.db').get_case('final')
 
         # Extract the timeseries from the implicit solution and the explicit simulation
         x = p.get_val('traj.phase0.timeseries.states:x')

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_tandem_phases.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_tandem_phases.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 import openmdao.api as om
 from dymos.utils.doc_utils import save_for_docs
+from openmdao.utils.testing_utils import use_tempdirs
 
 
 class BrachistochroneArclengthODE(om.ExplicitComponent):
@@ -43,6 +44,7 @@ class BrachistochroneArclengthODE(om.ExplicitComponent):
             (np.sqrt(1 + cot_theta**2))
 
 
+@use_tempdirs
 class TestBrachistochroneTandemPhases(unittest.TestCase):
 
     @save_for_docs

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_implicit_recorder.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_implicit_recorder.py
@@ -46,20 +46,6 @@ class TestBrachistochroneRecordingExample(unittest.TestCase):
 
         p.model.linear_solver = om.DirectSolver()
 
-        # Recording
-        rec = om.SqliteRecorder('brachistochrone_solution.db')
-
-        p.driver.recording_options['record_desvars'] = True
-        p.driver.recording_options['record_responses'] = True
-        p.driver.recording_options['record_objectives'] = True
-        p.driver.recording_options['record_constraints'] = True
-
-        p.model.recording_options['record_metadata'] = True
-
-        p.driver.add_recorder(rec)
-        p.model.add_recorder(rec)
-        phase.add_recorder(rec)
-
         p.setup()
 
         p['phase0.t_initial'] = 0.0
@@ -71,14 +57,12 @@ class TestBrachistochroneRecordingExample(unittest.TestCase):
         p['phase0.controls:theta'] = phase.interpolate(ys=[5, 100.5], nodes='control_input')
 
         # Solve for the optimal trajectory
-        p.run_driver()
+        dm.run_problem(p)
 
         # Test the results
         assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
-        cr = om.CaseReader('brachistochrone_solution.db')
-        system_cases = cr.list_cases('root')
-        case = cr.get_case(system_cases[-1])
+        case = om.CaseReader('dymos_solution.db').get_case('final')
 
         outputs = dict([(o[0], o[1]) for o in case.list_outputs(units=True, shape=True,
                                                                 out_stream=None)])

--- a/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
+++ b/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
@@ -4,8 +4,10 @@ import matplotlib.pyplot as plt
 plt.switch_backend('Agg')
 
 from dymos.utils.doc_utils import save_for_docs
+from openmdao.utils.testing_utils import use_tempdirs
 
 
+@use_tempdirs
 class TestTwoPhaseCannonballForDocs(unittest.TestCase):
 
     @save_for_docs

--- a/dymos/examples/cannonball/test/test_two_phase_cannonball_ode_output_linkage.py
+++ b/dymos/examples/cannonball/test/test_two_phase_cannonball_ode_output_linkage.py
@@ -2,8 +2,10 @@ import unittest
 
 import matplotlib.pyplot as plt
 plt.switch_backend('Agg')
+from openmdao.utils.testing_utils import use_tempdirs
 
 
+@use_tempdirs
 class TestTwoPhaseCannonballODEOutputLinkage(unittest.TestCase):
 
     def test_two_phase_cannonball_ode_output_linkage(self):

--- a/dymos/examples/double_integrator/doc/test_doc_double_integrator.py
+++ b/dymos/examples/double_integrator/doc/test_doc_double_integrator.py
@@ -7,8 +7,10 @@ import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
 from dymos.utils.doc_utils import save_for_docs
+from openmdao.utils.testing_utils import use_tempdirs
 
 
+@use_tempdirs
 class TestDoubleIntegratorForDocs(unittest.TestCase):
 
     @classmethod

--- a/dymos/examples/double_integrator/test/test_double_integrator.py
+++ b/dymos/examples/double_integrator/test/test_double_integrator.py
@@ -6,6 +6,7 @@ from parameterized import parameterized
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos.examples.double_integrator.double_integrator_ode import DoubleIntegratorODE
@@ -55,6 +56,7 @@ def double_integrator_direct_collocation(transcription='gauss-lobatto', compress
     return p
 
 
+@use_tempdirs
 class TestDoubleIntegratorExample(unittest.TestCase):
 
     @classmethod

--- a/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
@@ -6,11 +6,13 @@ plt.style.use('ggplot')
 
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 from dymos.utils.doc_utils import save_for_docs
+from openmdao.utils.testing_utils import use_tempdirs
 
 
 _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
 
 
+@use_tempdirs
 class TestFiniteBurnOrbitRaise(unittest.TestCase):
 
     @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')

--- a/dymos/examples/finite_burn_orbit_raise/test/test_finite_burn_eom.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_finite_burn_eom.py
@@ -5,10 +5,12 @@ import numpy as np
 import openmdao.api as om
 
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
+from openmdao.utils.testing_utils import use_tempdirs
 
 from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
 
 
+@use_tempdirs
 class TestFiniteBurnEOM(unittest.TestCase):
 
     @classmethod

--- a/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
@@ -10,9 +10,9 @@ plt.switch_backend('Agg')
 
 
 @unittest.skipIf(optimizer is not 'IPOPT', 'IPOPT not available')
+@use_tempdirs
 class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
-    @use_tempdirs
     def test_two_burn_orbit_raise_gl_rk_gl_changing_units_error(self):
         import numpy as np
 
@@ -136,7 +136,6 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         self.assertEqual(expected_exception, str(e.exception))
 
-    @use_tempdirs
     def test_two_burn_orbit_raise_gl_rk_gl_constrained(self):
         import numpy as np
 
@@ -384,7 +383,6 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         plt.show()
 
-    @use_tempdirs
     def test_two_burn_orbit_raise_link_control_to_param(self):
         import numpy as np
 

--- a/dymos/examples/flying_robot/test/test_flying_robot.py
+++ b/dymos/examples/flying_robot/test/test_flying_robot.py
@@ -6,6 +6,7 @@ from parameterized import parameterized
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos.examples.flying_robot.flying_robot_ode import FlyingRobotODE
@@ -58,6 +59,7 @@ def flying_robot_direct_collocation(transcription='gauss-lobatto', compressed=Tr
     return p
 
 
+@use_tempdirs
 class TestFlyingRobot(unittest.TestCase):
 
     @classmethod

--- a/dymos/examples/hyper_sensitive/doc/test_doc_hyper_sensitive.py
+++ b/dymos/examples/hyper_sensitive/doc/test_doc_hyper_sensitive.py
@@ -10,6 +10,7 @@ matplotlib.use('Agg')
 plt.style.use('ggplot')
 
 from dymos.utils.doc_utils import save_for_docs
+from openmdao.utils.testing_utils import use_tempdirs
 
 
 tf = np.float128(10)
@@ -28,6 +29,7 @@ def solution():
     return ui, uf, J
 
 
+@use_tempdirs
 class TestHyperSensitive(unittest.TestCase):
 
     @classmethod

--- a/dymos/examples/min_time_climb/doc/test_doc_min_time_climb.py
+++ b/dymos/examples/min_time_climb/doc/test_doc_min_time_climb.py
@@ -6,8 +6,10 @@ import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
 from dymos.utils.doc_utils import save_for_docs
+from openmdao.utils.testing_utils import use_tempdirs
 
 
+@use_tempdirs
 class TestMinTimeClimbForDocs(unittest.TestCase):
 
     @save_for_docs

--- a/dymos/examples/min_time_climb/doc/test_doc_min_time_climb_fd.py
+++ b/dymos/examples/min_time_climb/doc/test_doc_min_time_climb_fd.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
 from dymos.utils.doc_utils import save_for_docs
+from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.coloring import Coloring
 
 
@@ -41,6 +42,7 @@ def _view_coloring(coloring_file, show_sparsity_text=False, show_sparsity=True,
     coloring.summary()
 
 
+@use_tempdirs
 class TestMinTimeClimbForDocs(unittest.TestCase):
 
     @save_for_docs

--- a/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
+++ b/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
@@ -105,9 +105,9 @@ def min_time_climb(optimizer='SLSQP', num_seg=3, transcription='gauss-lobatto',
     return p
 
 
+@use_tempdirs
 class TestMinTimeClimb(unittest.TestCase):
 
-    @use_tempdirs
     def test_results_gauss_lobatto(self):
         p = min_time_climb(optimizer='SLSQP', num_seg=12, transcription_order=3,
                            transcription='gauss-lobatto')
@@ -129,7 +129,6 @@ class TestMinTimeClimb(unittest.TestCase):
         assert(output_dict['traj.phases.phase0.timeseries.f_drag']['units'] == 'N')    # wildcard, from ODE
         assert(output_dict['traj.phases.phase0.timeseries.f_lift']['units'] == 'lbf')  # wildcard, from units dict
 
-    @use_tempdirs
     def test_results_radau(self):
         p = min_time_climb(optimizer='SLSQP', num_seg=12, transcription_order=3,
                            transcription='radau-ps')

--- a/dymos/examples/shuttle_reentry/doc/test_doc_reentry.py
+++ b/dymos/examples/shuttle_reentry/doc/test_doc_reentry.py
@@ -7,8 +7,10 @@ plt.style.use('ggplot')
 import numpy as np
 
 from dymos.utils.doc_utils import save_for_docs
+from openmdao.utils.testing_utils import use_tempdirs
 
 
+@use_tempdirs
 class TestReentryForDocs(unittest.TestCase):
 
     def tearDown(self):

--- a/dymos/examples/shuttle_reentry/test/test_reentry.py
+++ b/dymos/examples/shuttle_reentry/test/test_reentry.py
@@ -1,6 +1,7 @@
 import unittest
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
+from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 from dymos import Trajectory, GaussLobatto, Phase, Radau
 from dymos.examples.shuttle_reentry.shuttle_ode import ShuttleODE
@@ -11,6 +12,7 @@ expected_results = {'constrained': {'time': 2198.67, 'theta': 30.6255},
                     'unconstrained': {'time': 2008.59, 'theta': 34.1412}}
 
 
+@use_tempdirs
 class TestReentry(unittest.TestCase):
 
     def make_problem(self, constrained=True, transcription=GaussLobatto, optimizer='SLSQP',

--- a/dymos/examples/ssto/doc/test_doc_ssto_earth.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_earth.py
@@ -5,9 +5,11 @@ plt.switch_backend('Agg')
 plt.style.use('ggplot')
 
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 from dymos.utils.doc_utils import save_for_docs
 
 
+@use_tempdirs
 class TestDocSSTOEarth(unittest.TestCase):
 
     @save_for_docs

--- a/dymos/examples/ssto/doc/test_doc_ssto_linear_tangent_guidance.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_linear_tangent_guidance.py
@@ -6,8 +6,10 @@ import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
 from dymos.utils.doc_utils import save_for_docs
+from openmdao.utils.testing_utils import use_tempdirs
 
 
+@use_tempdirs
 class TestDocSSTOLinearTangentGuidance(unittest.TestCase):
 
     @save_for_docs

--- a/dymos/examples/ssto/doc/test_doc_ssto_polynomial_control.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_polynomial_control.py
@@ -6,8 +6,10 @@ import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
 from dymos.utils.doc_utils import save_for_docs
+from openmdao.utils.testing_utils import use_tempdirs
 
 
+@use_tempdirs
 class TestDocSSTOPolynomialControl(unittest.TestCase):
 
     @save_for_docs

--- a/dymos/examples/ssto/test/test_simulate_root_trajectory.py
+++ b/dymos/examples/ssto/test/test_simulate_root_trajectory.py
@@ -4,8 +4,10 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 plt.style.use('ggplot')
+from openmdao.utils.testing_utils import use_tempdirs
 
 
+@use_tempdirs
 class TestSSTOSimulateRootTrajectory(unittest.TestCase):
 
     def test_ssto_simulate_root_trajectory(self):

--- a/dymos/examples/vanderpol/doc/test_doc_vanderpol.py
+++ b/dymos/examples/vanderpol/doc/test_doc_vanderpol.py
@@ -6,8 +6,10 @@ import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
 from dymos.utils.doc_utils import save_for_docs
+from openmdao.utils.testing_utils import use_tempdirs
 
 
+@use_tempdirs
 class TestVanderpolForDocs(unittest.TestCase):
     def tearDown(self):
         for filename in ['total_coloring.pkl', 'SLSQP.out', 'SNOPT_print.out', 'SNOPT_summary.out']:

--- a/dymos/examples/vanderpol/test/test_vanderpol.py
+++ b/dymos/examples/vanderpol/test/test_vanderpol.py
@@ -64,7 +64,7 @@ class TestVanderpolExampleMPI(unittest.TestCase):
         """
         p = vanderpol(transcription='gauss-lobatto', num_segments=75, delay=True,
                       use_pyoptsparse=True, optimizer='IPOPT')
-        dm.run_problem(p)  # find optimal control solution to stop oscillation
+        p.run_driver()  # find optimal control solution to stop oscillation
 
         if SHOW_PLOTS:
             vanderpol_dymos_plots(p)

--- a/dymos/examples/water_rocket/doc/test_doc_water_rocket.py
+++ b/dymos/examples/water_rocket/doc/test_doc_water_rocket.py
@@ -8,6 +8,7 @@ import numpy as np
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import set_pyoptsparse_opt
+from openmdao.utils.testing_utils import use_tempdirs
 
 from dymos.examples.water_rocket.phases import (new_water_rocket_trajectory,
                                                 set_sane_initial_guesses)
@@ -15,6 +16,7 @@ from dymos.examples.water_rocket.phases import (new_water_rocket_trajectory,
 from dymos.utils.doc_utils import save_for_docs
 
 
+@use_tempdirs
 class TestWaterRocketForDocs(unittest.TestCase):
 
     @save_for_docs

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -1967,9 +1967,7 @@ class Phase(om.Group):
 
         if record_file is not None:
             rec = om.SqliteRecorder(record_file)
-            sim_prob.model.recording_options['includes'] = ['*.timeseries.*']
-
-            sim_prob.model.add_recorder(rec)
+            sim_prob.add_recorder(rec)
 
         sim_prob.setup(check=True)
         sim_phase.initialize_values_from_phase(sim_prob, self)
@@ -1977,6 +1975,7 @@ class Phase(om.Group):
         print('\nSimulating phase {0}'.format(self.pathname))
         sim_prob.run_model()
         print('Done simulating phase {0}'.format(self.pathname))
+        sim_prob.record('final')
 
         sim_prob.cleanup()
 

--- a/dymos/run_problem.py
+++ b/dymos/run_problem.py
@@ -104,9 +104,7 @@ def run_problem(problem, refine_method='hp', refine_iteration_limit=0, run_drive
     problem.final_setup()  # make sure command line option hook has a chance to run
 
     if restart is not None:
-        cr = om.CaseReader(restart)
-        system_cases = cr.list_cases('root')
-        case = cr.get_case(system_cases[-1])
+        case = om.CaseReader(restart).get_case('final')
         load_case(problem, case)
 
     if run_driver:

--- a/dymos/run_problem.py
+++ b/dymos/run_problem.py
@@ -30,7 +30,7 @@ def modify_problem(problem, restart=None, reset_grid=False):
     """
     # record variables to database when running driver under hook
     # pre-hook is important, because recording initialization is skipped if final_setup has run once
-    save_db = os.getcwd() + '/dymos_solution.db'
+    save_db = 'dymos_solution.db'
 
     try:
         os.remove(save_db)
@@ -39,8 +39,6 @@ def modify_problem(problem, restart=None, reset_grid=False):
 
     print('adding recorder at:', save_db)
     problem.add_recorder(om.SqliteRecorder(save_db))
-    problem.recording_options['includes'] = ['*']
-    problem.recording_options['record_inputs'] = True
 
     # if opts.get('reset_grid'):  # TODO: implement this option
     #     pass
@@ -100,6 +98,9 @@ def run_problem(problem, refine_method='hp', refine_iteration_limit=0, run_drive
         If True, perform a simulation of Trajectories found in the Problem after the driver
         has been run and grid refinement is complete.
     """
+    if 'dymos_solution.db' not in [rec._filepath for rec in iter(problem._rec_mgr)]:
+        problem.add_recorder(om.SqliteRecorder('dymos_solution.db'))
+
     problem.final_setup()  # make sure command line option hook has a chance to run
 
     if restart is not None:
@@ -117,6 +118,7 @@ def run_problem(problem, refine_method='hp', refine_iteration_limit=0, run_drive
             warnings.warn("Refinement not performed. Set run_driver to True to perform refinement.")
 
     problem.record('final')  # save case for potential restart
+    problem.cleanup()
 
     if simulate:
         for subsys in problem.model.system_iter(include_self=True, recurse=True):

--- a/dymos/test/test_load_case.py
+++ b/dymos/test/test_load_case.py
@@ -52,15 +52,6 @@ def setup_problem(trans=dm.GaussLobatto(num_segments=10), polynomial_control=Fal
 
     p.model.linear_solver = om.DirectSolver()
 
-    # Recording
-    rec = om.SqliteRecorder('brachistochrone_solution.db')
-    p.driver.recording_options['record_desvars'] = True
-    p.driver.recording_options['record_responses'] = True
-    p.driver.recording_options['record_objectives'] = True
-    p.driver.recording_options['record_constraints'] = True
-    p.model.recording_options['record_metadata'] = True
-    p.model.add_recorder(rec)
-
     p.setup()
 
     p['phase0.t_initial'] = 0.0
@@ -94,12 +85,10 @@ class TestLoadCase(unittest.TestCase):
         p = setup_problem(dm.GaussLobatto(num_segments=10))
 
         # Solve for the optimal trajectory
-        p.run_driver()
+        dm.run_problem(p)
 
         # Load the solution
-        cr = om.CaseReader('brachistochrone_solution.db')
-        system_cases = cr.list_cases('root')
-        case = cr.get_case(system_cases[-1])
+        case = om.CaseReader('dymos_solution.db').get_case('final')
 
         # Initialize the system with values from the case.
         # We unnecessarily call setup again just to make sure we obliterate the previous solution
@@ -125,12 +114,10 @@ class TestLoadCase(unittest.TestCase):
         p = setup_problem(dm.GaussLobatto(num_segments=10), polynomial_control=True)
 
         # Solve for the optimal trajectory
-        p.run_driver()
+        dm.run_problem(p)
 
         # Load the solution
-        cr = om.CaseReader('brachistochrone_solution.db')
-        system_cases = cr.list_cases('root')
-        case = cr.get_case(system_cases[-1])
+        case = om.CaseReader('dymos_solution.db').get_case('final')
 
         # Initialize the system with values from the case.
         # We unnecessarily call setup again just to make sure we obliterate the previous solution
@@ -157,12 +144,10 @@ class TestLoadCase(unittest.TestCase):
         p = setup_problem(dm.GaussLobatto(num_segments=10))
 
         # Solve for the optimal trajectory
-        p.run_driver()
+        dm.run_problem(p)
 
         # Load the solution
-        cr = om.CaseReader('brachistochrone_solution.db')
-        system_cases = cr.list_cases('root')
-        case = cr.get_case(system_cases[-1])
+        case = om.CaseReader('dymos_solution.db').get_case('final')
 
         # create a problem with a different transcription with a different number of variables
         q = setup_problem(dm.Radau(num_segments=20))
@@ -191,12 +176,10 @@ class TestLoadCase(unittest.TestCase):
         p = setup_problem(dm.Radau(num_segments=20))
 
         # Solve for the optimal trajectory
-        p.run_driver()
+        dm.run_problem(p)
 
         # Load the solution
-        cr = om.CaseReader('brachistochrone_solution.db')
-        system_cases = cr.list_cases('root')
-        case = cr.get_case(system_cases[-1])
+        case = om.CaseReader('dymos_solution.db').get_case('final')
 
         # create a problem with a different transcription with a different number of variables
         q = setup_problem(dm.GaussLobatto(num_segments=50))
@@ -225,12 +208,10 @@ class TestLoadCase(unittest.TestCase):
         p = setup_problem(dm.RungeKutta(num_segments=50))
 
         # Solve for the optimal trajectory
-        p.run_driver()
+        dm.run_problem(p)
 
         # Load the solution
-        cr = om.CaseReader('brachistochrone_solution.db')
-        system_cases = cr.list_cases('root')
-        case = cr.get_case(system_cases[-1])
+        case = om.CaseReader('dymos_solution.db').get_case('final')
 
         # create a problem with a different transcription with a different number of variables
         q = setup_problem(dm.GaussLobatto(num_segments=10))
@@ -261,12 +242,10 @@ class TestLoadCase(unittest.TestCase):
         p = setup_problem(dm.GaussLobatto(num_segments=20))
 
         # Solve for the optimal trajectory
-        p.run_driver()
+        dm.run_problem(p)
 
         # Load the solution
-        cr = om.CaseReader('brachistochrone_solution.db')
-        system_cases = cr.list_cases('root')
-        case = cr.get_case(system_cases[-1])
+        case = om.CaseReader('dymos_solution.db').get_case('final')
 
         # create a problem with a different transcription with a different number of variables
         q = setup_problem(dm.RungeKutta(num_segments=50))

--- a/dymos/test/test_upgrade_guide.py
+++ b/dymos/test/test_upgrade_guide.py
@@ -5,8 +5,10 @@ import openmdao.api as om
 import dymos as dm
 
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 
+@use_tempdirs
 class TestUpgrade_0_16_0(unittest.TestCase):
 
     def test_parameters(self):

--- a/dymos/trajectory/test/test_trajectory.py
+++ b/dymos/trajectory/test/test_trajectory.py
@@ -5,11 +5,13 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
 
 
+@use_tempdirs
 class TestTrajectory(unittest.TestCase):
 
     @classmethod
@@ -159,6 +161,7 @@ class TestTrajectory(unittest.TestCase):
         assert_near_equal(accel_link_error, burn1_accel[-1]-burn2_accel[0])
 
 
+@use_tempdirs
 class TestInvalidLinkages(unittest.TestCase):
 
     def test_invalid_linkage_variable(self):
@@ -246,8 +249,6 @@ class TestInvalidLinkages(unittest.TestCase):
 
         # Finish Problem Setup
         p.model.linear_solver = om.DirectSolver()
-
-        p.model.add_recorder(om.SqliteRecorder('test_trajectory_rec.db'))
 
         with self.assertRaises(ValueError) as e:
             p.setup(check=True)

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -935,13 +935,9 @@ class Trajectory(om.Group):
 
         if record_file is not None:
             rec = om.SqliteRecorder(record_file)
-            sim_prob.model.recording_options['includes'] = ['*.timeseries.*']
-            sim_prob.model.add_recorder(rec)
+            sim_prob.add_recorder(rec)
 
         sim_prob.setup()
-
-        traj_op_dict = dict([(name, opts) for (name, opts) in self.list_outputs(units=True,
-                                                                                out_stream=None)])
 
         # Assign trajectory parameter values
         param_names = [key for key in self.parameter_options.keys()]
@@ -972,5 +968,8 @@ class Trajectory(om.Group):
         print('\nSimulating trajectory {0}'.format(self.pathname))
         sim_prob.run_model()
         print('Done simulating trajectory {0}'.format(self.pathname))
+        if record_file:
+            sim_prob.record('final')
+        sim_prob.cleanup()
 
         return sim_prob


### PR DESCRIPTION
### Summary

The dymos.run_problem convenience function now attaches a problem recorder that saves to `'dymos_solution.db'` if not already present.  The recorder in the command line interface saves to the same one.  Unfortunately, the way the CLI currently works, we couldn't just _only_ add the recorder in run_problem, due to the way the hooks work.

### Related Issues

- Resolves #435 

### Status

- [x] Ready for merge

### Backwards incompatibilities

`Trajectory.simulate` now uses a Problem recorder to save the final results of the simulation.
This means that the results of the simulation are now obtained using
```
sim = om.CaseReader('dymos_simulation.db').get_case('final')
```
instead of
```
sim = om.CaseReader('dymos_simulation.db').get_case(-1)
```

### New Dependencies

None
