### PR TITLE
adds a deprecation warning when using the command line interface

### DIFF
--- a/dymos/utils/command_line.py
+++ b/dymos/utils/command_line.py
@@ -2,6 +2,7 @@ import openmdao.utils.hooks as hooks
 import argparse
 import sys
 import os
+from openmdao.utils.general_utils import warn_deprecation
 from dymos.run_problem import modify_problem, run_problem
 from unittest.mock import patch
 
@@ -37,6 +38,15 @@ def _simple_exec(script_name, user_args):
 
 
 def dymos_cmd(argv=None):
+    """
+    The Dymos command line script.
+    """
+    msg = """
+    The Dymos command-line interface is deprecated and will be removed in dymos 1.0.0.
+    This functionality is available by using the run_problem function from a python script instead.
+    """
+    warn_deprecation(msg)
+
     # pre-parse sys.argv to split between before and after '--'
     alt_args = argv if argv else sys.argv
     if '--' in alt_args:


### PR DESCRIPTION
### Summary

The command-line interface now issues a deprecation warning when used, and the functionality will be removed completely and totally folded into `run_problem` in 1.0.0.

### Related Issues

- Resolves #504

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
