### PR TITLE
Bugfix for array parameters not passing correctly

### DIFF
--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -1932,7 +1932,7 @@ class Phase(om.Group):
 
             # We use this private function to grab the correctly sized variable from the
             # auto_ivc source.
-            if om_version < (3, 4, 1):
+            if om_version < (3, 4, 1) and phs.parameter_options[name]['dynamic']:
                 val = phs.get_val(f'parameters:{name}')[0, ...]
             else:
                 val = phs.get_val(f'parameters:{name}')


### PR DESCRIPTION


### Summary

In the function initialize_values_from_phase parameters are handled differently for OpenMDAO 3.4.0 and older. This handling assumes parameters are dynamic and only uses the first element (element may be an array). This presents an issue when using static, array-valued parameters. 
Added check for whether parameters are dynamic when getting the parameter values for older versions of OpenMDAO.

### Related Issues

- Resolves #503 

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
