### PR TITLE
Release notes 0.16.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.16.1-dev
+current_version = 0.16.1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/dymos/__init__.py
+++ b/dymos/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.16.1-dev'
+__version__ = '0.16.1'
 
 from .phase import Phase
 from .transcriptions import GaussLobatto, Radau, RungeKutta

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from scipy import interpolate
 
+import openmdao
 import openmdao.api as om
 from openmdao.core.system import System
 from openmdao.utils.general_utils import warn_deprecation
@@ -17,6 +18,10 @@ from .options import ControlOptionsDictionary, ParameterOptionsDictionary, \
 
 from ..transcriptions.transcription_base import TranscriptionBase
 from ..utils.misc import _unspecified
+
+
+om_dev_version = openmdao.__version__.endswith('dev')
+om_version = tuple(int(s) for s in openmdao.__version__.split('-')[0].split('.'))
 
 
 class Phase(om.Group):
@@ -1919,7 +1924,11 @@ class Phase(om.Group):
 
             # We use this private function to grab the correctly sized variable from the
             # auto_ivc source.
-            val = phs.get_val(f'parameters:{name}')
+            if om_version < (3, 4, 1):
+                val = phs.get_val(f'parameters:{name}')[0, ...]
+            else:
+                val = phs.get_val(f'parameters:{name}')
+
             if phase_path:
                 prob_path = '{0}.{1}.parameters:{2}'.format(phase_path, self.name, name)
             else:

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,7 +6,8 @@ November 13, 2020
 This release of Dymos fixes an issue that now allows portions of an array
 output to be connected to a parameter.
 
-This version requires OpenMDAO 3.4.1.
+This version works with OpenMDAO 3.3.0 but version 3.4.1 offers some
+improved handling of parameters.
 
 ## Backwards Incompatible API Changes & Deprecations
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,4 +1,34 @@
 ********************************
+# Release Notes for Dymos 0.16.1
+
+November 13, 2020
+
+This release of Dymos fixes an issue that now allows portions of an array
+output to be connected to a parameter.
+
+This version requires OpenMDAO 3.4.1.
+
+## Backwards Incompatible API Changes & Deprecations
+
+* Parameter shapes in 0.16.1 were stored as (1,) + the shape of the parameter.  Now they are shaped as expected. [#444](https://github.com/OpenMDAO/dymos/pull/444)
+
+## Enhancements
+
+* State shapes and units, if not explicitly given, are now pulled from targets (if present and uniquely defined), or from the rate source variable. [#449](https://github.com/OpenMDAO/dymos/pull/449)
+
+## Bug Fixes
+
+* Fixes a bug where user-defined shapes of states were colliding with those found during introspection, and other state introspection updates. [#449](https://github.com/OpenMDAO/dymos/pull/449)
+
+## Miscellaneous
+
+* Added test to verify functionality of OpenMDAO 3.4.1 that allows the final value of a control (or a partial portion of any output) to be connected to a parameter. [#445](https://github.com/OpenMDAO/dymos/pull/445)
+
+
+None
+
+
+********************************
 # Release Notes for Dymos 0.16.0
 
 October 23, 2020

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(name='dymos',
     packages=find_packages(),
     python_requires=">=3.6",
     install_requires=[
-        'openmdao>=3.3.0',
+        'openmdao>=3.4.1',
         'numpy>=1.14.1',
         'scipy>=1.0.0'
     ],

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ optional_dependencies['all'] = sorted([
 
 
 setup(name='dymos',
-    version='0.16.1-dev',
+    version='0.16.1',
     description='Open-Source Optimization of Dynamic Multidisciplinary Systems',
     url='https://github.com/OpenMDAO/dymos',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(name='dymos',
     description='Open-Source Optimization of Dynamic Multidisciplinary Systems',
     url='https://github.com/OpenMDAO/dymos',
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: Apache 2.0',
         'Natural Language :: English',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ optional_dependencies['all'] = sorted([
 
 
 setup(name='dymos',
-    version='0.16.1',
+    version='0.16.1-dev',
     description='Open-Source Optimization of Dynamic Multidisciplinary Systems',
     url='https://github.com/OpenMDAO/dymos',
     classifiers=[
@@ -49,7 +49,7 @@ setup(name='dymos',
     packages=find_packages(),
     python_requires=">=3.6",
     install_requires=[
-        'openmdao>=3.4.1',
+        'openmdao>=3.3.0',
         'numpy>=1.14.1',
         'scipy>=1.0.0'
     ],


### PR DESCRIPTION
### Summary

Add release notes for 0.16.1
Dymos now requires OpenMDAO 3.4.1
Bumped version to 0.16.1

### Related Issues

- N/A

### Status

- [ ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
