### PR TITLE
add long_description for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,14 @@ optional_dependencies['all'] = sorted([
 setup(name='dymos',
     version='0.16.2-dev',
     description='Open-Source Optimization of Dynamic Multidisciplinary Systems',
+    long_description='''
+Dymos is a framework for the simulation and optimization of dynamical systems within the OpenMDAO Multidisciplinary Analysis and Optimization environment.
+Dymos leverages implicit and explicit simulation techniques to simulate generic dynamic systems of arbitary complexity.
+
+The software has two primary objectives:
+-   Provide a generic ODE integration interface that allows for the analysis of dynamical systems.
+-   Allow the user to solve optimal control problems involving dynamical multidisciplinary systems.''',
+    long_description_content_type='text/markdown',
     url='https://github.com/OpenMDAO/dymos',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
### Summary

Dymos is now on PyPI but setup.py lacks a `long_description` field.

I added one, and tested by uploading to https://test.pypi.org.

### Related Issues

- Resolves #459

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
