### PR TITLE
allow Numpy array as a boundary constraint

### DIFF
--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -1189,7 +1189,7 @@ class Phase(om.Group):
         bc_dict[name]['indices'] = indices
         bc_dict[name]['lower'] = lower
         bc_dict[name]['upper'] = upper
-        bc_dict[name]['equals'] = list(equals) if type(equals) is np.ndarray else equals
+        bc_dict[name]['equals'] = equals
         bc_dict[name]['scaler'] = scaler
         bc_dict[name]['adder'] = adder
         bc_dict[name]['ref0'] = ref0

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -1189,7 +1189,7 @@ class Phase(om.Group):
         bc_dict[name]['indices'] = indices
         bc_dict[name]['lower'] = lower
         bc_dict[name]['upper'] = upper
-        bc_dict[name]['equals'] = equals
+        bc_dict[name]['equals'] = list(equals) if type(equals) is np.ndarray else equals
         bc_dict[name]['scaler'] = scaler
         bc_dict[name]['adder'] = adder
         bc_dict[name]['ref0'] = ref0

--- a/dymos/phase/test/test_add_boundary_constraint_array.py
+++ b/dymos/phase/test/test_add_boundary_constraint_array.py
@@ -47,11 +47,7 @@ class BrachistochroneVectorStatesODE(om.ExplicitComponent):
 p = om.Problem(model=om.Group())
 
 p.driver = om.pyOptSparseDriver()
-p.driver.options['optimizer'] = 'SNOPT'
-p.driver.opt_settings['Major iterations limit'] = 100
-p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
-p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
-p.driver.opt_settings['iSumm'] = 6
+p.driver.options['optimizer'] = 'SLSQP'
 
 p.driver.declare_coloring()
 

--- a/dymos/phase/test/test_add_boundary_constraint_array.py
+++ b/dymos/phase/test/test_add_boundary_constraint_array.py
@@ -1,0 +1,111 @@
+import numpy as np
+import openmdao.api as om
+import dymos as dm
+
+
+class BrachistochroneVectorStatesODE(om.ExplicitComponent):
+    def initialize(self):
+        self.options.declare('num_nodes', types=int)
+
+    def setup(self):
+        nn = self.options['num_nodes']
+
+        self.add_input('v', val=np.zeros(nn), desc='velocity', units='m/s')
+        self.add_input('g', val=9.80665 * np.ones(nn), desc='grav. acceleration', units='m/s/s')
+        self.add_input('theta', val=np.zeros(nn), desc='angle of wire', units='rad')
+
+        self.add_output('pos_dot', val=np.zeros((nn, 2)), desc='velocity components', units='m/s')
+        self.add_output('vdot', val=np.zeros(nn), desc='acceleration magnitude', units='m/s**2')
+        self.add_output('check', val=np.zeros(nn), desc='check solution: v/sin(theta) = constant', units='m/s')
+
+        # Setup partials
+        arange = np.arange(self.options['num_nodes'])
+
+        self.declare_partials(of='vdot', wrt='g', rows=arange, cols=arange)
+        self.declare_partials(of='vdot', wrt='theta', rows=arange, cols=arange)
+
+        rs = np.arange(2*nn, dtype=int)
+        cs = np.repeat(np.arange(nn, dtype=int), 2)
+
+        self.declare_partials('*', '*', method='cs')
+        self.declare_coloring(wrt='*', method='cs', show_sparsity=True)
+
+    def compute(self, inputs, outputs):
+        theta = inputs['theta']
+        cos_theta = np.cos(theta)
+        sin_theta = np.sin(theta)
+        g = inputs['g']
+        v = inputs['v']
+
+        outputs['vdot'] = g * cos_theta
+        outputs['pos_dot'][:, 0] = v * sin_theta
+        outputs['pos_dot'][:, 1] = -v * cos_theta
+
+        outputs['check'] = v / sin_theta
+
+
+p = om.Problem(model=om.Group())
+
+p.driver = om.pyOptSparseDriver()
+p.driver.options['optimizer'] = 'SNOPT'
+p.driver.opt_settings['Major iterations limit'] = 100
+p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
+p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
+p.driver.opt_settings['iSumm'] = 6
+
+p.driver.declare_coloring()
+
+transcription = dm.GaussLobatto(num_segments=3,
+                                order=3,
+                                compressed=True, solve_segments=True)
+fix_final = True
+
+traj = dm.Trajectory()
+phase = dm.Phase(ode_class=BrachistochroneVectorStatesODE,
+                 transcription=transcription)
+traj.add_phase('phase0', phase)
+
+p.model.add_subsystem('traj0', traj)
+
+phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10), units='s')
+
+# can't fix final position if you're solving the segments
+phase.add_state('pos',
+                rate_source='pos_dot', units='m',
+                fix_initial=True, shape=(2, 2))
+
+# test add_boundary_constraint with arrays:
+expected = np.array([10, 5])
+phase.add_boundary_constraint(name='pos', loc='final', lower=expected-1)
+phase.add_boundary_constraint(name='pos', loc='final', upper=expected+1)
+phase.add_boundary_constraint(name='pos', loc='final', equals=expected)
+
+phase.add_state('v',
+                rate_source='vdot', units='m/s',
+                fix_initial=True, fix_final=False)
+
+phase.add_control('theta',
+                  continuity=True, rate_continuity=True,
+                  units='deg', lower=0.01, upper=179.9)
+
+phase.add_parameter('g', units='m/s**2', val=9.80665, opt=False)
+
+# Minimize time at the end of the phase
+phase.add_objective('time', loc='final', scaler=10)
+
+p.model.linear_solver = om.DirectSolver()
+p.setup(check=True, force_alloc_complex=True)
+p.final_setup()
+
+p['traj0.phase0.t_initial'] = 0.0
+p['traj0.phase0.t_duration'] = 1.8016
+
+pos0 = [0, 10]
+posf = [10, 5]
+
+p['traj0.phase0.states:pos'] = phase.interpolate(ys=[pos0, posf], nodes='state_input')
+p['traj0.phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+p['traj0.phase0.controls:theta'] = phase.interpolate(ys=[5, 100], nodes='control_input')
+p['traj0.phase0.parameters:g'] = 9.80665
+
+p.run_driver()

--- a/dymos/phase/test/test_add_boundary_constraint_array.py
+++ b/dymos/phase/test/test_add_boundary_constraint_array.py
@@ -72,7 +72,7 @@ phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10), units='s')
 # can't fix final position if you're solving the segments
 phase.add_state('pos',
                 rate_source='pos_dot', units='m',
-                fix_initial=True, shape=(2, 2))
+                fix_initial=True)
 
 # test add_boundary_constraint with arrays:
 expected = np.array([10, 5])

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -445,22 +445,22 @@ class TranscriptionBase(object):
                                      'compatible the provided indices. Provide them as a '
                                      'flat array with the same size as indices.'.format(var))
 
-            elif options['lower'] or options['upper'] or options['equals']:
+            elif 'lower' in options or 'upper' in options or 'equals' in options:
                 # Indices not provided, make sure lower/upper/equals have shape of source.
-                if options['lower'] and not np.isscalar(options['lower']) and \
-                        np.asarray(options['lower']).shape != shape:
+                if 'lower' in options and options['lower'] is not None and \
+                        not np.isscalar(options['lower']) and np.asarray(options['lower']).shape != shape:
                     raise ValueError('The lower bounds of boundary constraint on {0} are not '
                                      'compatible with its shape, and no indices were '
                                      'provided.'.format(var))
 
-                if options['upper'] and not np.isscalar(options['upper']) and \
-                        np.asarray(options['upper']).shape != shape:
+                if 'upper' in options and options['upper'] is not None and \
+                        not np.isscalar(options['upper']) and np.asarray(options['upper']).shape != shape:
                     raise ValueError('The upper bounds of boundary constraint on {0} are not '
                                      'compatible with its shape, and no indices were '
                                      'provided.'.format(var))
 
-                if options['equals'] and not np.isscalar(options['equals']) \
-                        and np.asarray(options['equals']).shape != shape:
+                if 'equals' in options and options['equals'] is not None and \
+                        not np.isscalar(options['equals']) and np.asarray(options['equals']).shape != shape:
                     raise ValueError('The equality boundary constraint value on {0} is not '
                                      'compatible with its shape, and no indices were '
                                      'provided.'.format(var))

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -451,19 +451,22 @@ class TranscriptionBase(object):
                         not np.isscalar(options['lower']) and np.asarray(options['lower']).shape != shape:
                     raise ValueError('The lower bounds of boundary constraint on {0} are not '
                                      'compatible with its shape, and no indices were '
-                                     'provided.'.format(var))
+                                     'provided. Expected a shape of {1} but given shape '
+                                     'is {2}'.format(var, shape, np.asarray(options['lower']).shape))
 
                 if 'upper' in options and options['upper'] is not None and \
                         not np.isscalar(options['upper']) and np.asarray(options['upper']).shape != shape:
                     raise ValueError('The upper bounds of boundary constraint on {0} are not '
                                      'compatible with its shape, and no indices were '
-                                     'provided.'.format(var))
+                                     'provided. Expected a shape of {1} but given shape '
+                                     'is {2}'.format(var, shape, np.asarray(options['upper']).shape))
 
                 if 'equals' in options and options['equals'] is not None and \
                         not np.isscalar(options['equals']) and np.asarray(options['equals']).shape != shape:
                     raise ValueError('The equality boundary constraint value on {0} is not '
                                      'compatible with its shape, and no indices were '
-                                     'provided.'.format(var))
+                                     'provided. Expected a shape of {1} but given shape '
+                                     'is {2}'.format(var, shape, np.asarray(options['equals']).shape))
                 con_shape = (np.prod(shape),)
 
             size = np.prod(shape)

--- a/release_notes.md
+++ b/release_notes.md
@@ -21,6 +21,8 @@ improved handling of parameters.
 
 * Fixes a bug where user-defined shapes of states were colliding with those found during introspection, and other state introspection updates. [#449](https://github.com/OpenMDAO/dymos/pull/449)
 
+* Fixes a bug that prevented the use of numpy arrays as a boundary constraints [#450](https://github.com/OpenMDAO/dymos/pull/450)
+
 ## Miscellaneous
 
 * Added test to verify functionality of OpenMDAO 3.4.1 that allows the final value of a control (or a partial portion of any output) to be connected to a parameter. [#445](https://github.com/OpenMDAO/dymos/pull/445)
@@ -131,4 +133,3 @@ If you rely on this capability, we recommend waiting for that update before usin
 * [__Enhancement__] ODE options can be specified at the phase level rather than in the ODE. This feature is experimental, but it allows one way of programmatically defining an ODE.
 * [__Enhancement__] Changed the use of OpenMDAO to do `import openmdao.api as om` for consistency with the OpenMDAO documentation.
 * [__Enhancement__] Dymos is now imported in the examples as import `dymos as dm`
-


### PR DESCRIPTION
### Summary

Setting the equals argument of add_boundary_constraint works if its a list but not an array. The documentations says that an array should be allowed.

### Related Issues

- Resolves #447

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
