### PR TITLE
Parameter shapes are now as expected, not prepended by (1,)

### DIFF
--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
@@ -81,15 +81,12 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         phase.set_time_options(initial_bounds=(0, 0), duration_bounds=(.5, 10))
 
         phase.add_state('x', rate_source=BrachistochroneODE.states['x']['rate_source'],
-                        units=BrachistochroneODE.states['x']['units'],
                         fix_initial=True, fix_final=True, solve_segments=False)
 
         phase.add_state('y', rate_source=BrachistochroneODE.states['y']['rate_source'],
-                        units=BrachistochroneODE.states['y']['units'],
                         fix_initial=True, fix_final=True, solve_segments=False)
 
         phase.add_state('v', rate_source=BrachistochroneODE.states['v']['rate_source'],
-                        units=BrachistochroneODE.states['v']['units'],
                         fix_initial=True, fix_final=False, solve_segments=False)
 
         phase.add_control('theta', continuity=True, rate_continuity=True,

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
@@ -57,6 +57,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         import dymos as dm
         from dymos.examples.plotting import plot_results
         from dymos.examples.brachistochrone import BrachistochroneODE
+        import matplotlib.pyplot as plt
 
         #
         # Initialize the Problem and the optimization driver

--- a/dymos/trajectory/test/test_phase_linkage_comp.py
+++ b/dymos/trajectory/test/test_phase_linkage_comp.py
@@ -14,7 +14,6 @@ from dymos.trajectory.options import LinkageOptionsDictionary
 class TestPhaseLinkageComp(unittest.TestCase):
 
     def setUp(self):
-
         dm.options['include_check_partials'] = True
         self.p = om.Problem(model=om.Group())
 
@@ -101,6 +100,9 @@ class TestPhaseLinkageComp(unittest.TestCase):
         self.p['phase1:v'] = np.random.rand(*self.p['phase1:v'].shape)
 
         self.p.run_model()
+
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
 
     def test_results(self):
 

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -372,7 +372,7 @@ class Trajectory(om.Group):
             targets = options['targets']
 
             val = options['val']
-            _shape = (1,) + options['shape']
+            _shape = options['shape']
             shaped_val = np.broadcast_to(val, _shape)
 
             self.set_input_defaults(name=prom_name,

--- a/dymos/transcriptions/common/test/test_boundary_constraint_comp.py
+++ b/dymos/transcriptions/common/test/test_boundary_constraint_comp.py
@@ -18,6 +18,7 @@ class TestInitialScalarBoundaryValue(unittest.TestCase):
 
     def setUp(self):
         dm.options['include_check_partials'] = True
+
         self.p = om.Problem(model=om.Group())
 
         ivp = self.p.model.add_subsystem('ivc', subsys=om.IndepVarComp(), promotes_outputs=['*'])
@@ -33,6 +34,9 @@ class TestInitialScalarBoundaryValue(unittest.TestCase):
         self.p.setup(force_alloc_complex=True)
         self.p.run_model()
 
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
+
     def test_results(self):
 
         self.assertAlmostEqual(self.p['bv_comp.initial_value_in:x'][0], self.p['x'][0])
@@ -47,6 +51,7 @@ class TestFinalScalarBoundaryValue(unittest.TestCase):
 
     def setUp(self):
         dm.options['include_check_partials'] = True
+
         self.p = om.Problem(model=om.Group())
 
         ivp = self.p.model.add_subsystem('ivc', subsys=om.IndepVarComp(), promotes_outputs=['*'])
@@ -62,6 +67,9 @@ class TestFinalScalarBoundaryValue(unittest.TestCase):
         self.p.setup(force_alloc_complex=True)
         self.p.run_model()
 
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
+
     def test_results(self):
 
         self.assertAlmostEqual(self.p['bv_comp.final_value_in:x'][0], self.p['x'][-1])
@@ -76,6 +84,7 @@ class TestVectorInitialBoundaryValue(unittest.TestCase):
 
     def setUp(self):
         dm.options['include_check_partials'] = True
+
         self.p = om.Problem(model=om.Group())
 
         ivp = self.p.model.add_subsystem('ivc', subsys=om.IndepVarComp(), promotes_outputs=['*'])
@@ -99,6 +108,9 @@ class TestVectorInitialBoundaryValue(unittest.TestCase):
 
         self.p.run_model()
 
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
+
     def test_results(self):
         assert_almost_equal(self.p['bv_comp.initial_value_in:pos'], self.p['pos'][0, :])
         assert_almost_equal(self.p['bv_comp.initial_value:pos'], self.p['pos'][0, :])
@@ -111,6 +123,7 @@ class TestVectorInitialBoundaryValue(unittest.TestCase):
 class TestVectorFinalBoundaryValue(unittest.TestCase):
 
     def setUp(self):
+        dm.options['include_check_partials'] = True
 
         self.p = om.Problem(model=om.Group())
 
@@ -135,6 +148,9 @@ class TestVectorFinalBoundaryValue(unittest.TestCase):
 
         self.p.run_model()
 
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
+
     def test_results(self):
 
         assert_almost_equal(self.p['bv_comp.final_value_in:pos'], self.p['pos'][-1, :])
@@ -148,6 +164,7 @@ class TestVectorFinalBoundaryValue(unittest.TestCase):
 class TestMatrixInitialBoundaryValue(unittest.TestCase):
 
     def setUp(self):
+        dm.options['include_check_partials'] = True
 
         self.p = om.Problem(model=om.Group())
 
@@ -180,6 +197,9 @@ class TestMatrixInitialBoundaryValue(unittest.TestCase):
 
         self.p.run_model()
 
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
+
     def test_results(self):
 
         assert_almost_equal(self.p['bv_comp.initial_value_in:M'], self.p['M'][0, ...])
@@ -193,6 +213,7 @@ class TestMatrixInitialBoundaryValue(unittest.TestCase):
 class TestMatrixFinalBoundaryValue(unittest.TestCase):
 
     def setUp(self):
+        dm.options['include_check_partials'] = True
 
         self.p = om.Problem(model=om.Group())
 
@@ -225,6 +246,9 @@ class TestMatrixFinalBoundaryValue(unittest.TestCase):
 
         self.p.run_model()
 
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
+
     def test_results(self):
 
         assert_almost_equal(self.p['bv_comp.final_value_in:M'], self.p['M'][-1, ...])
@@ -238,6 +262,7 @@ class TestMatrixFinalBoundaryValue(unittest.TestCase):
 class TestMultipleConstraints(unittest.TestCase):
 
     def setUp(self):
+        dm.options['include_check_partials'] = True
 
         self.p = om.Problem(model=om.Group())
 
@@ -293,6 +318,9 @@ class TestMultipleConstraints(unittest.TestCase):
         self.p['pos'][:, 2] = 100000 + 200 + np.arange(100)
 
         self.p.run_model()
+
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
 
     def test_results(self):
 

--- a/dymos/transcriptions/common/test/test_control_interp_comp.py
+++ b/dymos/transcriptions/common/test/test_control_interp_comp.py
@@ -71,6 +71,12 @@ def f2_d(t):
 
 class TestControlRateComp(unittest.TestCase):
 
+    def setUp(self):
+        dm.options['include_check_partials'] = True
+
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
+
     @parameterized.expand(
         itertools.product(['gauss-lobatto', 'radau-ps'],  # transcription
                           [True, False],  # compressed
@@ -78,7 +84,6 @@ class TestControlRateComp(unittest.TestCase):
             ['test_control_interp_scalar', p.args[0], str(p.args[1])])
     )
     def test_control_interp_scalar(self, transcription='gauss-lobatto', compressed=True):
-        dm.options['include_check_partials'] = True
         segends = np.array([0.0, 3.0, 10.0])
 
         gd = GridData(num_segments=2,
@@ -170,7 +175,6 @@ class TestControlRateComp(unittest.TestCase):
             ['test_control_interp_scalar_RK4', str(p.args[0])]))
     def test_control_interp_scalar_rk4(self, compressed=False):
 
-        dm.options['include_check_partials'] = True
         segends = np.array([0.0, 3.0, 9.0])
 
         gd = GridData(num_segments=2,
@@ -357,7 +361,6 @@ class TestControlRateComp(unittest.TestCase):
     )
     def test_control_interp_matrix_3x1(self, transcription='gauss-lobatto', compressed=True):
 
-        dm.options['include_check_partials'] = True
         segends = np.array([0.0, 3.0, 10.0])
 
         gd = GridData(num_segments=2,
@@ -459,7 +462,6 @@ class TestControlRateComp(unittest.TestCase):
     )
     def test_control_interp_matrix_2x2(self, transcription='gauss-lobatto', compressed=True):
 
-        dm.options['include_check_partials'] = True
         segends = np.array([0.0, 3.0, 10.0])
 
         gd = GridData(num_segments=2,

--- a/dymos/transcriptions/common/test/test_path_constraint_comp.py
+++ b/dymos/transcriptions/common/test/test_path_constraint_comp.py
@@ -62,6 +62,9 @@ class TestPathConstraintComp(unittest.TestCase):
 
         self.p.run_model()
 
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
+
     def test_results(self):
         p = self.p
         gd = self.gd

--- a/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_opt.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_opt.py
@@ -78,6 +78,9 @@ class TestCollocationComp(unittest.TestCase):
 
         self.p.run_model()
 
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
+
     def test_results(self):
         dt_dstau = self.p['dt_dstau']
 

--- a/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_sol_opt.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_sol_opt.py
@@ -19,7 +19,12 @@ StateIndependentsComp = CompWrapperConfig(StateIndependentsComp)
 
 class TestCollocationCompSolOpt(unittest.TestCase):
 
-    # def setUp(self):
+    def setUp(self):
+        dm.options['include_check_partials'] = True
+
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
+
     def make_prob(self, transcription, n_segs, order, compressed):
 
         p = om.Problem(model=om.Group())
@@ -99,8 +104,6 @@ class TestCollocationCompSolOpt(unittest.TestCase):
                             dt_dstau[:, np.newaxis, np.newaxis] *
                             (p['f_approx:v']-p['f_computed:v']))
 
-        #################################################################################
-        #################################################################################
         p = self.make_prob('gauss-lobatto', n_segs=4, order=3, compressed=True)
 
         dt_dstau = p['dt_dstau']

--- a/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_solver.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_solver.py
@@ -10,12 +10,19 @@ from dymos.transcriptions.pseudospectral.components.collocation_comp import Coll
 from dymos.transcriptions.pseudospectral.components.state_independents import StateIndependentsComp
 
 # Modify class so we can run it standalone.
+import dymos as dm
 from dymos.utils.misc import CompWrapperConfig
 CollocationComp = CompWrapperConfig(CollocationComp)
 StateIndependentsComp = CompWrapperConfig(StateIndependentsComp)
 
 
 class TestCollocationBalanceIndex(unittest.TestCase):
+
+    def setUp(self):
+        dm.options['include_check_partials'] = True
+
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
 
     def make_prob(self, transcription, n_segs, order, compressed):
 
@@ -112,6 +119,12 @@ class TestCollocationBalanceIndex(unittest.TestCase):
 
 
 class TestCollocationBalanceApplyNL(unittest.TestCase):
+
+    def setUp(self):
+        dm.options['include_check_partials'] = True
+
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
 
     def make_prob(self, transcription, n_segs, order, compressed):
 

--- a/dymos/transcriptions/pseudospectral/components/test/test_control_endpoint_defect_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_control_endpoint_defect_comp.py
@@ -6,6 +6,7 @@ import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 from dymos.utils.testing_utils import assert_check_partials
 
+import dymos as dm
 from dymos.transcriptions.pseudospectral.components import ControlEndpointDefectComp
 from dymos.transcriptions.grid_data import GridData
 
@@ -13,6 +14,7 @@ from dymos.transcriptions.grid_data import GridData
 class TestControlEndpointDefectComp(unittest.TestCase):
 
     def setUp(self):
+        dm.options['include_check_partials'] = True
         gd = GridData(num_segments=2, segment_ends=np.array([0., 2., 4.]),
                       transcription='radau-ps', transcription_order=3)
 
@@ -45,6 +47,9 @@ class TestControlEndpointDefectComp(unittest.TestCase):
         self.p['controls:v'] = np.random.random((gd.subset_num_nodes['all'], 3, 2))
 
         self.p.run_model()
+
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
 
     def test_results(self):
 

--- a/dymos/transcriptions/pseudospectral/components/test/test_gauss_lobatto_interleave_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_gauss_lobatto_interleave_comp.py
@@ -6,6 +6,7 @@ import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 from dymos.utils.testing_utils import assert_check_partials
 
+import dymos as dm
 from dymos.transcriptions.pseudospectral.components import GaussLobattoInterleaveComp
 from dymos.transcriptions.grid_data import GridData
 
@@ -13,6 +14,8 @@ from dymos.transcriptions.grid_data import GridData
 class TestGaussLobattoInterleaveComp(unittest.TestCase):
 
     def setUp(self):
+        dm.options['include_check_partials'] = True
+
         self.grid_data = gd = GridData(num_segments=3, segment_ends=np.array([0., 2., 4., 10.0]),
                                        transcription='gauss-lobatto', transcription_order=[3, 3, 3])
 
@@ -70,6 +73,9 @@ class TestGaussLobattoInterleaveComp(unittest.TestCase):
         self.p['state_col:v'] = np.random.random((num_col_nodes, 3, 2))
 
         self.p.run_model()
+
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
 
     def test_results(self):
 

--- a/dymos/transcriptions/pseudospectral/components/test/test_state_interp_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_state_interp_comp.py
@@ -10,6 +10,7 @@ from dymos.transcriptions.grid_data import GridData
 from dymos.utils.lgr import lgr
 
 # Modify class so we can run it standalone.
+import dymos as dm
 from dymos.utils.misc import CompWrapperConfig
 StateInterpComp = CompWrapperConfig(StateInterpComp)
 
@@ -38,6 +39,12 @@ def f_v(t):
 
 
 class TestStateInterpComp(unittest.TestCase):
+
+    def setUp(self):
+        dm.options['include_check_partials'] = True
+
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
 
     def test_state_interp_comp_lobatto(self):
 

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_iter_group.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_continuity_iter_group.py
@@ -5,11 +5,18 @@ import numpy as np
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 
+import dymos as dm
 from dymos.transcriptions.runge_kutta.components import RungeKuttaStateContinuityIterGroup
 from dymos.transcriptions.runge_kutta.test.rk_test_ode import TestODE
 
 
 class TestRungeKuttaContinuityIterGroup(unittest.TestCase):
+
+    def setUp(self):
+        dm.options['include_check_partials'] = True
+
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
 
     def test_continuity_comp_no_iteration(self):
         num_seg = 4

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_k_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_k_comp.py
@@ -6,6 +6,7 @@ import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 from dymos.utils.testing_utils import assert_check_partials
 
+import dymos as dm
 from dymos.transcriptions.runge_kutta.components.runge_kutta_k_comp import RungeKuttaKComp
 
 # Modify class so we can run it standalone.
@@ -14,6 +15,12 @@ RungeKuttaKComp = CompWrapperConfig(RungeKuttaKComp)
 
 
 class TestRKKComp(unittest.TestCase):
+
+    def setUp(self):
+        dm.options['include_check_partials'] = True
+
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
 
     def test_rk_k_comp_rk4_scalar(self):
         state_options = {'y': {'shape': (1,), 'units': 'm'}}

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_state_advance_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_state_advance_comp.py
@@ -6,6 +6,7 @@ import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 from dymos.utils.testing_utils import assert_check_partials
 
+import dymos as dm
 from dymos.transcriptions.runge_kutta.components.runge_kutta_state_advance_comp import \
     RungeKuttaStateAdvanceComp
 
@@ -15,6 +16,12 @@ RungeKuttaStateAdvanceComp = CompWrapperConfig(RungeKuttaStateAdvanceComp)
 
 
 class TestRKStateAdvanceComp(unittest.TestCase):
+
+    def setUp(self):
+        dm.options['include_check_partials'] = True
+
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
 
     def test_rk_state_advance_comp_rk4_scalar(self):
         state_options = {'y': {'shape': (1,), 'units': 'm'}}

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_state_predict_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_state_predict_comp.py
@@ -8,6 +8,7 @@ from dymos.utils.testing_utils import assert_check_partials
 
 from dymos.transcriptions.runge_kutta.components.runge_kutta_state_predict_comp import \
     RungeKuttaStatePredictComp
+import dymos as dm
 
 # Modify class so we can run it standalone.
 from dymos.utils.misc import CompWrapperConfig
@@ -15,6 +16,12 @@ RungeKuttaStatePredictComp = CompWrapperConfig(RungeKuttaStatePredictComp)
 
 
 class TestRKStatePredictComp(unittest.TestCase):
+
+    def setUp(self) -> None:
+        dm.options['include_check_partials'] = True
+
+    def tearDown(self) -> None:
+        dm.options['include_check_partials'] = False
 
     def test_rk_state_predict_comp_rk4(self):
         num_seg = 4
@@ -82,7 +89,6 @@ class TestRKStatePredictComp(unittest.TestCase):
                              [5.308168919136127]])
 
         assert_near_equal(p.get_val('c.predicted_states:y'), expected)
-
         cpd = p.check_partials(method='cs', out_stream=None)
         assert_check_partials(cpd)
 

--- a/dymos/transcriptions/runge_kutta/components/test/test_rk_stepsize_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/test/test_rk_stepsize_comp.py
@@ -6,6 +6,7 @@ import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 from dymos.utils.testing_utils import assert_check_partials
 
+import dymos as dm
 from dymos.transcriptions.runge_kutta.components.runge_kutta_stepsize_comp import RungeKuttaStepsizeComp
 
 from dymos.utils.misc import CompWrapperConfig
@@ -13,6 +14,12 @@ RungeKuttaStepsizeComp = CompWrapperConfig(RungeKuttaStepsizeComp)
 
 
 class TestRKStepsizeComp(unittest.TestCase):
+
+    def setUp(self):
+        dm.options['include_check_partials'] = True
+
+    def tearDown(self):
+        dm.options['include_check_partials'] = False
 
     def test_rk_stepsize_comp(self):
         p = om.Problem(model=om.Group())

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -242,7 +242,7 @@ class TranscriptionBase(object):
                                        src_indices=src_idxs, flat_src_indices=True)
 
                 val = options['val']
-                _shape = (1,) + options['shape']
+                _shape = options['shape']
                 shaped_val = np.broadcast_to(val, _shape)
                 phase.set_input_defaults(name=src_name,
                                          val=shaped_val,


### PR DESCRIPTION
### Summary

Parameter shapes were being prepended by (1,), which led to unexpected behavior when retrieving values.

Also made an effort to further isolate a lot of check_partials tests where side effects from `dm.options['include_check_partials']` in other tests were causing unintended behavior.

### Related Issues

- Resolves #439

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
