### PR TITLE
Fixes issue where show_plots argument to run_problem is permanently changing matplotlib backend.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,7 @@ install:
     python -m pip install testflo==1.3.6;
     python -m pip install pyyaml;
     python -m pip install coveralls;
+    python -m pip install bokeh;
 
     python -m pip install mkdocs
     python -m pip install mkdocs-material

--- a/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise_bokeh_plots.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise_bokeh_plots.py
@@ -1,0 +1,309 @@
+import unittest
+
+import numpy as np
+
+import openmdao.api as om
+from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.general_utils import set_pyoptsparse_opt
+_, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
+
+import dymos as dm
+from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
+from openmdao.utils.testing_utils import use_tempdirs
+
+dm.options['plots'] = 'bokeh'
+
+
+def make_traj(transcription='gauss-lobatto', transcription_order=3, compressed=False,
+              connected=False):
+
+    t = {'gauss-lobatto': dm.GaussLobatto(num_segments=5, order=transcription_order, compressed=compressed),
+         'radau': dm.Radau(num_segments=20, order=transcription_order, compressed=compressed),
+         'runge-kutta': dm.RungeKutta(num_segments=5, compressed=compressed)}
+
+    traj = dm.Trajectory()
+
+    traj.add_parameter('c', opt=False, val=1.5, units='DU/TU',
+                       targets={'burn1': ['c'], 'burn2': ['c']})
+
+    # First Phase (burn)
+
+    burn1 = dm.Phase(ode_class=FiniteBurnODE, transcription=t[transcription])
+
+    burn1 = traj.add_phase('burn1', burn1)
+
+    burn1.set_time_options(fix_initial=True, duration_bounds=(.5, 10), units='TU')
+    burn1.add_state('r', fix_initial=True, fix_final=False, defect_scaler=100.0,
+                    rate_source='r_dot', units='DU')
+    burn1.add_state('theta', fix_initial=True, fix_final=False, defect_scaler=100.0,
+                    rate_source='theta_dot', units='rad')
+    burn1.add_state('vr', fix_initial=True, fix_final=False, defect_scaler=100.0,
+                    rate_source='vr_dot', units='DU/TU')
+    burn1.add_state('vt', fix_initial=True, fix_final=False, defect_scaler=100.0,
+                    rate_source='vt_dot', units='DU/TU')
+    burn1.add_state('accel', fix_initial=True, fix_final=False,
+                    rate_source='at_dot', units='DU/TU**2')
+    burn1.add_state('deltav', fix_initial=True, fix_final=False,
+                    rate_source='deltav_dot', units='DU/TU')
+    burn1.add_control('u1', rate_continuity=True, rate2_continuity=True, units='deg', scaler=0.01,
+                      rate_continuity_scaler=0.001, rate2_continuity_scaler=0.001,
+                      lower=-30, upper=30)
+    # Second Phase (Coast)
+    coast = dm.Phase(ode_class=FiniteBurnODE, transcription=t[transcription])
+
+    coast.set_time_options(initial_bounds=(0.5, 20), duration_bounds=(.5, 50), duration_ref=50, units='TU')
+    coast.add_state('r', fix_initial=False, fix_final=False, defect_scaler=100.0,
+                    rate_source='r_dot', units='DU')
+    coast.add_state('theta', fix_initial=False, fix_final=False, defect_scaler=100.0,
+                    rate_source='theta_dot', units='rad')
+    coast.add_state('vr', fix_initial=False, fix_final=False, defect_scaler=100.0,
+                    rate_source='vr_dot', units='DU/TU')
+    coast.add_state('vt', fix_initial=False, fix_final=False, defect_scaler=100.0,
+                    rate_source='vt_dot', units='DU/TU')
+    coast.add_state('accel', fix_initial=True, fix_final=True,
+                    rate_source='at_dot', units='DU/TU**2')
+    coast.add_state('deltav', fix_initial=False, fix_final=False,
+                    rate_source='deltav_dot', units='DU/TU')
+
+    coast.add_parameter('u1', opt=False, val=0.0, units='deg')
+    coast.add_parameter('c', val=0.0, units='DU/TU')
+
+    # Third Phase (burn)
+    burn2 = dm.Phase(ode_class=FiniteBurnODE, transcription=t[transcription])
+
+    if connected:
+        traj.add_phase('burn2', burn2)
+        traj.add_phase('coast', coast)
+
+        burn2.set_time_options(initial_bounds=(1.0, 60), duration_bounds=(-10.0, -0.5),
+                               initial_ref=10, units='TU')
+        burn2.add_state('r', fix_initial=True, fix_final=False, defect_scaler=100.0,
+                        rate_source='r_dot', units='DU')
+        burn2.add_state('theta', fix_initial=False, fix_final=False, defect_scaler=100.0,
+                        rate_source='theta_dot', units='rad')
+        burn2.add_state('vr', fix_initial=True, fix_final=False, defect_scaler=1000.0,
+                        rate_source='vr_dot', units='DU/TU')
+        burn2.add_state('vt', fix_initial=True, fix_final=False, defect_scaler=1000.0,
+                        rate_source='vt_dot', units='DU/TU')
+        burn2.add_state('accel', fix_initial=False, fix_final=False, defect_scaler=1.0,
+                        rate_source='at_dot', units='DU/TU**2')
+        burn2.add_state('deltav', fix_initial=False, fix_final=False, defect_scaler=1.0,
+                        rate_source='deltav_dot', units='DU/TU')
+
+        burn2.add_objective('deltav', loc='initial', scaler=100.0)
+
+        burn2.add_control('u1', rate_continuity=True, rate2_continuity=True, units='deg',
+                          scaler=0.01, lower=-180, upper=180)
+    else:
+        traj.add_phase('coast', coast)
+        traj.add_phase('burn2', burn2)
+
+        burn2.set_time_options(initial_bounds=(0.5, 50), duration_bounds=(.5, 10), initial_ref=10, units='TU')
+        burn2.add_state('r', fix_initial=False, fix_final=True, defect_scaler=100.0,
+                        rate_source='r_dot', targets=['r'], units='DU')
+        burn2.add_state('theta', fix_initial=False, fix_final=False, defect_scaler=100.0,
+                        rate_source='theta_dot', targets=['theta'], units='rad')
+        burn2.add_state('vr', fix_initial=False, fix_final=True, defect_scaler=1000.0,
+                        rate_source='vr_dot', targets=['vr'], units='DU/TU')
+        burn2.add_state('vt', fix_initial=False, fix_final=True, defect_scaler=1000.0,
+                        rate_source='vt_dot', targets=['vt'], units='DU/TU')
+        burn2.add_state('accel', fix_initial=False, fix_final=False, defect_scaler=1.0,
+                        rate_source='at_dot', targets=['accel'], units='DU/TU**2')
+        burn2.add_state('deltav', fix_initial=False, fix_final=False, defect_scaler=1.0,
+                        rate_source='deltav_dot', units='DU/TU')
+
+        burn2.add_objective('deltav', loc='final', scaler=100.0)
+
+        burn2.add_control('u1', rate_continuity=True, rate2_continuity=True, units='deg',
+                          scaler=0.01, lower=-180, upper=180, targets=['u1'])
+
+    burn1.add_timeseries_output('pos_x')
+    coast.add_timeseries_output('pos_x')
+    burn2.add_timeseries_output('pos_x')
+
+    burn1.add_timeseries_output('pos_y')
+    coast.add_timeseries_output('pos_y')
+    burn2.add_timeseries_output('pos_y')
+
+    # Link Phases
+    if connected:
+        traj.link_phases(phases=['burn1', 'coast'],
+                         vars=['time', 'r', 'theta', 'vr', 'vt', 'deltav'],
+                         connected=True)
+
+        # No direct connections to the end of a phase.
+        traj.link_phases(phases=['burn2', 'coast'],
+                         vars=['r', 'theta', 'vr', 'vt', 'deltav'],
+                         locs=('final', 'final'))
+        traj.link_phases(phases=['burn2', 'coast'],
+                         vars=['time'], locs=('final', 'final'))
+
+        traj.link_phases(phases=['burn1', 'burn2'], vars=['accel'],
+                         locs=('final', 'final'))
+
+    else:
+        traj.link_phases(phases=['burn1', 'coast', 'burn2'],
+                         vars=['time', 'r', 'theta', 'vr', 'vt', 'deltav'])
+
+        traj.link_phases(phases=['burn1', 'burn2'], vars=['accel'])
+
+    return traj
+
+
+def two_burn_orbit_raise_problem(transcription='gauss-lobatto', optimizer='SLSQP', r_target=3.0,
+                                 transcription_order=3, compressed=False,
+                                 show_output=True, connected=False):
+
+    p = om.Problem(model=om.Group())
+
+    p.driver = om.pyOptSparseDriver()
+    p.driver.options['optimizer'] = optimizer
+    p.driver.declare_coloring()
+    if optimizer == 'SNOPT':
+        p.driver.opt_settings['Major iterations limit'] = 100
+        p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
+        p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
+        if show_output:
+            p.driver.opt_settings['iSumm'] = 6
+    elif optimizer == 'IPOPT':
+        p.driver.opt_settings['hessian_approximation'] = 'limited-memory'
+        p.driver.opt_settings['nlp_scaling_method'] = 'gradient-based'
+        p.driver.opt_settings['print_level'] = 4
+        p.driver.opt_settings['linear_solver'] = 'mumps'
+        p.driver.opt_settings['mu_strategy'] = 'adaptive'
+        # p.driver.opt_settings['derivative_test'] = 'first-order'
+
+    traj = make_traj(transcription=transcription, transcription_order=transcription_order,
+                     compressed=compressed, connected=connected)
+    p.model.add_subsystem('traj', subsys=traj)
+
+    # Needed to move the direct solver down into the phases for use with MPI.
+    #  - After moving down, used fewer iterations (about 30 less)
+
+    p.setup(check=True)
+
+    # Set Initial Guesses
+    p.set_val('traj.parameters:c', value=1.5, units='DU/TU')
+
+    burn1 = p.model.traj.phases.burn1
+    burn2 = p.model.traj.phases.burn2
+    coast = p.model.traj.phases.coast
+
+    if burn1 in p.model.traj.phases._subsystems_myproc:
+        p.set_val('traj.burn1.t_initial', value=0.0)
+        p.set_val('traj.burn1.t_duration', value=2.25)
+        p.set_val('traj.burn1.states:r', value=burn1.interpolate(ys=[1, 1.5],
+                                                                 nodes='state_input'))
+        p.set_val('traj.burn1.states:theta', value=burn1.interpolate(ys=[0, 1.7],
+                  nodes='state_input'))
+        p.set_val('traj.burn1.states:vr', value=burn1.interpolate(ys=[0, 0],
+                                                                  nodes='state_input'))
+        p.set_val('traj.burn1.states:vt', value=burn1.interpolate(ys=[1, 1],
+                                                                  nodes='state_input'))
+        p.set_val('traj.burn1.states:accel', value=burn1.interpolate(ys=[0.1, 0],
+                  nodes='state_input'))
+        p.set_val('traj.burn1.states:deltav', value=burn1.interpolate(ys=[0, 0.1],
+                  nodes='state_input'))
+        p.set_val('traj.burn1.controls:u1',
+                  value=burn1.interpolate(ys=[-3.5, 13.0], nodes='control_input'))
+
+    if coast in p.model.traj.phases._subsystems_myproc:
+        p.set_val('traj.coast.t_initial', value=2.25)
+        p.set_val('traj.coast.t_duration', value=3.0)
+
+        p.set_val('traj.coast.states:r', value=coast.interpolate(ys=[1.3, 1.5],
+                  nodes='state_input'))
+        p.set_val('traj.coast.states:theta',
+                  value=coast.interpolate(ys=[2.1767, 1.7], nodes='state_input'))
+
+        p.set_val('traj.coast.states:vr', value=coast.interpolate(ys=[0.3285, 0],
+                  nodes='state_input'))
+        p.set_val('traj.coast.states:vt', value=coast.interpolate(ys=[0.97, 1],
+                  nodes='state_input'))
+        p.set_val('traj.coast.states:accel', value=coast.interpolate(ys=[0, 0],
+                  nodes='state_input'))
+
+    if burn2 in p.model.traj.phases._subsystems_myproc:
+        if connected:
+            p.set_val('traj.burn2.t_initial', value=7.0)
+            p.set_val('traj.burn2.t_duration', value=-1.75)
+
+            p.set_val('traj.burn2.states:r', value=burn2.interpolate(ys=[r_target, 1],
+                      nodes='state_input'))
+            p.set_val('traj.burn2.states:theta', value=burn2.interpolate(ys=[4.0, 0.0],
+                      nodes='state_input'))
+            p.set_val('traj.burn2.states:vr', value=burn2.interpolate(ys=[0, 0],
+                                                                      nodes='state_input'))
+            p.set_val('traj.burn2.states:vt',
+                      value=burn2.interpolate(ys=[np.sqrt(1 / r_target), 1],
+                                              nodes='state_input'))
+            p.set_val('traj.burn2.states:deltav',
+                      value=burn2.interpolate(ys=[0.2, 0.1], nodes='state_input'))
+            p.set_val('traj.burn2.states:accel', value=burn2.interpolate(ys=[0., 0.1],
+                      nodes='state_input'))
+
+        else:
+            p.set_val('traj.burn2.t_initial', value=5.25)
+            p.set_val('traj.burn2.t_duration', value=1.75)
+
+            p.set_val('traj.burn2.states:r', value=burn2.interpolate(ys=[1, r_target],
+                      nodes='state_input'))
+            p.set_val('traj.burn2.states:theta', value=burn2.interpolate(ys=[0, 4.0],
+                      nodes='state_input'))
+            p.set_val('traj.burn2.states:vr', value=burn2.interpolate(ys=[0, 0],
+                                                                      nodes='state_input'))
+            p.set_val('traj.burn2.states:vt',
+                      value=burn2.interpolate(ys=[1, np.sqrt(1 / r_target)],
+                                              nodes='state_input'))
+            p.set_val('traj.burn2.states:deltav',
+                      value=burn2.interpolate(ys=[0.1, 0.2], nodes='state_input'))
+            p.set_val('traj.burn2.states:accel', value=burn2.interpolate(ys=[0.1, 0],
+                      nodes='state_input'))
+
+        p.set_val('traj.burn2.controls:u1', value=burn2.interpolate(ys=[0, 0],
+                  nodes='control_input'))
+
+    dm.run_problem(p, simulate=True, make_plots=True)
+
+    return p
+
+
+# @use_tempdirs
+class TestExampleTwoBurnOrbitRaise(unittest.TestCase):
+
+    @unittest.skipIf(optimizer is not 'IPOPT', 'IPOPT not available')
+    def test_ex_two_burn_orbit_raise(self):
+        optimizer = 'IPOPT'
+
+        p = two_burn_orbit_raise_problem(transcription='gauss-lobatto', transcription_order=3,
+                                         compressed=False, optimizer=optimizer,
+                                         show_output=False)
+
+        if p.model.traj.phases.burn2 in p.model.traj.phases._subsystems_myproc:
+            assert_near_equal(p.get_val('traj.burn2.states:deltav')[-1], 0.3995,
+                              tolerance=2.0E-3)
+
+
+# This test is separate because connected phases aren't directly parallelizable.
+@use_tempdirs
+class TestExampleTwoBurnOrbitRaiseConnected(unittest.TestCase):
+
+    @unittest.skipIf(optimizer is not 'IPOPT', 'IPOPT not available')
+    def test_ex_two_burn_orbit_raise_connected(self):
+        optimizer = 'IPOPT'
+
+        p = two_burn_orbit_raise_problem(transcription='gauss-lobatto', transcription_order=3,
+                                         compressed=False, optimizer=optimizer,
+                                         show_output=False, connected=True)
+
+        if p.model.traj.phases.burn2 in p.model.traj.phases._subsystems_myproc:
+            assert_near_equal(p.get_val('traj.burn2.states:deltav')[0], 0.3995,
+                              tolerance=4.0E-3)
+
+
+class TestExampleTwoBurnOrbitRaiseMPI(TestExampleTwoBurnOrbitRaise):
+    N_PROCS = 3
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()

--- a/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise_bokeh_plots.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise_bokeh_plots.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import shutil
 import unittest
@@ -12,6 +13,8 @@ _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
 import dymos as dm
 from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
 from openmdao.utils.testing_utils import use_tempdirs
+
+bokeh_available = importlib.util.find_spec('bokeh') is not None
 
 
 def make_traj(transcription='gauss-lobatto', transcription_order=3, compressed=False,
@@ -275,6 +278,7 @@ class TestExampleTwoBurnOrbitRaise(unittest.TestCase):
         if os.path.isdir('plots'):
             shutil.rmtree('plots')
 
+    @unittest.skipIf(not bokeh_available, 'bokeh unavailable')
     def test_bokeh_plots(self):
         dm.options['plots'] = 'bokeh'
 

--- a/dymos/options.py
+++ b/dymos/options.py
@@ -4,3 +4,9 @@ options = OptionsDictionary()
 
 options.declare('include_check_partials', default=True, types=bool,
                 desc='If True, include dymos components when checking partials.')
+
+options.declare('plots', default='matplotlib', values=['matplotlib', 'bokeh'],
+                desc='The plot library used to generate output plots for Dymos.')
+
+options.declare('notebook_mode', default=False, types=bool,
+                desc='If True, provide notebook-enhanced plots and outputs.')

--- a/dymos/visualization/timeseries_plots.py
+++ b/dymos/visualization/timeseries_plots.py
@@ -1,11 +1,14 @@
 import os
 import warnings
 
+import numpy as np
+
 import matplotlib.pyplot as plt
 import matplotlib.lines as mlines
 import matplotlib.patches as mpatches
 
 import openmdao.api as om
+from dymos.options import options as dymos_options
 
 
 def _get_phases_node_in_problem_metadata(node, path=""):
@@ -47,78 +50,8 @@ def _get_phases_node_in_problem_metadata(node, path=""):
     return None, None
 
 
-def timeseries_plots(solution_recorder_filename, simulation_record_file=None, plot_dir="plots"):
-    """
-    Given timeseries data from case recorder files, make separate plots of each variable
-    and store the plot files in the directory indicated by the variable plot_dir
-
-    Parameters
-    ----------
-    solution_recorder_filename : str
-        The path to the case recorder file containing solution data
-    simulation_record_file : str or None (default:None)
-        The path to the case recorder file containing simulation data. If not None,
-        this implies that the data from it should be plotted
-    plot_dir : str
-        The path to the directory to which the plot files will be written
-    """
-
-    # get ready to generate plot files
-    plot_dir_path = os.path.join(os.getcwd(), plot_dir)
-    if not os.path.isdir(plot_dir_path):
-        os.mkdir(plot_dir_path)
-
-    cr = om.CaseReader(solution_recorder_filename)
-
-    # get outputs from the solution
-    solution_cases = cr.list_cases('problem')
-    last_solution_case = cr.get_case(solution_cases[-1])
-
-    # If plotting simulation results, get the values for those variables
-    if simulation_record_file:
-        cr_simulate = om.CaseReader(simulation_record_file)
-        system_simulation_cases = cr_simulate.list_cases('problem')
-        last_simulation_case = cr_simulate.get_case(system_simulation_cases[-1])
-
-    # we will use the problem metadata to get information about the phases and units
-    root_children = cr.problem_metadata['tree']['children']
-
-    # We have to key off the phases node. It will tell us
-    #  what the prefix is for the variable names before the phases part of the variables
-    #  and also let us know what the phase names are
-    phases_node, phases_node_path = _get_phases_node_in_problem_metadata(root_children)
-
-    # get phase names
-    phase_names = [phase['name'] for phase in phases_node['children']]
-
-    # Get the units and var names along the way
-    var_units = {}
-    time_units = {}
-    for phase_node in phases_node['children']:  # Hopefully all phases have the same vars
-        for phase_node_child in phase_node['children']:  # find the timeseries node
-            if phase_node_child['name'] == 'timeseries':
-                timeseries_node = phase_node_child
-                break
-        # get the time units first so they can be associated with all the variables
-        for timeseries_node_child in timeseries_node['children']:
-            if timeseries_node_child['name'] == 'time':
-                units_for_time = timeseries_node_child['units']
-                break
-        for timeseries_node_child in timeseries_node['children']:
-            # plot everything in the timeseries except input_values. Also not time since that
-            #   is the independent variable in these plot
-            if not timeseries_node_child['name'].startswith("input_values:")\
-                    and not timeseries_node_child['name'] == 'time':
-                varname = timeseries_node_child['name']
-                var_units[varname] = timeseries_node_child['units']
-                time_units[varname] = units_for_time
-    varnames = list(var_units.keys())
-
-    # Check to see if there is anything to plot
-    if len(varnames) == 0:
-        warnings.warn('There are no timeseries variables to plot', RuntimeWarning)
-        return
-
+def _mpl_timeseries_plots(varnames, time_units, var_units, phase_names, phases_node_path,
+                          last_solution_case, last_simulation_case, plot_dir_path):
     # get ready to plot
     plt.switch_backend('Agg')
     # use a colormap with 20 values
@@ -160,7 +93,7 @@ def timeseries_plots(solution_recorder_filename, simulation_record_file=None, pl
             ax.plot(time_val, var_val, marker='o', linestyle='None', label='solution', color=color)
 
             # get simulation values, if plotting simulation
-            if simulation_record_file:
+            if last_simulation_case:
                 # if the phases_node_path is empty, need to pre-pend names with "sim_traj."
                 #   as that is pre-pended in Trajectory.simulate code
                 sim_prefix = "" if phases_node_path else "sim_traj."
@@ -173,7 +106,7 @@ def timeseries_plots(solution_recorder_filename, simulation_record_file=None, pl
         #   Solution/Simulation legend
         solution_line = mlines.Line2D([], [], color='black', marker='o', linestyle='None',
                                       label='Solution')
-        if simulation_record_file:
+        if last_simulation_case:
             simulation_line = mlines.Line2D([], [], color='black', linestyle='--',
                                             label='Simulation')
             sol_sim_legend = plt.legend(handles=[solution_line, simulation_line],
@@ -197,3 +130,269 @@ def timeseries_plots(solution_recorder_filename, simulation_record_file=None, pl
         # save to file
         plot_file_path = os.path.join(plot_dir_path, f'{var_name.replace(":","_")}.png')
         plt.savefig(plot_file_path)
+
+
+def _bokeh_timeseries_plots(varnames, time_units, var_units, phase_names, phases_node_path,
+                            last_solution_case, last_simulation_case, plot_dir_path, num_cols=4,
+                            page_width=1080):
+    from bokeh.io import output_file, show
+    from bokeh.layouts import gridplot, column
+    from bokeh.models import Legend, Circle, Line, Square, ColumnDataSource, Label
+    from bokeh.plotting import figure
+    import bokeh.palettes as bp
+
+    # Create a figure of annotations that will serve as the legend
+
+    output_file(os.path.join(plot_dir_path, 'plots.html')) # f'{var_name.replace(":", "_")}.png')
+
+    # Prune the edges from the color map
+    cmap = bp.turbo(len(phase_names) + 2)[1:-1]
+    figures = []
+
+    # Get the minimum and maximum times in any phase, so when we plot a variable that only exists
+    # in a few phases, it is plotted against the entire time range.
+    min_time = 1.0E21
+    max_time = -1.0E21
+
+    legend_figs = []
+
+    for iphase, phase_name in enumerate(phase_names):
+        if phases_node_path:
+            time_name = f'{phases_node_path}.{phase_name}.timeseries.time'
+        else:
+            time_name = f'{phase_name}.timeseries.time'
+        min_time = min(min_time, np.min(last_solution_case.outputs[time_name]))
+        max_time = max(max_time, np.max(last_solution_case.outputs[time_name]))
+    #     color = cmap[iphase]
+    #     legend_fig = figure(title='', x_range=(0, 50), y_range=(-25, 25))
+    #     legend_fig.axis.visible = False
+    #     legend_fig.xgrid.visible = False
+    #     legend_fig.ygrid.visible = False
+    #     legend_fig.square([10], [0], size=20, color=color)
+    #     legend_figs.append(legend_fig)
+    #
+    # legend_grid = gridplot(legend_figs, ncols=5, plot_width=100, plot_height=100)
+    sol_plots = {}
+    sim_plots = {}
+
+    for ivar, var_name in enumerate(varnames):
+        # start a new plot
+
+        # Get the labels
+        time_label = f'time ({time_units[var_name]})'
+        var_label = f'{var_name} ({var_units[var_name]})'
+        title = f'timeseries.{var_name}'
+
+        # add labels, title, and legend
+        padding = 0.05 * (max_time - min_time)
+        fig = figure(title=title, background_fill_color="#282828",
+                     x_range=(min_time - padding, max_time + padding))
+        fig.xaxis.axis_label = time_label
+        fig.yaxis.axis_label = var_label
+        fig.xgrid.grid_line_color = '#666666'
+        fig.ygrid.grid_line_color = '#666666'
+
+        # Plot each phase
+        for iphase, phase_name in enumerate(phase_names):
+            sol_color = cmap[iphase]
+            sim_color = cmap[iphase]
+
+            if phases_node_path:
+                var_name_full = f'{phases_node_path}.{phase_name}.timeseries.{var_name}'
+                time_name = f'{phases_node_path}.{phase_name}.timeseries.time'
+            else:
+                var_name_full = f'{phase_name}.timeseries.{var_name}'
+                time_name = f'{phase_name}.timeseries.time'
+
+            # Get values
+            if var_name_full not in last_solution_case.outputs:
+                continue
+
+            var_val = last_solution_case.outputs[var_name_full]
+            time_val = last_solution_case.outputs[time_name]
+            mean_time = np.mean(time_val)
+            mean_val = np.mean(var_val)
+
+            # Plot the data
+            # color = cm.colors[iphase % 20]
+
+            for idxs, i in np.ndenumerate(np.zeros(var_val.shape[1:])):
+                var_val_i = var_val[:, idxs].ravel()
+                sol_plots[phase_name] = fig.circle(time_val.ravel(), var_val_i, size=5,
+                                                   color=sol_color)
+
+            # get simulation values, if plotting simulation
+            if last_simulation_case:
+                # if the phases_node_path is empty, need to pre-pend names with "sim_traj."
+                #   as that is pre-pended in Trajectory.simulate code
+                sim_prefix = '' if phases_node_path else 'sim_traj.'
+                var_val_simulate = last_simulation_case.outputs[sim_prefix + var_name_full]
+                time_val_simulate = last_simulation_case.outputs[sim_prefix + time_name]
+                for idxs, i in np.ndenumerate(np.zeros(var_val_simulate.shape[1:])):
+                    var_val_i = var_val_simulate[:, idxs].ravel()
+                    sim_plots[phase_name] = fig.line(time_val_simulate.ravel(), var_val_i,
+                                                     line_dash='solid', line_width=0.5, color=sim_color)
+
+            # phase_label = Label(x=mean_time, y=mean_val, x_units='data', y_units='data',
+            #                     text=phase_name, render_mode='css', text_color=sol_color,
+            #                     border_line_alpha=0.0, background_fill_alpha=0.0,
+            #                     x_offset=-mean_time//2, y_offset=-20)
+            #
+            # fig.add_layout(phase_label)
+
+        for key, plt in sol_plots.items():
+            pass
+
+        # legend = Legend(items=[('foo', [sol_plots['coast']])],
+        #                 location='top_left', orientation='horizontal')
+        #
+        # fig.add_layout(legend, 'above')
+
+        print(dir(fig))
+        print(fig.renderers)
+        print(fig.legend)
+        exit(0)
+
+        figures.append(fig)
+
+    # ## Use a dummy figure for the LEGEND
+    # dum_fig = figure(plot_width=300, plot_height=600, outline_line_alpha=0, toolbar_location=None)
+    # # set the components of the figure invisible
+    # for fig_component in [dum_fig.grid[0], dum_fig.ygrid[0], dum_fig.xaxis[0], dum_fig.yaxis[0]]:
+    #     fig_component.visible = False
+    # # The glyphs referred by the legend need to be present in the figure that holds the legend, so we must add them to the figure renderers
+    # dum_fig.renderers += renderer_list
+    # # set the figure range outside of the range of all glyphs
+    # dum_fig.x_range.end = 1005
+    # dum_fig.x_range.start = 1000
+    # # add the legend
+    # dum_fig.add_layout(
+    #     Legend(click_policy='hide', location='top_left', border_line_alpha=0, items=legend_items))
+    #
+    # figrid = gridplot(fig_list, ncols=2, toolbar_location='left')
+    # final = gridplot([[figrid, dum_fig]], toolbar_location=None)
+    # show(final)
+
+    grid = gridplot(figures, ncols=num_cols,
+                    plot_width=page_width//num_cols, plot_height=min(400, page_width//num_cols))
+    show(grid)
+
+        # # Create two legends
+        # #   Solution/Simulation legend
+        # solution_line = mlines.Line2D([], [], color='black', marker='o', linestyle='None',
+        #                               label='Solution')
+        # if last_simulation_case:
+        #     simulation_line = mlines.Line2D([], [], color='black', linestyle='--',
+        #                                     label='Simulation')
+        #     sol_sim_legend = plt.legend(handles=[solution_line, simulation_line],
+        #                                 loc='upper left', bbox_to_anchor=(-0.3, -0.12), shadow=True)
+        # else:
+        #     sol_sim_legend = plt.legend(handles=[solution_line],
+        #                                 loc='upper left', bbox_to_anchor=(-0.3, -0.12),
+        #                                 shadow=True)
+        # plt.gca().add_artist(sol_sim_legend)
+        #
+        # #   Phases legend
+        # handles = []
+        # for iphase, phase_name in enumerate(phase_names):
+        #     patch = mpatches.Patch(color=cm.colors[iphase], label=phase_name)
+        #     handles.append(patch)
+        # plt.legend(handles=handles, loc='upper right', ncol=len(phase_names), shadow=True,
+        #            bbox_to_anchor=(1.15, -0.12), title='Phases')
+
+        # plt.subplots_adjust(bottom=0.23, top=0.9, left=0.2)
+
+        # save to file
+        # plot_file_path = os.path.join(plot_dir_path, f'{var_name.replace(":","_")}.png')
+        # plt.savefig(plot_file_path)
+
+
+def timeseries_plots(solution_recorder_filename, simulation_record_file=None, plot_dir="plots"):
+    """
+    Given timeseries data from case recorder files, make separate plots of each variable
+    and store the plot files in the directory indicated by the variable plot_dir
+
+    Parameters
+    ----------
+    solution_recorder_filename : str
+        The path to the case recorder file containing solution data
+    simulation_record_file : str or None (default:None)
+        The path to the case recorder file containing simulation data. If not None,
+        this implies that the data from it should be plotted
+    plot_dir : str
+        The path to the directory to which the plot files will be written
+    """
+
+    # get ready to generate plot files
+    plot_dir_path = os.path.join(os.getcwd(), plot_dir)
+    if not os.path.isdir(plot_dir_path):
+        os.mkdir(plot_dir_path)
+
+    cr = om.CaseReader(solution_recorder_filename)
+
+    # get outputs from the solution
+    solution_cases = cr.list_cases('problem')
+    last_solution_case = cr.get_case(solution_cases[-1])
+
+    # If plotting simulation results, get the values for those variables
+    if simulation_record_file:
+        cr_simulate = om.CaseReader(simulation_record_file)
+        system_simulation_cases = cr_simulate.list_cases('problem')
+        last_simulation_case = cr_simulate.get_case(system_simulation_cases[-1])
+    else:
+        last_simulation_case = None
+
+    # we will use the problem metadata to get information about the phases and units
+    root_children = cr.problem_metadata['tree']['children']
+
+    # We have to key off the phases node. It will tell us
+    #  what the prefix is for the variable names before the phases part of the variables
+    #  and also let us know what the phase names are
+    phases_node, phases_node_path = _get_phases_node_in_problem_metadata(root_children)
+
+    # get phase names
+    phase_names = [phase['name'] for phase in phases_node['children']]
+
+    # Get the units and var names along the way
+    var_units = {}
+    time_units = {}
+    for phase_node in phases_node['children']:  # Hopefully all phases have the same vars
+        for phase_node_child in phase_node['children']:  # find the timeseries node
+            if phase_node_child['name'] == 'timeseries':
+                timeseries_node = phase_node_child
+                break
+        # get the time units first so they can be associated with all the variables
+        for timeseries_node_child in timeseries_node['children']:
+            if timeseries_node_child['name'] == 'time':
+                units_for_time = timeseries_node_child['units']
+                break
+        for timeseries_node_child in timeseries_node['children']:
+            # plot everything in the timeseries except input_values. Also not time since that
+            #   is the independent variable in these plot
+            if not timeseries_node_child['name'].startswith("input_values:")\
+                    and not timeseries_node_child['name'] == 'time':
+                varname = timeseries_node_child['name']
+                var_units[varname] = timeseries_node_child['units']
+                time_units[varname] = units_for_time
+    varnames = list(var_units.keys())
+
+    # Check to see if there is anything to plot
+    if len(varnames) == 0:
+        warnings.warn('There are no timeseries variables to plot', RuntimeWarning)
+        return
+
+    if dymos_options['plots'] == 'bokeh':
+        _bokeh_timeseries_plots(varnames, time_units, var_units, phase_names, phases_node_path,
+                                last_solution_case, last_simulation_case, plot_dir_path)
+    elif dymos_options['plots'] == 'matplotlib':
+        _mpl_timeseries_plots(varnames, time_units, var_units, phase_names, phases_node_path,
+                              last_solution_case, last_simulation_case, plot_dir_path)
+    else:
+        raise ValueError(f'Unknown plotting option: {dymos_options["plots"]}')
+
+
+if __name__ == '__main__':
+    dymos_options['plots'] = 'bokeh'
+    os.chdir('/Users/rfalck/Projects/dymos.git/dymos/examples/finite_burn_orbit_raise/test')
+    timeseries_plots('dymos_solution.db', simulation_record_file='dymos_simulation.db',
+                     plot_dir='plots')

--- a/dymos/visualization/timeseries_plots.py
+++ b/dymos/visualization/timeseries_plots.py
@@ -135,13 +135,16 @@ def _mpl_timeseries_plots(varnames, time_units, var_units, phase_names, phases_n
 def _bokeh_timeseries_plots(varnames, time_units, var_units, phase_names, phases_node_path,
                             last_solution_case, last_simulation_case, plot_dir_path, num_cols=2,
                             bg_fill_color='#282828', grid_line_color='#666666'):
-    from bokeh.io import output_file, show
+    from bokeh.io import output_notebook, output_file, show
     from bokeh.layouts import gridplot, column, row, grid, layout
     from bokeh.models import Legend, LegendItem
     from bokeh.plotting import figure
     import bokeh.palettes as bp
 
-    output_file(os.path.join(plot_dir_path, 'plots.html')) # f'{var_name.replace(":", "_")}.png')
+    if dymos_options['notebook_mode']:
+        output_notebook()
+    else:
+        output_file(os.path.join(plot_dir_path, 'plots.html')) # f'{var_name.replace(":", "_")}.png')
 
     # Prune the edges from the color map
     cmap = bp.turbo(len(phase_names) + 2)[1:-1]

--- a/dymos/visualization/timeseries_plots.py
+++ b/dymos/visualization/timeseries_plots.py
@@ -351,10 +351,3 @@ def timeseries_plots(solution_recorder_filename, simulation_record_file=None, pl
                               last_solution_case, last_simulation_case, plot_dir_path)
     else:
         raise ValueError(f'Unknown plotting option: {dymos_options["plots"]}')
-
-
-if __name__ == '__main__':
-    dymos_options['plots'] = 'bokeh'
-    os.chdir('/Users/rfalck/Projects/dymos.git/dymos/examples/finite_burn_orbit_raise/test')
-    timeseries_plots('dymos_solution.db', simulation_record_file='dymos_simulation.db',
-                     plot_dir='plots')


### PR DESCRIPTION
### Summary

Timeseries plots now cached the current matplotlib backend and restore it once all plots have been saved.

In addition, timeseries plot generation has been split into two sub functions; one for matplotlib and one for bokeh.
The plotting package used for timeseries plots is set using `dymos.options['plots']` and can take the value `'matplotlib'` (the default) or `'bokeh'`.

### Related Issues

- Resolves #495

### Status

- [ ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
