### PR TITLE
Fixed a bug that was causing matrix-shaped states to have connection errors.

### DIFF
--- a/dymos/examples/cannonball/test/test_cannonball_matrix_state.py
+++ b/dymos/examples/cannonball/test/test_cannonball_matrix_state.py
@@ -1,0 +1,51 @@
+import numpy as np
+import openmdao.api as om
+import dymos as dm
+
+import unittest
+
+
+class ODEComp(om.ExplicitComponent):
+
+    def initialize(self):
+        self.options.declare('num_nodes', types=int)
+
+    def setup(self):
+        nn = self.options['num_nodes']
+        # z is the state vector, a nn x 2 x 2 in the form of [[x, y], [vx, vy]]
+        self.add_input('z', shape=(nn, 2, 2), units=None)
+        self.add_output('zdot', shape=(nn, 2, 2), units=None)
+
+        self.declare_partials(of='zdot', wrt='z', method='cs')
+        self.declare_coloring(wrt=['z'], method='cs', num_full_jacs=5, tol=1.0E-12)
+
+    def compute(self, inputs, outputs):
+        outputs['zdot'][:, 0, 0] = inputs['z'][:, 1, 0]
+        outputs['zdot'][:, 0, 1] = inputs['z'][:, 1, 1]
+        outputs['zdot'][:, 1, 0] = 0.0
+        outputs['zdot'][:, 1, 1] = -9.81
+
+
+class TestCannonballMatrixState(unittest.TestCase):
+    """ Tests to verify that dymos can use matrix-states"""
+
+    def test_cannonball_matrix_state(self):
+        p = om.Problem()
+
+        traj = dm.Trajectory()
+        phase = dm.Phase(ode_class=ODEComp,
+                         transcription=dm.Radau(num_segments=10, order=3, solve_segments=True))
+        traj.add_phase('phase', phase)
+        p.model.add_subsystem('traj', traj)
+
+        phase.set_time_options(fix_initial=True, duration_bounds=(5, 5))
+        phase.add_state('z', rate_source='zdot', fix_initial=True, units=None)
+
+        p.setup()
+
+        p.set_val('traj.phase.states:z', phase.interpolate(ys=[[[0, 0], [10, 10]], [[10, 0], [10, -10]]], nodes='state_input'))
+
+        p.run_model()
+
+        p.model.list_outputs(print_arrays=True, residuals=True)
+

--- a/dymos/examples/cannonball/test/test_cannonball_matrix_state.py
+++ b/dymos/examples/cannonball/test/test_cannonball_matrix_state.py
@@ -61,7 +61,7 @@ class TestCannonballMatrixState(unittest.TestCase):
         tx = dm.Radau(num_segments=10, order=3, solve_segments=False)
 
         p = self._make_problem(tx)
-        
+
         dm.run_problem(p, simulate=True)
 
         assert_near_equal(p.get_val('traj.phase.timeseries.time')[-1], 2.03873598, tolerance=1E-5)

--- a/dymos/examples/cannonball/test/test_cannonball_matrix_state.py
+++ b/dymos/examples/cannonball/test/test_cannonball_matrix_state.py
@@ -61,8 +61,8 @@ class TestCannonballMatrixState(unittest.TestCase):
         tx = dm.Radau(num_segments=10, order=3, solve_segments=False)
 
         p = self._make_problem(tx)
-
-        p.run_driver()
+        
+        dm.run_problem(p, simulate=True)
 
         assert_near_equal(p.get_val('traj.phase.timeseries.time')[-1], 2.03873598, tolerance=1E-5)
         assert_near_equal(p.get_val('traj.phase.timeseries.states:z')[-1, 0, 1], 0.0, tolerance=1E-5)
@@ -79,7 +79,7 @@ class TestCannonballMatrixState(unittest.TestCase):
 
         p = self._make_problem(tx)
 
-        p.run_driver()
+        dm.run_problem(p, simulate=True)
 
         assert_near_equal(p.get_val('traj.phase.timeseries.time')[-1], 2.03873598, tolerance=1E-5)
         assert_near_equal(p.get_val('traj.phase.timeseries.states:z')[-1, 0, 1], 0.0, tolerance=1E-5)

--- a/dymos/examples/cannonball/test/test_cannonball_matrix_state.py
+++ b/dymos/examples/cannonball/test/test_cannonball_matrix_state.py
@@ -3,6 +3,7 @@ import openmdao.api as om
 import dymos as dm
 
 import unittest
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class ODEComp(om.ExplicitComponent):
@@ -28,24 +29,52 @@ class ODEComp(om.ExplicitComponent):
 
 class TestCannonballMatrixState(unittest.TestCase):
     """ Tests to verify that dymos can use matrix-states"""
-
-    def test_cannonball_matrix_state(self):
+    def _make_problem(self, tx):
         p = om.Problem()
 
         traj = dm.Trajectory()
         phase = dm.Phase(ode_class=ODEComp,
-                         transcription=dm.Radau(num_segments=10, order=3, solve_segments=True))
+                         transcription=tx)
         traj.add_phase('phase', phase)
         p.model.add_subsystem('traj', traj)
 
-        phase.set_time_options(fix_initial=True, duration_bounds=(5, 5))
+        phase.set_time_options(fix_initial=True, duration_bounds=(1, 5))
         phase.add_state('z', rate_source='zdot', fix_initial=True, units=None)
+
+        phase.add_boundary_constraint('z', loc='final', lower=0, upper=0, indices=[1])
+        phase.add_objective('time', loc='final')
+
+        p.driver = om.pyOptSparseDriver()
 
         p.setup()
 
+        p.set_val('traj.phase.t_initial', 0)
+        p.set_val('traj.phase.t_duration', 5)
         p.set_val('traj.phase.states:z', phase.interpolate(ys=[[[0, 0], [10, 10]], [[10, 0], [10, -10]]], nodes='state_input'))
 
-        p.run_model()
+        return p
 
-        p.model.list_outputs(print_arrays=True, residuals=True)
+    def test_cannonball_matrix_state_radau(self):
 
+        tx = dm.Radau(num_segments=10, order=3, solve_segments=True)
+
+        p = self._make_problem(tx)
+
+        p.run_driver()
+
+        assert_near_equal(p.get_val('traj.phase.timeseries.time')[-1], 2.03873598, tolerance=1E-5)
+        assert_near_equal(p.get_val('traj.phase.timeseries.states:z')[-1, 0, 1], 0.0, tolerance=1E-5)
+        assert_near_equal(p.get_val('traj.phase.timeseries.states:z')[-1, 0, 0], 20.3873598, tolerance=1E-5)
+
+        p.model.traj.simulate()
+
+    def test_cannonball_matrix_state_gl(self):
+        tx = dm.GaussLobatto(num_segments=10, order=3, solve_segments=True)
+
+        p = self._make_problem(tx)
+
+        p.run_driver()
+
+        assert_near_equal(p.get_val('traj.phase.timeseries.time')[-1], 2.03873598, tolerance=1E-5)
+        assert_near_equal(p.get_val('traj.phase.timeseries.states:z')[-1, 0, 1], 0.0, tolerance=1E-5)
+        assert_near_equal(p.get_val('traj.phase.timeseries.states:z')[-1, 0, 0], 20.3873598, tolerance=1E-5)

--- a/dymos/examples/cannonball/test/test_cannonball_matrix_state.py
+++ b/dymos/examples/cannonball/test/test_cannonball_matrix_state.py
@@ -1,9 +1,9 @@
-import numpy as np
 import openmdao.api as om
 import dymos as dm
 
 import unittest
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 
 class ODEComp(om.ExplicitComponent):
@@ -27,6 +27,7 @@ class ODEComp(om.ExplicitComponent):
         outputs['zdot'][:, 1, 1] = -9.81
 
 
+@use_tempdirs
 class TestCannonballMatrixState(unittest.TestCase):
     """ Tests to verify that dymos can use matrix-states"""
     def _make_problem(self, tx):
@@ -113,7 +114,7 @@ class TestCannonballMatrixState(unittest.TestCase):
 
         p = self._make_problem(tx)
 
-        p.run_driver()
+        dm.run_problem(p, simulate=True)
 
         assert_near_equal(p.get_val('traj.phase.timeseries.time')[-1], 2.03873598, tolerance=1E-5)
         assert_near_equal(p.get_val('traj.phase.timeseries.states:z')[-1, 0, 1], 0.0, tolerance=1E-5)

--- a/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise.py
@@ -175,12 +175,8 @@ def two_burn_orbit_raise_problem(transcription='gauss-lobatto', optimizer='SLSQP
                      compressed=compressed, connected=connected)
     p.model.add_subsystem('traj', subsys=traj)
 
-    # Finish Problem Setup
-
     # Needed to move the direct solver down into the phases for use with MPI.
     #  - After moving down, used fewer iterations (about 30 less)
-
-    p.driver.add_recorder(om.SqliteRecorder('two_burn_orbit_raise_example.db'))
 
     p.setup(check=True)
 

--- a/dymos/transcriptions/pseudospectral/gauss_lobatto.py
+++ b/dymos/transcriptions/pseudospectral/gauss_lobatto.py
@@ -1,4 +1,5 @@
 import numpy as np
+import openmdao.api as om
 
 from .pseudospectral_base import PseudospectralBase
 from .components import GaussLobattoInterleaveComp
@@ -181,20 +182,21 @@ class GaussLobatto(PseudospectralBase):
         for name, options in phase.state_options.items():
             size = np.prod(options['shape'])
 
-            src_idxs_mat = np.reshape(np.arange(size * num_input_nodes, dtype=int),
-                                      (num_input_nodes, size), order='C')
-            src_idxs = src_idxs_mat[map_input_indices_to_disc, :]
+            # src_idxs_mat = np.reshape(np.arange(size * num_input_nodes, dtype=int),
+            #                           (num_input_nodes, size), order='C')
+            # src_idxs = src_idxs_mat[map_input_indices_to_disc, :]
+            src_idxs = om.slicer[map_input_indices_to_disc, ...]
 
-            if size == 1:
-                """ Flat state variable is passed as 1D data."""
-                src_idxs = src_idxs.ravel()
+            # if size == 1:
+            #     """ Flat state variable is passed as 1D data."""
+            #     src_idxs = src_idxs.ravel()
 
             targets = get_targets(ode=phase.rhs_disc, name=name, user_targets=options['targets'])
 
             if targets:
                 phase.connect('states:{0}'.format(name),
                               ['rhs_disc.{0}'.format(tgt) for tgt in targets],
-                              src_indices=src_idxs, flat_src_indices=True)
+                              src_indices=src_idxs)
                 phase.connect('state_interp.state_col:{0}'.format(name),
                               ['rhs_col.{0}'.format(tgt) for tgt in targets])
 
@@ -202,23 +204,21 @@ class GaussLobatto(PseudospectralBase):
 
             phase.connect(rate_path,
                           'state_interp.staterate_disc:{0}'.format(name),
-                          src_indices=disc_src_idxs, flat_src_indices=True)
+                          src_indices=disc_src_idxs)
 
             phase.connect(rate_path,
                           'interleave_comp.disc_values:state_rates:{0}'.format(name),
-                          src_indices=disc_src_idxs, flat_src_indices=True)
+                          src_indices=disc_src_idxs)
 
             rate_path, col_src_idxs = self.get_rate_source_path(name, nodes='col', phase=phase)
 
             phase.connect(rate_path,
                           'interleave_comp.col_values:state_rates:{0}'.format(name),
-                          src_indices=col_src_idxs, flat_src_indices=True)
+                          src_indices=col_src_idxs)
 
         self.configure_interleave_comp(phase)
 
     def configure_interleave_comp(self, phase):
-
-        num_input_nodes = self.grid_data.subset_num_nodes['state_input']
 
         map_input_indices_to_disc = self.grid_data.input_maps['state_input_to_disc']
 
@@ -229,7 +229,6 @@ class GaussLobatto(PseudospectralBase):
         for state_name, options in phase.state_options.items():
             shape = options['shape']
             units = options['units']
-            rate_source = options['rate_source']
 
             interleave_comp = phase._get_subsystem('interleave_comp')
 
@@ -237,14 +236,9 @@ class GaussLobatto(PseudospectralBase):
             interleave_comp.add_var('state_rates:{0}'.format(state_name), shape,
                                     get_rate_units(options['units'], time_units))
 
-            size = np.prod(options['shape'])
-            src_idxs_mat = np.reshape(np.arange(size * num_input_nodes, dtype=int),
-                                      (num_input_nodes, size), order='C')
-            src_idxs = src_idxs_mat[map_input_indices_to_disc, :]
-
             phase.connect('states:{0}'.format(state_name),
                           'interleave_comp.disc_values:states:{0}'.format(state_name),
-                          src_indices=src_idxs, flat_src_indices=True)
+                          src_indices=om.slicer[map_input_indices_to_disc, ...])
 
             phase.connect('state_interp.state_col:{0}'.format(state_name),
                           'interleave_comp.col_values:states:{0}'.format(state_name))
@@ -275,7 +269,7 @@ class GaussLobatto(PseudospectralBase):
             rate_path, src_idxs = self.get_rate_source_path(name, nodes='col', phase=phase)
             phase.connect(rate_path,
                           'collocation_constraint.f_computed:{0}'.format(name),
-                          src_indices=src_idxs, flat_src_indices=True)
+                          src_indices=src_idxs)
 
     def configure_path_constraints(self, phase):
         super(GaussLobatto, self).configure_path_constraints(phase)
@@ -596,7 +590,7 @@ class GaussLobatto(PseudospectralBase):
             else:
                 raise ValueError('Unabled to find rate path for variable {0} at '
                                  'node subset {1}'.format(var, nodes))
-        src_idxs = get_src_indices_by_row(node_idxs, shape=shape)
+        src_idxs = om.slicer[node_idxs, ...]
 
         return rate_path, src_idxs
 

--- a/dymos/transcriptions/pseudospectral/pseudospectral_base.py
+++ b/dymos/transcriptions/pseudospectral/pseudospectral_base.py
@@ -223,7 +223,6 @@ class PseudospectralBase(TranscriptionBase):
     def configure_ode(self, phase):
         grid_data = self.grid_data
         map_input_indices_to_disc = grid_data.input_maps['state_input_to_disc']
-        num_input_nodes = grid_data.subset_num_nodes['state_input']
 
         phase.state_interp.configure_io()
 
@@ -233,14 +232,9 @@ class PseudospectralBase(TranscriptionBase):
         for name, options in phase.state_options.items():
             size = np.prod(options['shape'])
 
-            src_idxs_mat = np.reshape(np.arange(size * num_input_nodes, dtype=int),
-                                      (num_input_nodes, size), order='C')
-
-            src_idxs = src_idxs_mat[map_input_indices_to_disc, :]
-
             phase.connect('states:{0}'.format(name),
                           'state_interp.state_disc:{0}'.format(name),
-                          src_indices=src_idxs, flat_src_indices=True)
+                          src_indices=om.slicer[map_input_indices_to_disc, ...])
 
     def setup_defects(self, phase):
         """

--- a/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
+++ b/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
@@ -145,7 +145,7 @@ class Radau(PseudospectralBase):
 
             phase.connect(rate_src,
                           'collocation_constraint.f_computed:{0}'.format(name),
-                          src_indices=src_idxs, flat_src_indices=True)
+                          src_indices=src_idxs)
 
     def configure_path_constraints(self, phase):
         super(Radau, self).configure_path_constraints(phase)
@@ -255,15 +255,14 @@ class Radau(PseudospectralBase):
                                                       desc=f'rate of state {state_name}')
 
                 src_rows = gd.input_maps['state_input_to_disc']
-                src_idxs = get_src_indices_by_row(src_rows, options['shape'])
                 phase.connect(src_name=f'states:{state_name}',
                               tgt_name=f'{timeseries_name}.input_values:states:{state_name}',
-                              src_indices=src_idxs, flat_src_indices=True)
+                              src_indices=om.slicer[src_rows, ...])
 
                 rate_src, src_idxs = self.get_rate_source_path(state_name, 'all', phase)
                 phase.connect(src_name=rate_src,
                               tgt_name=f'{timeseries_name}.input_values:state_rates:{state_name}',
-                              src_indices=src_idxs, flat_src_indices=True)
+                              src_indices=src_idxs)
 
             for control_name, options in phase.control_options.items():
                 control_units = options['units']
@@ -480,7 +479,7 @@ class Radau(PseudospectralBase):
             rate_path = 'rhs_all.{0}'.format(var)
             node_idxs = gd.subset_node_indices[nodes]
 
-        src_idxs = get_src_indices_by_row(node_idxs, shape=shape)
+        src_idxs = om.slicer[node_idxs, ...]
 
         return rate_path, src_idxs
 

--- a/dymos/transcriptions/solve_ivp/components/ode_integration_interface_system.py
+++ b/dymos/transcriptions/solve_ivp/components/ode_integration_interface_system.py
@@ -76,8 +76,10 @@ class ODEIntegrationInterfaceSystem(om.Group):
 
         # Configure states
         for name, options in self.options['state_options'].items():
+            ndim = len(options['shape'])
+            size = np.prod(options['shape'])
             ivc.add_output(f'states:{name}',
-                           shape=(1, np.prod(options['shape'])),
+                           shape=(1, size),
                            units=options['units'])
 
             rate_src = self._get_rate_source_path(name)
@@ -85,9 +87,12 @@ class ODEIntegrationInterfaceSystem(om.Group):
             self.connect(rate_src, f'state_rate_collector.state_rates_in:{name}_rate')
 
             targets = get_targets(ode=ode, name=name, user_targets=options['targets'])
-
             if targets:
-                self.connect(f'states:{name}', [f'ode.{tgt}' for tgt in targets])
+                for tgt in targets:
+                    tgt_shape, _ = get_target_metadata(ode=ode, name=name, user_targets=tgt)
+                    src_idxs = np.arange(size, dtype=int).reshape(tgt_shape)
+                    self.connect(f'states:{name}', f'ode.{tgt}',
+                                 src_indices=src_idxs, flat_src_indices=True)
 
         # Configure controls
         if self.options['control_options']:


### PR DESCRIPTION
### Summary

Matrix-shaped states are encountering connection errors in various components.
This fix uses OpenMDAO's slicer to connect these components correctly regardless of their dimension.
Similar changes were required in simulation.
Adds a new test: test_cannonball_matrix_states.py, which packs the state for two-dimensional ballistic trajectories `[x, y, vx, vy]` as a 2 x 2 matrix `[[x, y], [vx, vy]]`.

### Related Issues

- Resolves #440 

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
