### PR TITLE
fix for apache license string in setup.py classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='dymos',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: Apache 2.0',
+        'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: POSIX :: Linux',


### PR DESCRIPTION
### Summary

The apache license string in Dymos is not recognized as a valid license by PyPI.

### Related Issues

None

### Status

- [ ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
