### PR TITLE
Fixed a bug that was preventing parameters from being state rate sources.

### DIFF
--- a/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_parameter.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_parameter.py
@@ -1,0 +1,263 @@
+import os
+import unittest
+
+import numpy as np
+from scipy.interpolate import interp1d
+
+import openmdao.api as om
+import dymos as dm
+from dymos.utils.testing_utils import assert_timeseries_near_equal
+
+
+class BrachistochroneODE(om.ExplicitComponent):
+
+    def initialize(self):
+        self.options.declare('num_nodes', types=int)
+
+    def setup(self):
+        nn = self.options['num_nodes']
+
+        # Inputs
+        self.add_input('v', val=np.zeros(nn), desc='velocity', units='m/s')
+
+        self.add_input('g', val=9.80665 * np.ones(nn), desc='grav. acceleration', units='m/s/s')
+
+        self.add_input('theta', val=np.zeros(nn), desc='angle of wire', units='rad')
+
+        self.add_output('xdot', val=np.zeros(nn), desc='velocity component in x', units='m/s')
+
+        self.add_output('ydot', val=np.zeros(nn), desc='velocity component in y', units='m/s')
+
+        self.add_output('vdot', val=np.zeros(nn), desc='acceleration magnitude', units='m/s**2')
+
+        self.add_output('check', val=np.zeros(nn), desc='check solution: v/sin(theta) = constant',
+                        units='m/s')
+
+        # Setup partials
+        arange = np.arange(self.options['num_nodes'])
+
+        self.declare_partials(of='vdot', wrt='g', rows=arange, cols=arange)
+        self.declare_partials(of='vdot', wrt='theta', rows=arange, cols=arange)
+
+        self.declare_partials(of='xdot', wrt='v', rows=arange, cols=arange)
+        self.declare_partials(of='xdot', wrt='theta', rows=arange, cols=arange)
+
+        self.declare_partials(of='ydot', wrt='v', rows=arange, cols=arange)
+        self.declare_partials(of='ydot', wrt='theta', rows=arange, cols=arange)
+
+        self.declare_partials(of='check', wrt='v', rows=arange, cols=arange)
+        self.declare_partials(of='check', wrt='theta', rows=arange, cols=arange)
+
+    def compute(self, inputs, outputs):
+        theta = inputs['theta']
+        cos_theta = np.cos(theta)
+        sin_theta = np.sin(theta)
+        g = inputs['g']
+        v = inputs['v']
+
+        outputs['vdot'] = g * cos_theta
+        outputs['xdot'] = v * sin_theta
+        outputs['ydot'] = -v * cos_theta
+        outputs['check'] = v / sin_theta
+
+    def compute_partials(self, inputs, jacobian):
+        theta = inputs['theta']
+        cos_theta = np.cos(theta)
+        sin_theta = np.sin(theta)
+        g = inputs['g']
+        v = inputs['v']
+
+        jacobian['vdot', 'g'] = cos_theta
+        jacobian['vdot', 'theta'] = -g * sin_theta
+
+        jacobian['xdot', 'v'] = sin_theta
+        jacobian['xdot', 'theta'] = v * cos_theta
+
+        jacobian['ydot', 'v'] = -cos_theta
+        jacobian['ydot', 'theta'] = v * sin_theta
+
+        jacobian['check', 'v'] = 1 / sin_theta
+        jacobian['check', 'theta'] = -v * cos_theta / sin_theta**2
+
+
+class TestBrachistochroneIntegratedControl(unittest.TestCase):
+
+    @classmethod
+    def tearDownClass(cls):
+        for filename in ['phase0_sim.db']:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    def test_brachistochrone_integrated_param_gauss_lobatto(self):
+        import numpy as np
+        import openmdao.api as om
+        from openmdao.utils.assert_utils import assert_near_equal
+        import dymos as dm
+
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
+
+        phase = dm.Phase(ode_class=BrachistochroneODE, transcription=dm.GaussLobatto(num_segments=10))
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(initial_bounds=(0, 0), duration_bounds=(.5, 10), units='s')
+
+        phase.add_state('x', fix_initial=True, fix_final=False, rate_source='xdot', units='m')
+        phase.add_state('y', fix_initial=True, fix_final=False, rate_source='ydot', units='m')
+        phase.add_state('v', fix_initial=True, rate_source='vdot', units='m/s')
+        phase.add_state('theta', targets='theta', fix_initial=False, rate_source='theta_dot', units='rad')
+
+        phase.add_parameter('theta_dot', units='rad/s', opt=True, lower=0, upper=1)
+
+        phase.add_parameter('g', units='m/s**2', opt=False, val=9.80665)
+
+        # Minimize time at the end of the phase
+        phase.add_objective('time', loc='final', scaler=10)
+
+        p.model.linear_solver = om.DirectSolver()
+
+        p.setup()
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 2.0
+
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_input')
+        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+        p['phase0.states:theta'] = np.radians(phase.interpolate(ys=[0.05, 100.0],
+                                                                nodes='state_input'))
+        p['phase0.parameters:theta_dot'] = 1.0
+
+        # Solve for the optimal trajectory
+        p.run_driver()
+
+        # Test the results
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+
+        sim_out = phase.simulate(times_per_seg=20)
+
+        x_sol = p.get_val('phase0.timeseries.states:x')
+        y_sol = p.get_val('phase0.timeseries.states:y')
+        v_sol = p.get_val('phase0.timeseries.states:v')
+        theta_sol = p.get_val('phase0.timeseries.states:theta')
+        theta_dot_sol = p.get_val('phase0.timeseries.parameters:theta_dot')
+        time_sol = p.get_val('phase0.timeseries.time')
+
+        x_sim = sim_out.get_val('phase0.timeseries.states:x')
+        y_sim = sim_out.get_val('phase0.timeseries.states:y')
+        v_sim = sim_out.get_val('phase0.timeseries.states:v')
+        theta_sim = sim_out.get_val('phase0.timeseries.states:theta')
+        theta_dot_sim = sim_out.get_val('phase0.timeseries.parameters:theta_dot')
+        time_sim = sim_out.get_val('phase0.timeseries.time')
+
+        x_interp = interp1d(time_sim[:, 0], x_sim[:, 0])
+        y_interp = interp1d(time_sim[:, 0], y_sim[:, 0])
+        v_interp = interp1d(time_sim[:, 0], v_sim[:, 0])
+        theta_interp = interp1d(time_sim[:, 0], theta_sim[:, 0])
+        theta_dot_interp = interp1d(time_sim[:, 0], theta_dot_sim[:, 0])
+
+        assert_near_equal(x_interp(time_sol), x_sol, tolerance=1.0E-5)
+        assert_near_equal(y_interp(time_sol), y_sol, tolerance=1.0E-5)
+        assert_near_equal(v_interp(time_sol), v_sol, tolerance=1.0E-5)
+        assert_near_equal(theta_interp(time_sol), theta_sol, tolerance=1.0E-5)
+        assert_near_equal(theta_dot_interp(time_sol), theta_dot_sol, tolerance=1.0E-5)
+
+    def test_brachistochrone_integrated_control_radau_ps(self):
+        import numpy as np
+        import openmdao.api as om
+        from openmdao.utils.assert_utils import assert_near_equal
+        import dymos as dm
+
+        p = om.Problem(model=om.Group())
+        p.driver = om.pyOptSparseDriver()
+        p.driver.options['optimizer'] = 'SLSQP'
+
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.Radau(num_segments=10))
+
+        p.model.add_subsystem('phase0', phase)
+
+        phase.set_time_options(initial_bounds=(0, 0), duration_bounds=(.5, 10), units='s')
+
+        phase.add_state('x', fix_initial=True, fix_final=True, rate_source='xdot', units='m')
+        phase.add_state('y', fix_initial=True, fix_final=True, rate_source='ydot', units='m')
+        phase.add_state('v', fix_initial=True, rate_source='vdot', units='m/s')
+        phase.add_state('theta', fix_initial=False, rate_source='theta_dot', lower=1E-3)
+
+        phase.add_parameter('theta_dot', units='deg/s', opt=True, lower=0, upper=100)
+
+        phase.add_parameter('g', units='m/s**2', opt=False, val=9.80665)
+
+        # Minimize time at the end of the phase
+        phase.add_objective('time', loc='final', scaler=10)
+
+        p.model.linear_solver = om.DirectSolver()
+
+        p.setup()
+
+        p['phase0.t_initial'] = 0.0
+        p['phase0.t_duration'] = 2.0
+
+        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_input')
+        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_input')
+        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+        p['phase0.states:theta'] = np.radians(phase.interpolate(ys=[0.05, 100.0], nodes='state_input'))
+        p['phase0.parameters:theta_dot'] = 60.0
+
+        # Solve for the optimal trajectory
+        dm.run_problem(p, refine_iteration_limit=5)
+
+        # Test the results
+        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+
+        sim_out = phase.simulate(times_per_seg=20)
+
+        t_sol = p.get_val('phase0.timeseries.time')
+        x_sol = p.get_val('phase0.timeseries.states:x')
+        y_sol = p.get_val('phase0.timeseries.states:y')
+        v_sol = p.get_val('phase0.timeseries.states:v')
+        theta_sol = p.get_val('phase0.timeseries.states:theta')
+        theta_dot_sol = p.get_val('phase0.timeseries.parameters:theta_dot')
+        time_sol = p.get_val('phase0.timeseries.time')
+        #
+        # p.model.list_inputs(print_arrays=True)
+        # p.model.list_outputs(print_arrays=True)
+        # om.n2(p.model)
+
+        t_sim = sim_out.get_val('phase0.timeseries.time')
+        x_sim = sim_out.get_val('phase0.timeseries.states:x')
+        y_sim = sim_out.get_val('phase0.timeseries.states:y')
+        v_sim = sim_out.get_val('phase0.timeseries.states:v')
+        theta_sim = sim_out.get_val('phase0.timeseries.states:theta')
+        theta_dot_sim = sim_out.get_val('phase0.timeseries.parameters:theta_dot')
+        time_sim = sim_out.get_val('phase0.timeseries.time')
+
+        assert_timeseries_near_equal(t_sol, x_sol, t_sim, x_sim, tolerance=1.0E-3, num_points=10)
+        assert_timeseries_near_equal(t_sol, y_sol, t_sim, y_sim, tolerance=1.0E-3, num_points=10)
+        assert_timeseries_near_equal(t_sol, v_sol, t_sim, v_sim, tolerance=1.0E-3, num_points=10)
+        assert_timeseries_near_equal(t_sol, theta_sol, t_sim, theta_sim, tolerance=1.0E-3, num_points=10)
+
+        # print(theta_sol.T)
+        # print(theta_dot_sol.T)
+        # import matplotlib.pyplot as plt
+        # plt.plot(x_sol, y_sol, 'o')
+        # plt.plot(x_sim, y_sim, '-')
+        # plt.show()
+
+
+        # x_interp = interp1d(time_sim[:, 0], x_sim[:, 0])
+        # y_interp = interp1d(time_sim[:, 0], y_sim[:, 0])
+        # v_interp = interp1d(time_sim[:, 0], v_sim[:, 0])
+        # theta_interp = interp1d(time_sim[:, 0], theta_sim[:, 0])
+        # theta_dot_interp = interp1d(time_sim[:, 0], theta_dot_sim[:, 0])
+
+        # assert_near_equal(x_interp(time_sol), x_sol, tolerance=1.0E-5)
+        # assert_near_equal(y_interp(time_sol), y_sol, tolerance=1.0E-5)
+        # assert_near_equal(v_interp(time_sol), v_sol, tolerance=1.0E-5)
+        # assert_near_equal(theta_interp(time_sol), theta_sol, tolerance=1.0E-5)
+        # assert_near_equal(theta_dot_interp(time_sol), theta_dot_sol, tolerance=1.0E-5)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_parameter.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_parameter.py
@@ -96,8 +96,7 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()
-        p.driver.options['optimizer'] = 'SNOPT'
-        p.driver.opt_settings['iSumm'] = 6
+        p.driver.options['optimizer'] = 'SLSQP'
         p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
@@ -167,8 +166,7 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()
-        p.driver.options['optimizer'] = 'SNOPT'
-        p.driver.opt_settings['iSumm'] = 6
+        p.driver.options['optimizer'] = 'SLSQP'
         p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_parameter.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_parameter.py
@@ -80,7 +80,7 @@ class BrachistochroneODE(om.ExplicitComponent):
         jacobian['check', 'theta'] = -v * cos_theta / sin_theta**2
 
 
-class TestBrachistochroneIntegratedControl(unittest.TestCase):
+class TestBrachistochroneIntegratedParameter(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
@@ -144,21 +144,19 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         y_sol = p.get_val('phase0.timeseries.states:y')
         v_sol = p.get_val('phase0.timeseries.states:v')
         theta_sol = p.get_val('phase0.timeseries.states:theta')
-        theta_dot_sol = p.get_val('phase0.timeseries.parameters:theta_dot')
 
         t_sim = sim_out.get_val('phase0.timeseries.time')
         x_sim = sim_out.get_val('phase0.timeseries.states:x')
         y_sim = sim_out.get_val('phase0.timeseries.states:y')
         v_sim = sim_out.get_val('phase0.timeseries.states:v')
         theta_sim = sim_out.get_val('phase0.timeseries.states:theta')
-        theta_dot_sim = sim_out.get_val('phase0.timeseries.parameters:theta_dot')
 
         assert_timeseries_near_equal(t_sol, x_sol, t_sim, x_sim, tolerance=5.0E-3)
         assert_timeseries_near_equal(t_sol, y_sol, t_sim, y_sim, tolerance=5.0E-3)
         assert_timeseries_near_equal(t_sol, v_sol, t_sim, v_sim, tolerance=5.0E-3)
         assert_timeseries_near_equal(t_sol, theta_sol, t_sim, theta_sim, tolerance=5.0E-3)
 
-    def test_brachistochrone_integrated_control_radau_ps(self):
+    def test_brachistochrone_integrated_parameter_radau_ps(self):
         import numpy as np
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal
@@ -214,20 +212,12 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         y_sol = p.get_val('phase0.timeseries.states:y')
         v_sol = p.get_val('phase0.timeseries.states:v')
         theta_sol = p.get_val('phase0.timeseries.states:theta')
-        theta_dot_sol = p.get_val('phase0.timeseries.parameters:theta_dot')
-        time_sol = p.get_val('phase0.timeseries.time')
-        #
-        # p.model.list_inputs(print_arrays=True)
-        # p.model.list_outputs(print_arrays=True)
-        # om.n2(p.model)
 
         t_sim = sim_out.get_val('phase0.timeseries.time')
         x_sim = sim_out.get_val('phase0.timeseries.states:x')
         y_sim = sim_out.get_val('phase0.timeseries.states:y')
         v_sim = sim_out.get_val('phase0.timeseries.states:v')
         theta_sim = sim_out.get_val('phase0.timeseries.states:theta')
-        theta_dot_sim = sim_out.get_val('phase0.timeseries.parameters:theta_dot')
-        time_sim = sim_out.get_val('phase0.timeseries.time')
 
         assert_timeseries_near_equal(t_sol, x_sol, t_sim, x_sim, tolerance=1.0E-3, num_points=10)
         assert_timeseries_near_equal(t_sol, y_sol, t_sim, y_sim, tolerance=1.0E-3, num_points=10)

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_parameter.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_parameter.py
@@ -171,7 +171,9 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()
-        p.driver.options['optimizer'] = 'SLSQP'
+        p.driver.options['optimizer'] = 'SNOPT'
+        p.driver.opt_settings['iSumm'] = 6
+        p.driver.declare_coloring()
 
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.Radau(num_segments=10))

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_parameter.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_parameter.py
@@ -111,7 +111,8 @@ class TestBrachistochroneIntegratedParameter(unittest.TestCase):
         phase.add_state('v', fix_initial=True, rate_source='vdot', units='m/s')
         phase.add_state('theta', fix_initial=False, rate_source='theta_dot', lower=1E-3)
 
-        phase.add_parameter('theta_dot', units='deg/s', opt=True, lower=0, upper=100)
+        # theta_dot has no target, therefore we need to explicitly set the units and shape.
+        phase.add_parameter('theta_dot', units='deg/s', shape=(1,), opt=True, lower=0, upper=100)
 
         phase.add_parameter('g', units='m/s**2', opt=False, val=9.80665)
 
@@ -179,7 +180,8 @@ class TestBrachistochroneIntegratedParameter(unittest.TestCase):
         phase.add_state('v', fix_initial=True, rate_source='vdot', units='m/s')
         phase.add_state('theta', fix_initial=False, rate_source='theta_dot', lower=1E-3)
 
-        phase.add_parameter('theta_dot', units='deg/s', opt=True, lower=0, upper=100)
+        # theta_dot has no target, therefore we need to explicitly set the units and shape.
+        phase.add_parameter('theta_dot', units='deg/s', shape=(1,), opt=True, lower=0, upper=100)
 
         phase.add_parameter('g', units='m/s**2', opt=False, val=9.80665)
 

--- a/dymos/grid_refinement/error_estimation.py
+++ b/dymos/grid_refinement/error_estimation.py
@@ -208,10 +208,19 @@ def eval_ode_on_grid(phase, transcription):
     # Assign the state rates on the new grid to f
     for name, options in phase.state_options.items():
         rate_source = options['rate_source']
-        rate_units = get_rate_units(options['units'], phase.time_options['units'])
-        f[name] = np.atleast_2d(p_refine.get_val(f'ode.{rate_source}', units=rate_units))
-        if options['shape'] == (1,):
-            f[name] = f[name].T
+        rate_source_class = phase.classify_var(rate_source)
+        print(name, rate_source, rate_source_class, rate_source_class == 'parameter')
+        if rate_source_class == 'parameter':
+            print(p_refine.model.list_inputs())
+            print(p_refine.model.list_outputs())
+            # print(p_refine.get_val(f'parameters:{rate_source}'))
+            exit(0)
+        else:
+            rate_source_path = transcription.get_rate_source_path(name, nodes='all', phase=phase)
+            rate_units = get_rate_units(options['units'], phase.time_options['units'])
+            f[name] = np.atleast_2d(p_refine.get_val(f'ode.{rate_source}', units=rate_units))
+            if options['shape'] == (1,):
+                f[name] = f[name].T
 
     return x, u, p, f
 

--- a/dymos/grid_refinement/error_estimation.py
+++ b/dymos/grid_refinement/error_estimation.py
@@ -117,7 +117,12 @@ def eval_ode_on_grid(phase, transcription):
     """
     x = {}
     u = {}
+    u_rate = {}
+    u_rate2 = {}
     p = {}
+    p_rate = {}
+    p_rate2 = {}
+    param = {}
     f = {}
 
     # Build the interpolation matrix which interpolates from all nodes on the old grid to
@@ -144,83 +149,133 @@ def eval_ode_on_grid(phase, transcription):
     # Set the values in the refinement problem using the outputs from the first
     ode = p_refine.model.grid_refinement_system.ode
 
+    t_prev = phase.get_val('timeseries.time', units=phase.time_options['units'])
+    t_phase_prev = phase.get_val('timeseries.time_phase', units=phase.time_options['units'])
+    t_initial = np.repeat(t_prev[0, 0], repeats=transcription.grid_data.num_nodes, axis=0)
+    t_duration = np.repeat(t_prev[-1, 0], repeats=transcription.grid_data.num_nodes, axis=0)
+    t = np.dot(L, t_prev)
+    t_phase = np.dot(L, t_phase_prev)
+    targets = get_targets(ode, 'time', phase.time_options['targets'])
+    time_phase_targets = get_targets(ode, 'time_phase', phase.time_options['time_phase_targets'])
+    t_initial_targets = get_targets(ode, 't_initial', phase.time_options['t_initial_targets'])
+    t_duration_targets = get_targets(ode, 't_duration', phase.time_options['t_duration_targets'])
+    if targets:
+        p_refine.set_val(f'time', t)
+    if time_phase_targets:
+        p_refine.set_val(f'time_phase', t_phase)
+    if t_initial_targets:
+        p_refine.set_val(f't_initial', t_initial)
+    if t_duration_targets:
+        p_refine.set_val(f't_duration', t_duration)
+
     for name, options in phase.state_options.items():
         x_prev = phase.get_val(f'timeseries.states:{name}', units=options['units'])
         x[name] = np.dot(L, x_prev)
         targets = get_targets(ode, name, options['targets'])
-        if not targets:
-            continue
-        p_refine.set_val(f'states:{name}', x[name])
+        if targets:
+            p_refine.set_val(f'states:{name}', x[name])
 
     for name, options in phase.control_options.items():
         targets = get_targets(ode, name, options['targets'])
         rate_targets = get_targets(ode, f'{name}_rate', options['rate_targets'])
         rate2_targets = get_targets(ode, f'{name}_rate12', options['rate2_targets'])
 
+        u_prev = phase.get_val(f'timeseries.controls:{name}', units=options['units'])
+        u[name] = np.dot(L, u_prev)
         if targets:
-            u_prev = phase.get_val(f'timeseries.controls:{name}', units=options['units'])
-            u[name] = np.dot(L, u_prev)
             p_refine.set_val(f'controls:{name}', u[name])
 
+        u_rate_prev = phase.get_val(f'timeseries.control_rates:{name}_rate')
+        u_rate[name] = np.dot(L, u_rate_prev)
         if rate_targets:
-            u_rate_prev = phase.get_val(f'timeseries.control_rates:{name}_rate')
-            u_rate_hat = np.dot(L, u_rate_prev)
-            p_refine.set_val(f'control_rates:{name}_rate', u_rate_hat)
+            p_refine.set_val(f'control_rates:{name}_rate', u_rate[name])
 
+        u_rate2_prev = phase.get_val(f'timeseries.control_rates:{name}_rate2')
+        u_rate2[name] = np.dot(L, u_rate2_prev)
         if rate2_targets:
-            u_rate2_prev = phase.get_val(f'timeseries.control_rates:{name}_rate2')
-            u_rate2_hat = np.dot(L, u_rate2_prev)
-            p_refine.set_val(f'control_rates:{name}_rate2', u_rate2_hat)
+            p_refine.set_val(f'control_rates:{name}_rate2', u_rate2[name])
 
     for name, options in phase.polynomial_control_options.items():
         targets = get_targets(ode, name, options['targets'])
         rate_targets = get_targets(ode, f'{name}_rate', options['rate_targets'])
         rate2_targets = get_targets(ode, f'{name}_rate2', options['rate2_targets'])
 
+        p_prev = phase.get_val(f'timeseries.polynomial_controls:{name}', units=options['units'])
+        p[name] = np.dot(L, p_prev)
         if targets:
-            p_prev = phase.get_val(f'timeseries.polynomial_controls:{name}', units=options['units'])
-            p[name] = np.dot(L, p_prev)
             p_refine.set_val(f'polynomial_controls:{name}', p[name])
 
+        p_rate_prev = phase.get_val(f'timeseries.polynomial_control_rates:{name}_rate')
+        p_rate[name] = np.dot(L, p_rate_prev)
         if rate_targets:
-            u_rate_prev = phase.get_val(f'timeseries.polynomial_control_rates:{name}_rate')
-            u_rate_hat = np.dot(L, u_rate_prev)
-            p_refine.set_val(f'polynomial_control_rates:{name}_rate', u_rate_hat)
+            p_refine.set_val(f'polynomial_control_rates:{name}_rate', p_rate[name])
 
+        p_rate2_prev = phase.get_val(f'timeseries.polynomial_control_rates:{name}_rate2')
+        p_rate2[name] = np.dot(L, p_rate2_prev)
         if rate2_targets:
-            u_rate2_prev = phase.get_val(f'timeseries.polynomial_control_rates:{name}_rate2')
-            u_rate2_hat = np.dot(L, u_rate2_prev)
-            p_refine.set_val(f'polynomial_control_rates:{name}_rate2', u_rate2_hat)
+            p_refine.set_val(f'polynomial_control_rates:{name}_rate2', p_rate2[name])
 
     # Configure the parameters
     for name, options in phase.parameter_options.items():
         targets = get_targets(ode, name, options['targets'])
+        # The value of the parameter at one node
+        d = phase.get_val(f'timeseries.parameters:{name}', units=options['units'])[0, ...]
+        # Duplicate along the first axis by the number of nodes in the new transcription
+        param[name] = np.atleast_2d(np.repeat(d, repeats=transcription.grid_data.num_nodes, axis=0))
         if targets:
-            # The value of the parameter at one node
-            d = phase.get_val(f'timeseries.parameters:{name}', units=options['units'])[0, ...]
-            # Duplicate along the first axis by the number of nodes in the new transcription
-            d = np.repeat(d, repeats=transcription.grid_data.num_nodes, axis=0)
-            p_refine.set_val(f'parameters:{name}', d, units=options['units'])
+            p_refine.set_val(f'parameters:{name}', param[name], units=options['units'])
 
     # Execute the model
     p_refine.run_model()
 
     # Assign the state rates on the new grid to f
     for name, options in phase.state_options.items():
+        rate_units = get_rate_units(options['units'], phase.time_options['units'])
         rate_source = options['rate_source']
         rate_source_class = phase.classify_var(rate_source)
-        print(name, rate_source, rate_source_class, rate_source_class == 'parameter')
-        if rate_source_class == 'parameter':
-            print(p_refine.model.list_inputs())
-            print(p_refine.model.list_outputs())
-            # print(p_refine.get_val(f'parameters:{rate_source}'))
-            exit(0)
-        else:
-            rate_source_path = transcription.get_rate_source_path(name, nodes='all', phase=phase)
-            rate_units = get_rate_units(options['units'], phase.time_options['units'])
+        if rate_source_class in {'time'}:
+            src_units = phase.time_options['units']
+            f[name] = om.convert_units(t, src_units, rate_units)
+        elif rate_source_class in {'time_phase'}:
+            src_units = phase.time_options['units']
+            f[name] = om.convert_units(t_phase, src_units, rate_units)
+        elif rate_source_class in {'state'}:
+            src_units = phase.state_options[rate_source]['units']
+            f[name] = om.convert_units(x[rate_source], src_units, rate_units)
+        elif rate_source_class in {'input_control', 'indep_control'}:
+            src_units = phase.control_options[rate_source]['units']
+            f[name] = om.convert_units(u[rate_source], src_units, rate_units)
+        elif rate_source_class in {'control_rate'}:
+            u_name = rate_source[:-5]
+            u_units = phase.control_options[u_name]['units']
+            src_units = get_rate_units(u_units, phase.time_options['units'], deriv=1)
+            f[name] = om.convert_units(u_rate[rate_source], src_units, rate_units)
+        elif rate_source_class in {'control_rate2'}:
+            u_name = rate_source[:-6]
+            u_units = phase.control_options[u_name]['units']
+            src_units = get_rate_units(u_units, phase.time_options['units'], deriv=2)
+            f[name] = om.convert_units(u_rate2[rate_source], src_units, rate_units)
+        elif rate_source_class in {'input_polynomial_control', 'indep_polynomial_control'}:
+            src_units = phase.polynomial_control_options[rate_source]['units']
+            f[name] = om.convert_units(p[rate_source], src_units, rate_units)
+        elif rate_source_class in {'polynomial_control_rate'}:
+            pc_name = rate_source[:-5]
+            pc_units = phase.polynomial_control_options[pc_name]['units']
+            src_units = get_rate_units(pc_units, phase.time_options['units'], deriv=1)
+            f[name] = om.convert_units(p_rate[rate_source], src_units, rate_units)
+        elif rate_source_class in {'polynomial_control_rate2'}:
+            pc_name = rate_source[:-6]
+            pc_units = phase.polynomial_control_options[pc_name]['units']
+            src_units = get_rate_units(pc_units, phase.time_options['units'], deriv=2)
+            f[name] = om.convert_units(p_rate2[rate_source], src_units, rate_units)
+        elif rate_source_class in {'parameter'}:
+            src_units = phase.parameter_options[rate_source]['units']
+            f[name] = om.convert_units(param[rate_source], src_units, rate_units)
+        elif rate_source_class in {'ode'}:
             f[name] = np.atleast_2d(p_refine.get_val(f'ode.{rate_source}', units=rate_units))
-            if options['shape'] == (1,):
-                f[name] = f[name].T
+
+        if options['shape'] == (1,):
+            f[name] = f[name].T
 
     return x, u, p, f
 

--- a/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
+++ b/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
@@ -142,11 +142,22 @@ class Radau(PseudospectralBase):
             phase.connect('state_interp.staterate_col:{0}'.format(name),
                           'collocation_constraint.f_approx:{0}'.format(name))
 
-            rate_src, src_idxs = self.get_rate_source_path(name, 'col', phase)
-
-            phase.connect(rate_src,
-                          'collocation_constraint.f_computed:{0}'.format(name),
-                          src_indices=src_idxs)
+            rate_src = options['rate_source']
+            ncn = self.grid_data.subset_num_nodes['col']
+            if rate_src in phase.parameter_options:
+                # If the rate source is a parameter, which is an input, we need to promote
+                # f_computed to the parameter name instead of connecting to it.
+                shape = phase.parameter_options[rate_src]['shape']
+                param_size = np.prod(shape)
+                src_idxs = np.tile(np.arange(0, param_size, dtype=int), ncn)
+                src_idxs = np.reshape(src_idxs, (ncn,) + shape)
+                phase.promotes('collocation_constraint', inputs=[(f'f_computed:{name}', f'parameters:{rate_src}')],
+                               src_indices=src_idxs, flat_src_indices=True, src_shape=shape)
+            else:
+                rate_src_path, src_idxs = self.get_rate_source_path(name, 'col', phase)
+                phase.connect(rate_src_path,
+                              'collocation_constraint.f_computed:{0}'.format(name),
+                              src_indices=src_idxs)
 
     def configure_path_constraints(self, phase):
         super(Radau, self).configure_path_constraints(phase)
@@ -260,10 +271,24 @@ class Radau(PseudospectralBase):
                               tgt_name=f'{timeseries_name}.input_values:states:{state_name}',
                               src_indices=om.slicer[src_rows, ...])
 
-                rate_src, src_idxs = self.get_rate_source_path(state_name, 'all', phase)
-                phase.connect(src_name=rate_src,
-                              tgt_name=f'{timeseries_name}.input_values:state_rates:{state_name}',
-                              src_indices=src_idxs)
+                rate_src = options['rate_source']
+                if rate_src in phase.parameter_options:
+                    # If the rate source is a parameter, which is an input, we need to promote
+                    # the state rates input value to the parameter name instead of connecting to it.
+                    nn = self.grid_data.subset_num_nodes['all']
+                    shape = phase.parameter_options[rate_src]['shape']
+                    param_size = np.prod(shape)
+                    src_idxs = np.tile(np.arange(0, param_size, dtype=int), nn)
+                    src_idxs = np.reshape(src_idxs, (nn,) + shape)
+                    phase.promotes(f'{timeseries_name}',
+                                   inputs=[(f'input_values:state_rates:{state_name}',
+                                            f'parameters:{rate_src}')],
+                                   src_indices=src_idxs, flat_src_indices=True, src_shape=shape)
+                else:
+                    rate_src_path, src_idxs = self.get_rate_source_path(state_name, 'all', phase)
+                    phase.connect(src_name=rate_src_path,
+                                  tgt_name=f'{timeseries_name}.input_values:state_rates:{state_name}',
+                                  src_indices=src_idxs)
 
             for control_name, options in phase.control_options.items():
                 control_units = options['units']

--- a/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
+++ b/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
@@ -143,12 +143,12 @@ class Radau(PseudospectralBase):
                           'collocation_constraint.f_approx:{0}'.format(name))
 
             rate_src = options['rate_source']
-            ncn = self.grid_data.subset_num_nodes['col']
             if rate_src in phase.parameter_options:
                 # If the rate source is a parameter, which is an input, we need to promote
                 # f_computed to the parameter name instead of connecting to it.
                 shape = phase.parameter_options[rate_src]['shape']
                 param_size = np.prod(shape)
+                ncn = self.grid_data.subset_num_nodes['col']
                 src_idxs = np.tile(np.arange(0, param_size, dtype=int), ncn)
                 src_idxs = np.reshape(src_idxs, (ncn,) + shape)
                 phase.promotes('collocation_constraint', inputs=[(f'f_computed:{name}', f'parameters:{rate_src}')],

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -418,8 +418,19 @@ class SolveIVP(TranscriptionBase):
             phase.connect(src_name=f'state_mux_comp.states:{name}',
                           tgt_name=f'timeseries.all_values:states:{name}')
 
-            phase.connect(src_name=self.get_rate_source_path(name, phase),
-                          tgt_name=f'timeseries.all_values:state_rates:{name}')
+            rate_src = phase.state_options[name]['rate_source']
+            if rate_src in phase.parameter_options:
+                nn = num_seg * output_nodes_per_seg
+                shape = phase.parameter_options[rate_src]['shape']
+                param_size = np.prod(shape)
+                src_idxs = np.tile(np.arange(0, param_size, dtype=int), nn)
+                src_idxs = np.reshape(src_idxs, (nn,) + shape)
+                phase.promotes('timeseries', inputs=[(f'all_values:state_rates:{name}',
+                                                      f'parameters:{rate_src}')],
+                               src_indices=src_idxs, src_shape=shape)
+            else:
+                phase.connect(src_name=self.get_rate_source_path(name, phase),
+                              tgt_name=f'timeseries.all_values:state_rates:{name}')
 
         for name, options in phase.control_options.items():
             control_units = options['units']

--- a/dymos/utils/misc.py
+++ b/dymos/utils/misc.py
@@ -162,8 +162,10 @@ def get_target_metadata(ode, name, user_targets=_unspecified, user_units=_unspec
                 else:
                     shape = shape[1:]
         elif len(target_shape_set) == 0:
-            raise ValueError(f'Unable to automatically assign a shape to {name}. '
-                             'Independent controls need to declare a shape.')
+            raise ValueError(f'Unable to automatically assign a shape to {name}.\n'
+                             'Targets for this variable either do not exist or have no shape set.\n'
+                             'The shape for this variable must be set explicitly via the '
+                             '`shape=<tuple>` argument.')
         else:
             raise ValueError(f'Unable to automatically assign a shape to {name} based on targets. '
                              f'Targets have multiple shapes assigned: {target_shape_set}. '

--- a/dymos/utils/testing_utils.py
+++ b/dymos/utils/testing_utils.py
@@ -14,7 +14,7 @@ def assert_check_partials(data, atol=1.0E-6, rtol=1.0E-6):
     _om_assert_utils.assert_check_partials(data, atol, rtol)
 
 
-def assert_timeseries_near_equal(t1, x1, t2, x2, tolerance=1.0E-6, num_points=10):
+def assert_timeseries_near_equal(t1, x1, t2, x2, tolerance=1.0E-6, num_points=20):
     """
     Assert that two timeseries of data are approximately equal.
     This is done by fitting a 1D interpolant to each index of each timeseries, and then comparing
@@ -63,12 +63,12 @@ def assert_timeseries_near_equal(t1, x1, t2, x2, tolerance=1.0E-6, num_points=10
     a2 = np.reshape(x2, newshape=(nn2, size))
     t2_unique, idxs2 = np.unique(t2.ravel(), return_index=True)
 
-    interp1 = interp1d(x=t1_unique, y=a1[idxs1, ...], kind='cubic', axis=0)
-    interp2 = interp1d(x=t2_unique, y=a2[idxs2, ...], kind='cubic', axis=0)
+    interp1 = interp1d(x=t1_unique, y=a1[idxs1, ...], kind='slinear', axis=0)
+    interp2 = interp1d(x=t2_unique, y=a2[idxs2, ...], kind='slinear', axis=0)
 
     t_interp = np.linspace(t1[0], t1[-1], num_points)
 
-    y1 = interp1(t_interp)
-    y2 = interp2(t_interp)
+    y1 = np.reshape(interp1(t_interp), newshape=(num_points,) + shape1)
+    y2 = np.reshape(interp2(t_interp), newshape=(num_points,) + shape2)
 
     _om_assert_utils.assert_near_equal(y1, y2, tolerance=tolerance)

--- a/dymos/utils/testing_utils.py
+++ b/dymos/utils/testing_utils.py
@@ -1,3 +1,6 @@
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+from scipy.interpolate import interp1d
 import openmdao.utils.assert_utils as _om_assert_utils
 
 
@@ -9,3 +12,63 @@ def assert_check_partials(data, atol=1.0E-6, rtol=1.0E-6):
     assert len(data) >= 1, "No check partials data found.  Is " \
                            "dymos.options['include_check_partials'] set to True?"
     _om_assert_utils.assert_check_partials(data, atol, rtol)
+
+
+def assert_timeseries_near_equal(t1, x1, t2, x2, tolerance=1.0E-6, num_points=10):
+    """
+    Assert that two timeseries of data are approximately equal.
+    This is done by fitting a 1D interpolant to each index of each timeseries, and then comparing
+    the values of the two interpolants at some equally spaced number of points.
+
+    Parameters
+    ----------
+    t1 : np.array
+        Time values for the first timeseries.
+    x1 : np.array
+        Data values for the first timeseries.
+    t2 : np.array
+        Time values for the second timeseries.
+    x2 : np.array
+        Data values for the second timeseries.
+    tolerance : float
+        The tolerance for any errors along at each point checked.
+    num_points : int
+        The number of points along the timeseries to be compared.
+
+    Raises
+    ------
+    AssertionError
+        When one or more elements of the interpolated timeseries are not within the
+        desired tolerance.
+    """
+    shape1 = x1.shape[1:]
+    shape2 = x2.shape[1:]
+
+    if shape1 != shape2:
+        raise ValueError('The shape variable in the two timeseries is not equal')
+
+    if abs(t1[0] - t2[0]) > 1.0E-12:
+        raise ValueError('The initial time of the two timeseries is not the same.')
+
+    if abs(t1[-1] - t2[-1]) > 1.0E-12:
+        raise ValueError('The final time of the two timeseries is not the same.')
+
+    size = np.prod(shape1)
+
+    nn1 = x1.shape[0]
+    a1 = np.reshape(x1, newshape=(nn1, size))
+    t1_unique, idxs1 = np.unique(t1.ravel(), return_index=True)
+
+    nn2 = x2.shape[0]
+    a2 = np.reshape(x2, newshape=(nn2, size))
+    t2_unique, idxs2 = np.unique(t2.ravel(), return_index=True)
+
+    interp1 = interp1d(x=t1_unique, y=a1[idxs1, ...], kind='cubic', axis=0)
+    interp2 = interp1d(x=t2_unique, y=a2[idxs2, ...], kind='cubic', axis=0)
+
+    t_interp = np.linspace(t1[0], t1[-1], num_points)
+
+    y1 = interp1(t_interp)
+    y2 = interp2(t_interp)
+
+    _om_assert_utils.assert_near_equal(y1, y2, tolerance=tolerance)


### PR DESCRIPTION
### Summary

Fixed a bug that was preventing parameters from being state rate sources.
If a rate_source is a parameter, the targets of that rate source are promoted to the parameter name.

While fixing this story we also uncovered issue #465, where error estimation for grid refinement was not computing the state rates correctly if those state rates were not ODE outputs.  This has been fixed.

### Related Issues

- Resolves #463 
- Resolves #465

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
