### PR TITLE
Parameter shapes

### DIFF
--- a/dymos/examples/double_integrator/test/test_double_integrator.py
+++ b/dymos/examples/double_integrator/test/test_double_integrator.py
@@ -158,7 +158,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         phase.add_state('x', fix_initial=True, rate_source='v', units='m')
 
         phase.add_control('u', units='m/s**2', scaler=0.01, continuity=False, rate_continuity=False,
-                          rate2_continuity=False, shape=(0, 1), lower=-1.0, upper=1.0)
+                          rate2_continuity=False, shape=(1,), lower=-1.0, upper=1.0)
 
         # Maximize distance travelled in one second.
         phase.add_objective('x', loc='final', scaler=-1)

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -206,11 +206,16 @@ class PolynomialControlOptionsDictionary(om.OptionsDictionary):
                           'to the default value of True.')
 
 
+def check_valid_shape(name, value):
+    if name == 'shape':
+        if value is not _unspecified and not isinstance(value, (Iterable, Number, list, tuple)):
+            raise ValueError(f"Option '{name}' with value {value} is not valid.")
+
+
 class ParameterOptionsDictionary(om.OptionsDictionary):
     """
     An OptionsDictionary specific to parameters.
     """
-
     def __init__(self, read_only=False):
         super(ParameterOptionsDictionary, self).__init__(read_only)
 
@@ -237,7 +242,7 @@ class ParameterOptionsDictionary(om.OptionsDictionary):
         self.declare(name='val', types=(Iterable, np.ndarray, Number), default=np.zeros(1),
                      desc='The default value of the parameter in the phase.')
 
-        self.declare(name='shape', types=Iterable, default=(1,),
+        self.declare(name='shape',  check_valid=check_valid_shape, default=_unspecified,
                      desc='The shape of the parameter.')
 
         self.declare(name='lower', types=(Iterable, Number), default=None,

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -917,8 +917,6 @@ class Phase(om.Group):
                 self.parameter_options[name]['shape'] = (1,)
             else:
                 self.parameter_options[name]['shape'] = tuple(np.asarray(val).shape)
-        else:
-            self.parameter_options[name]['shape'] = (1,)  # TODO need to interrogate to find shape
 
         if dynamic is not _unspecified:
             self.parameter_options[name]['dynamic'] = dynamic

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -1626,7 +1626,6 @@ class Phase(om.Group):
         transcription.setup_boundary_constraints('initial', self)
         transcription.setup_boundary_constraints('final', self)
         transcription.setup_path_constraints(self)
-        transcription.setup_objective(self)
         transcription.setup_timeseries_outputs(self)
         transcription.setup_solvers(self)
 

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -906,14 +906,19 @@ class Phase(om.Group):
             self.parameter_options[name]['val'] = val
 
         if shape is not _unspecified:
-            self.parameter_options[name]['shape'] = shape
+            if np.isscalar(shape):
+                self.parameter_options[name]['shape'] = (shape,)
+            elif isinstance(shape, list):
+                self.parameter_options[name]['shape'] = tuple(shape)
+            else:
+                self.parameter_options[name]['shape'] = shape
         elif val is not _unspecified:
             if isinstance(val, float):
                 self.parameter_options[name]['shape'] = (1,)
             else:
-                self.parameter_options[name]['shape'] = np.asarray(val).shape
+                self.parameter_options[name]['shape'] = tuple(np.asarray(val).shape)
         else:
-            self.parameter_options[name]['shape'] = (1,)
+            self.parameter_options[name]['shape'] = (1,)  # TODO need to interrogate to find shape
 
         if dynamic is not _unspecified:
             self.parameter_options[name]['dynamic'] = dynamic

--- a/dymos/phase/test/test_add_parameter_types.py
+++ b/dymos/phase/test/test_add_parameter_types.py
@@ -69,5 +69,5 @@ class TestParameterTypes(unittest.TestCase):
     def test_scaler(self):
         add_parameter_test(3)
 
-    def test_nothing(self): # doesn't work, but should ? maybe? seems like you could interrogate
+    def test_nothing(self):
         add_parameter_test()

--- a/dymos/phase/test/test_add_parameter_types.py
+++ b/dymos/phase/test/test_add_parameter_types.py
@@ -2,6 +2,7 @@ import unittest
 import openmdao.api as om
 import dymos as dm
 
+
 class ODEComp(om.ExplicitComponent):
     def initialize(self):
         self.options.declare('num_nodes', types=int)
@@ -23,6 +24,7 @@ class ODEComp(om.ExplicitComponent):
         outputs['zdot'][:, 1, 0] = 0.0
         outputs['zdot'][:, 1, 1] = -9.81
 
+
 def add_parameter_test(testShape=None):
     p = om.Problem()
 
@@ -31,7 +33,7 @@ def add_parameter_test(testShape=None):
     traj = dm.Trajectory()
     phase = dm.Phase(ode_class=ODEComp, transcription=tx)
 
-    if testShape==None:
+    if testShape is None:
         phase.add_parameter('param', dynamic=False)
     else:
         phase.add_parameter('param', shape=testShape, dynamic=False)
@@ -59,12 +61,13 @@ def add_parameter_test(testShape=None):
 
     p.run_driver()
 
+
 class TestParameterTypes(unittest.TestCase):
     def test_tuple(self):
-        add_parameter_test((3,))
+        add_parameter_test((3, ))
 
     def test_list(self):
-        add_parameter_test([3,])
+        add_parameter_test([3, ])
 
     def test_scaler(self):
         add_parameter_test(3)

--- a/dymos/phase/test/test_add_parameter_types.py
+++ b/dymos/phase/test/test_add_parameter_types.py
@@ -1,0 +1,73 @@
+import unittest
+import openmdao.api as om
+import dymos as dm
+
+class ODEComp(om.ExplicitComponent):
+    def initialize(self):
+        self.options.declare('num_nodes', types=int)
+
+    def setup(self):
+        nn = self.options['num_nodes']
+        # z is the state vector, a nn x 2 x 2 in the form of [[x, y], [vx, vy]]
+        self.add_input('param', shape=3, units=None)
+        self.add_input('z', shape=(nn, 2, 2), units=None)
+        self.add_output('zdot', shape=(nn, 2, 2), units=None)
+
+        self.declare_partials(of='zdot', wrt='z', method='cs')
+        self.declare_coloring(wrt=['z'], method='cs', num_full_jacs=5, tol=1.0E-12)
+
+    def compute(self, inputs, outputs):
+        print('param', inputs['param'])
+        outputs['zdot'][:, 0, 0] = inputs['z'][:, 1, 0]
+        outputs['zdot'][:, 0, 1] = inputs['z'][:, 1, 1]
+        outputs['zdot'][:, 1, 0] = 0.0
+        outputs['zdot'][:, 1, 1] = -9.81
+
+def add_parameter_test(testShape=None):
+    p = om.Problem()
+
+    tx = dm.Radau(num_segments=10, order=3, solve_segments=False)
+
+    traj = dm.Trajectory()
+    phase = dm.Phase(ode_class=ODEComp, transcription=tx)
+
+    if testShape==None:
+        phase.add_parameter('param', dynamic=False)
+    else:
+        phase.add_parameter('param', shape=testShape, dynamic=False)
+
+    traj.add_phase('phase', phase)
+
+    p.model.add_subsystem('traj', traj)
+
+    phase.set_time_options(fix_initial=True, duration_bounds=(1, 5), units=None)
+    phase.add_state('z', rate_source='zdot', fix_initial=True, units=None)
+
+    phase.add_boundary_constraint('z', loc='final', lower=0, upper=0, indices=[1])
+    phase.add_objective('time', loc='final')
+
+    p.driver = om.pyOptSparseDriver()
+    p.driver.declare_coloring(tol=1.0E-12)
+
+    p.setup()
+
+    p['traj.phase.parameters:param'] = [2.5, 3.5, 4.5]
+
+    p.set_val('traj.phase.t_initial', 0)
+    p.set_val('traj.phase.t_duration', 5)
+    p.set_val('traj.phase.states:z', phase.interpolate(ys=[[[0, 0], [10, 10]], [[10, 0], [10, -10]]], nodes='state_input'))
+
+    p.run_driver()
+
+class TestParameterTypes(unittest.TestCase):
+    def test_tuple(self):
+        add_parameter_test((3,))
+
+    def test_list(self):
+        add_parameter_test([3,])
+
+    def test_scaler(self):
+        add_parameter_test(3)
+
+    def test_nothing(self): # doesn't work, but should ? maybe? seems like you could interrogate
+        add_parameter_test()

--- a/dymos/transcriptions/pseudospectral/pseudospectral_base.py
+++ b/dymos/transcriptions/pseudospectral/pseudospectral_base.py
@@ -6,9 +6,7 @@ import openmdao.api as om
 from ..transcription_base import TranscriptionBase
 from ..common import TimeComp, PseudospectralTimeseriesOutputComp
 from .components import StateIndependentsComp, StateInterpComp, CollocationComp
-from ...utils.misc import CoerceDesvar, get_rate_units, _unspecified, \
-    get_target_metadata, get_source_metadata
-from ...utils.introspection import get_targets, get_state_target_metadata
+from ...utils.misc import CoerceDesvar, get_rate_units
 from ...utils.constants import INF_BOUND
 from ...utils.indexing import get_src_indices_by_row
 

--- a/dymos/transcriptions/runge_kutta/runge_kutta.py
+++ b/dymos/transcriptions/runge_kutta/runge_kutta.py
@@ -8,8 +8,7 @@ from .components import RungeKuttaStepsizeComp, RungeKuttaStateContinuityIterGro
     RungeKuttaTimeseriesOutputComp, RungeKuttaControlContinuityComp
 from ..common import TimeComp, PathConstraintComp
 from ...utils.rk_methods import rk_methods
-from ...utils.misc import CoerceDesvar, get_rate_units, get_target_metadata,\
-    get_source_metadata, _unspecified
+from ...utils.misc import CoerceDesvar, get_rate_units, get_source_metadata
 from ...utils.introspection import get_targets
 from ...utils.constants import INF_BOUND
 from ...utils.indexing import get_src_indices_by_row

--- a/dymos/transcriptions/solve_ivp/components/ode_integration_interface_system.py
+++ b/dymos/transcriptions/solve_ivp/components/ode_integration_interface_system.py
@@ -91,7 +91,10 @@ class ODEIntegrationInterfaceSystem(om.Group):
             if targets:
                 for tgt in targets:
                     tgt_shape, _ = get_target_metadata(ode=ode, name=name, user_targets=tgt)
-                    src_idxs = np.arange(size, dtype=int).reshape(tgt_shape)
+                    if len(tgt_shape) == 1 and tgt_shape[0] == 1:
+                        src_idxs = np.arange(size, dtype=int).reshape(tgt_shape)
+                    else:
+                        src_idxs = np.arange(size, dtype=int).reshape((1,) + tgt_shape)
                     self.connect(f'states:{name}', f'ode.{tgt}',
                                  src_indices=src_idxs, flat_src_indices=True)
 

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -236,21 +236,14 @@ class SolveIVP(TranscriptionBase):
         # Interrogate shapes and units.
         for name, options in phase.control_options.items():
 
-            full_shape, units = get_target_metadata(ode, name=name,
-                                                    user_targets=options['targets'],
-                                                    user_units=options['units'],
-                                                    user_shape=options['shape'],
-                                                    control_rate=True)
+            shape, units = get_target_metadata(ode, name=name,
+                                               user_targets=options['targets'],
+                                               user_units=options['units'],
+                                               user_shape=options['shape'],
+                                               control_rate=True)
 
-            if options['units'] is None:
-                options['units'] = units
-
-            # Determine and store the pre-discretized state shape for use by other components.
-            if len(full_shape) < 2:
-                if options['shape'] in (_unspecified, None):
-                    options['shape'] = (1, )
-            else:
-                options['shape'] = full_shape[1:]
+            options['units'] = units
+            options['shape'] = shape
 
         grid_data = self.grid_data
 
@@ -350,9 +343,6 @@ class SolveIVP(TranscriptionBase):
         pass
 
     def configure_defects(self, phase):
-        pass
-
-    def setup_objective(self, phase):
         pass
 
     def configure_objective(self, phase):

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -72,7 +72,7 @@ class TranscriptionBase(object):
             if time_options['targets']:
                 ode = phase._get_subsystem(self._rhs_source)
 
-                _, time_options['units'] = get_target_metadata(ode, name=name,
+                _, time_options['units'] = get_target_metadata(ode, name='time',
                                                                user_targets=time_options['targets'],
                                                                user_units=time_options['units'],
                                                                user_shape='')
@@ -244,20 +244,14 @@ class TranscriptionBase(object):
         # Interrogate shapes and units.
         for name, options in phase.control_options.items():
 
-            full_shape, units = get_target_metadata(ode, name=name,
-                                                    user_targets=options['targets'],
-                                                    user_units=options['units'],
-                                                    user_shape=options['shape'],
-                                                    control_rate=True)
+            shape, units = get_target_metadata(ode, name=name,
+                                               user_targets=options['targets'],
+                                               user_units=options['units'],
+                                               user_shape=options['shape'],
+                                               control_rate=True)
 
             options['units'] = units
-
-            # Determine and store the pre-discretized state shape for use by other components.
-            if len(full_shape) < 2:
-                if options['shape'] in (_unspecified, None):
-                    options['shape'] = (1, )
-            else:
-                options['shape'] = full_shape[1:]
+            options['shape'] = shape
 
         if phase.control_options:
             phase.control_group.configure_io()
@@ -283,20 +277,14 @@ class TranscriptionBase(object):
         # Interrogate shapes and units.
         for name, options in phase.polynomial_control_options.items():
 
-            full_shape, units = get_target_metadata(ode, name=name,
-                                                    user_targets=options['targets'],
-                                                    user_units=options['units'],
-                                                    user_shape=options['shape'],
-                                                    control_rate=True)
+            shape, units = get_target_metadata(ode, name=name,
+                                               user_targets=options['targets'],
+                                               user_units=options['units'],
+                                               user_shape=options['shape'],
+                                               control_rate=True)
 
             options['units'] = units
-
-            # Determine and store the pre-discretized state shape for use by other components.
-            if len(full_shape) < 2:
-                if options['shape'] in (_unspecified, None):
-                    options['shape'] = (1, )
-            else:
-                options['shape'] = full_shape[1:]
+            options['shape'] = shape
 
         if phase.polynomial_control_options:
             phase.polynomial_control_group.configure_io()
@@ -334,7 +322,8 @@ class TranscriptionBase(object):
                 shape, units = get_target_metadata(ode, name=name,
                                                    user_targets=options['targets'],
                                                    user_shape=options['shape'],
-                                                   user_units=options['units'])
+                                                   user_units=options['units'],
+                                                   dynamic=options['dynamic'])
                 options['units'] = units
                 options['shape'] = shape
 
@@ -348,8 +337,7 @@ class TranscriptionBase(object):
                             phase.promotes(sub_sys, inputs=[(tgt_var, prom_name)],
                                            src_indices=src_idxs, flat_src_indices=True)
                         else:
-                            phase.promotes(sub_sys, inputs=[(tgt_var, prom_name)],
-                                           flat_src_indices=True)
+                            phase.promotes(sub_sys, inputs=[(tgt_var, prom_name)])
 
                 val = options['val']
                 _shape = options['shape']
@@ -635,7 +623,7 @@ class TranscriptionBase(object):
             constraint_kwargs.pop('constraint_name', None)
             phase._get_subsystem('path_constraints')._add_path_constraint_configure(con_name, **constraint_kwargs)
 
-    def setup_objective(self, phase):
+    def configure_objective(self, phase):
         """
         Find the path of the objective(s) and add the objective using the standard OpenMDAO method.
         """
@@ -675,9 +663,6 @@ class TranscriptionBase(object):
                                               scaler=options['scaler'],
                                               parallel_deriv_color=options['parallel_deriv_color'],
                                               vectorize_derivs=options['vectorize_derivs'])
-
-    def configure_objective(self, phase):
-        pass
 
     def _get_boundary_constraint_src(self, name, loc, phase):
         raise NotImplementedError('Transcription {0} does not implement method'

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -344,8 +344,12 @@ class TranscriptionBase(object):
                         parts = pathname.split('.')
                         sub_sys = parts[0]
                         tgt_var = '.'.join(parts[1:])
-                        phase.promotes(sub_sys, inputs=[(tgt_var, prom_name)],
-                                       src_indices=src_idxs, flat_src_indices=True)
+                        if options['dynamic']:
+                            phase.promotes(sub_sys, inputs=[(tgt_var, prom_name)],
+                                           src_indices=src_idxs, flat_src_indices=True)
+                        else:
+                            phase.promotes(sub_sys, inputs=[(tgt_var, prom_name)],
+                                           flat_src_indices=True)
 
                 val = options['val']
                 _shape = options['shape']

--- a/dymos/utils/misc.py
+++ b/dymos/utils/misc.py
@@ -78,7 +78,7 @@ def get_rate_units(units, time_units, deriv=1):
 
 
 def get_target_metadata(ode, name, user_targets=_unspecified, user_units=_unspecified,
-                        user_shape=_unspecified, control_rate=False):
+                        user_shape=_unspecified, control_rate=False, dynamic=True):
     """
     Return the targets of a state variable in a given ODE system.
     If the targets of the state is _unspecified, and the state name is a top level input name
@@ -102,6 +102,9 @@ def get_target_metadata(ode, name, user_targets=_unspecified, user_units=_unspec
         Shape for the variable as given by the user.
     control_rate : bool
         When True, check for the control rate if the name is not in the ODE.
+    dynamic : bool
+        When True, assume the shape of the target in the ODE includes the number of nodes as the
+        first dimension.
 
     Returns
     -------
@@ -153,6 +156,11 @@ def get_target_metadata(ode, name, user_targets=_unspecified, user_units=_unspec
         target_shape_set = {ode_inputs[tgt]['shape'] for tgt in targets}
         if len(target_shape_set) == 1:
             shape = next(iter(target_shape_set))
+            if dynamic:
+                if len(shape) == 1:
+                    shape = (1,)
+                else:
+                    shape = shape[1:]
         elif len(target_shape_set) == 0:
             raise ValueError(f'Unable to automatically assign a shape to {name}. '
                              'Independent controls need to declare a shape.')


### PR DESCRIPTION
### Summary

Bug when user provides parameter shape as a non-tuple (or doesn't provide it).

The add_parameter method for phase should allow the shape parameter to be a tuple, list, integer, or left out entirely.

### Related Issues

- Resolves #454

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
