### PR TITLE
setup now has the correct version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ optional_dependencies['all'] = sorted([
 
 
 setup(name='dymos',
-    version='0.16.1-dev',
+    version='0.16.1',
     description='Open-Source Optimization of Dynamic Multidisciplinary Systems',
     url='https://github.com/OpenMDAO/dymos',
     classifiers=[


### PR DESCRIPTION
### Summary

Fixed a parsing error that led to setup.py showing version 0.16.1-dev

### Related Issues

None

### Status

- [ ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
