### PR TITLE
Fixed a bug where timeseries outputs of non-dynamic ODE outputs would cause an exception.

### DIFF
--- a/dymos/examples/brachistochrone/test/test_static_outputs.py
+++ b/dymos/examples/brachistochrone/test/test_static_outputs.py
@@ -124,7 +124,7 @@ class TestStaticODEOutput(unittest.TestCase):
             warnings.simplefilter('always')
             p.setup(check=True)
             expected_warning = "Cannot add ODE output foo to the timeseries output. It is sized " \
-                               "such that its first dimension != num_nodes. The shape is (2, 2)."
+                               "such that its first dimension != num_nodes."
             self.assertIn(expected_warning, [str(w.message) for w in ctx])
 
         # Now that the OpenMDAO problem is setup, we can set the values of the states.
@@ -153,7 +153,7 @@ class TestStaticODEOutput(unittest.TestCase):
             warnings.simplefilter('always')
             dm.run_problem(p, simulate=True, make_plots=False)
             expected_warning = "Cannot add ODE output foo to the timeseries output. It is sized " \
-                               "such that its first dimension != num_nodes. The shape is (2, 2)."
+                               "such that its first dimension != num_nodes."
             self.assertIn(expected_warning, [str(w.message) for w in ctx])
 
         sol = om.CaseReader('dymos_solution.db').get_case('final')
@@ -237,7 +237,7 @@ class TestStaticODEOutput(unittest.TestCase):
             warnings.simplefilter('always')
             p.setup(check=True)
             expected_warning = "Cannot add ODE output foo to the timeseries output. It is sized " \
-                               "such that its first dimension != num_nodes. The shape is (2, 2)."
+                               "such that its first dimension != num_nodes."
             self.assertIn(expected_warning, [str(w.message) for w in ctx])
 
         # Now that the OpenMDAO problem is setup, we can set the values of the states.
@@ -266,7 +266,7 @@ class TestStaticODEOutput(unittest.TestCase):
             warnings.simplefilter('always')
             dm.run_problem(p, simulate=True, make_plots=False)
             expected_warning = "Cannot add ODE output foo to the timeseries output. It is sized " \
-                               "such that its first dimension != num_nodes. The shape is (2, 2)."
+                               "such that its first dimension != num_nodes."
             self.assertIn(expected_warning, [str(w.message) for w in ctx])
 
         sol = om.CaseReader('dymos_solution.db').get_case('final')

--- a/dymos/examples/brachistochrone/test/test_static_outputs.py
+++ b/dymos/examples/brachistochrone/test/test_static_outputs.py
@@ -1,0 +1,174 @@
+import warnings
+import unittest
+
+import numpy as np
+import openmdao.api as om
+import dymos as dm
+
+from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
+
+
+class BrachODEStaticOutput(om.ExplicitComponent):
+
+    def initialize(self):
+        self.options.declare('num_nodes', types=int)
+        self.options.declare('static_gravity', types=(bool,), default=False,
+                             desc='If True, treat gravity as a static (scalar) input, rather than '
+                                  'having different values at each node.')
+
+    def setup(self):
+        nn = self.options['num_nodes']
+        g_default_val = 9.80665 if self.options['static_gravity'] else 9.80665 * np.ones(nn)
+
+        # Inputs
+        self.add_input('v', val=np.zeros(nn), desc='velocity', units='m/s')
+
+        self.add_input('g', val=g_default_val, desc='grav. acceleration', units='m/s/s')
+
+        self.add_input('theta', val=np.ones(nn), desc='angle of wire', units='rad')
+
+        self.add_output('xdot', val=np.zeros(nn), desc='velocity component in x', units='m/s',
+                        tags=['state_rate_source:x', 'state_units:m'])
+
+        self.add_output('ydot', val=np.zeros(nn), desc='velocity component in y', units='m/s',
+                        tags=['state_rate_source:y', 'state_units:m'])
+
+        self.add_output('vdot', val=np.zeros(nn), desc='acceleration magnitude', units='m/s**2',
+                        tags=['state_rate_source:v', 'state_units:m/s'])
+
+        self.add_output('check', val=np.zeros(nn), desc='check solution: v/sin(theta) = constant',
+                        units='m/s')
+
+        self.add_output('foo', val=np.eye(2), desc='a static matrix to be output', units='m/s**2')
+
+        self.declare_partials(of='*', wrt='*', method='cs')
+        self.declare_coloring(wrt='*', method='cs', show_summary=True, show_sparsity=True)
+
+    def compute(self, inputs, outputs):
+        theta = inputs['theta']
+        cos_theta = np.cos(theta)
+        sin_theta = np.sin(theta)
+        g = inputs['g']
+        v = inputs['v']
+
+        outputs['vdot'] = g * cos_theta
+        outputs['xdot'] = v * sin_theta
+        outputs['ydot'] = -v * cos_theta
+        outputs['check'] = v / sin_theta
+
+        np.fill_diagonal(outputs['foo'], g)
+
+
+@use_tempdirs
+class TestStaticODEOutput(unittest.TestCase):
+
+    def _test_static_ode_output(self, transcription):
+
+        #
+        # Define the OpenMDAO problem
+        #
+        p = om.Problem(model=om.Group())
+
+        #
+        # Define a Trajectory object
+        #
+        traj = dm.Trajectory()
+
+        p.model.add_subsystem('traj', subsys=traj)
+
+        #
+        # Define a Dymos Phase object with GaussLobatto Transcription
+        #
+        phase = dm.Phase(ode_class=BrachODEStaticOutput,
+                         transcription=transcription(num_segments=10, order=3))
+
+        traj.add_phase(name='phase0', phase=phase)
+
+        #
+        # Set the time options
+        # Time has no targets in our ODE.
+        # We fix the initial time so that the it is not a design variable in the optimization.
+        # The duration of the phase is allowed to be optimized, but is bounded on [0.5, 10].
+        #
+        phase.set_time_options(fix_initial=True, duration_bounds=(1.0, 10.0), units='s')
+
+        #
+        # Set the time options
+        # Initial values of positions and velocity are all fixed.
+        # The final value of position are fixed, but the final velocity is a free variable.
+        # The equations of motion are not functions of position, so 'x' and 'y' have no targets.
+        # The rate source points to the output in the ODE which provides the time derivative of the
+        # given state.
+        phase.add_state('x', fix_initial=True, fix_final=True)
+        phase.add_state('y', fix_initial=True, fix_final=True)
+        phase.add_state('v', fix_initial=True)
+
+        # Define theta as a control.
+        phase.add_control(name='theta', units='rad', lower=0.01, upper=np.pi-0.01, shape=(1,))
+
+        phase.add_timeseries_output('*')
+
+        # Minimize final time.
+        phase.add_objective('time', loc='final')
+
+        # Set the driver.
+        p.driver = om.ScipyOptimizeDriver()
+
+        # Allow OpenMDAO to automatically determine our sparsity pattern.
+        # Doing so can significant speed up the execution of Dymos.
+        p.driver.declare_coloring()
+
+        # Setup the problem
+        with warnings.catch_warnings(record=True) as ctx:
+            warnings.simplefilter('always')
+            p.setup(check=True)
+            expected_warning = "Cannot add ODE output foo to the timeseries output. It is sized " \
+                               "such that its first dimension != num_nodes. The shape is (2, 2)."
+            self.assertIn(expected_warning, [str(w.message) for w in ctx])
+
+        # Now that the OpenMDAO problem is setup, we can set the values of the states.
+
+        p.set_val('traj.phase0.t_initial', 0.0, units='s')
+        p.set_val('traj.phase0.t_duration', 5.0, units='s')
+
+        p.set_val('traj.phase0.states:x',
+                  phase.interpolate(ys=[0, 10], nodes='state_input'),
+                  units='m')
+
+        p.set_val('traj.phase0.states:y',
+                  phase.interpolate(ys=[10, 5], nodes='state_input'),
+                  units='m')
+
+        p.set_val('traj.phase0.states:v',
+                  phase.interpolate(ys=[0, 5], nodes='state_input'),
+                  units='m/s')
+
+        p.set_val('traj.phase0.controls:theta',
+                  phase.interpolate(ys=[0.01, 90], nodes='control_input'),
+                  units='deg')
+
+        # Run the driver to solve the problem
+        with warnings.catch_warnings(record=True) as ctx:
+            warnings.simplefilter('always')
+            dm.run_problem(p, simulate=True, make_plots=False)
+            expected_warning = "Cannot add ODE output foo to the timeseries output. It is sized " \
+                               "such that its first dimension != num_nodes. The shape is (2, 2)."
+            self.assertIn(expected_warning, [str(w.message) for w in ctx])
+
+        sol = om.CaseReader('dymos_solution.db').get_case('final')
+        sim = om.CaseReader('dymos_simulation.db').get_case('final')
+
+        with self.assertRaises(expected_exception=KeyError) as e:
+            sol.get_val('traj.phase0.timeseries.foo')
+        self.assertEqual(str(e.exception), "'Variable name \"traj.phase0.timeseries.foo\" not found.'")
+
+        with self.assertRaises(expected_exception=KeyError) as e:
+            sim.get_val('traj.phase0.timeseries.foo')
+        self.assertEqual(str(e.exception), "'Variable name \"traj.phase0.timeseries.foo\" not found.'")
+
+    def test_static_ode_output_gl(self):
+        self._test_static_ode_output(dm.GaussLobatto)
+
+    def test_static_ode_output_radau(self):
+        self._test_static_ode_output(dm.Radau)

--- a/dymos/transcriptions/pseudospectral/gauss_lobatto.py
+++ b/dymos/transcriptions/pseudospectral/gauss_lobatto.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import openmdao.api as om
 
@@ -518,6 +520,16 @@ class GaussLobatto(PseudospectralBase):
 
                     # Ignore any variables that we've already added (states, times, controls, etc)
                     if var_type != 'ode':
+                        continue
+
+                    # If the full shape does not start with num_nodes, skip this variable.
+                    ode_outputs = {opts['prom_name']: opts for (k, opts) in
+                                   phase.rhs_disc.get_io_metadata(iotypes=('output',), get_remote=True).items()}
+                    ode_shape = ode_outputs[v]['shape']
+                    if ode_shape[0] != self.grid_data.subset_num_nodes['state_disc']:
+                        warnings.warn(f'Cannot add ODE output {v} to the timeseries output. It is '
+                                      f'sized such that its first dimension != num_nodes. '
+                                      f'The shape is {ode_shape}.')
                         continue
 
                     try:

--- a/dymos/transcriptions/pseudospectral/gauss_lobatto.py
+++ b/dymos/transcriptions/pseudospectral/gauss_lobatto.py
@@ -523,13 +523,9 @@ class GaussLobatto(PseudospectralBase):
                         continue
 
                     # If the full shape does not start with num_nodes, skip this variable.
-                    ode_outputs = {opts['prom_name']: opts for (k, opts) in
-                                   phase.rhs_disc.get_io_metadata(iotypes=('output',), get_remote=True).items()}
-                    ode_shape = ode_outputs[v]['shape']
-                    if ode_shape[0] != self.grid_data.subset_num_nodes['state_disc']:
+                    if self.is_static_ode_output(v, phase):
                         warnings.warn(f'Cannot add ODE output {v} to the timeseries output. It is '
-                                      f'sized such that its first dimension != num_nodes. '
-                                      f'The shape is {ode_shape}.')
+                                      f'sized such that its first dimension != num_nodes.')
                         continue
 
                     try:

--- a/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
+++ b/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
@@ -1,4 +1,5 @@
 from fnmatch import filter
+import warnings
 
 import numpy as np
 import openmdao.api as om
@@ -405,6 +406,16 @@ class Radau(PseudospectralBase):
 
                     # Ignore any variables that we've already added (states, times, controls, etc)
                     if var_type != 'ode':
+                        continue
+
+                    # If the full shape does not start with num_nodes, skip this variable.
+                    ode_outputs = {opts['prom_name']: opts for (k, opts) in
+                                   phase.rhs_all.get_io_metadata(iotypes=('output',), get_remote=True).items()}
+                    ode_shape = ode_outputs[v]['shape']
+                    if ode_shape[0] != self.grid_data.subset_num_nodes['all']:
+                        warnings.warn(f'Cannot add ODE output {v} to the timeseries output. It is '
+                                      f'sized such that its first dimension != num_nodes. '
+                                      f'The shape is {ode_shape}.')
                         continue
 
                     try:

--- a/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
+++ b/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
@@ -409,13 +409,9 @@ class Radau(PseudospectralBase):
                         continue
 
                     # If the full shape does not start with num_nodes, skip this variable.
-                    ode_outputs = {opts['prom_name']: opts for (k, opts) in
-                                   phase.rhs_all.get_io_metadata(iotypes=('output',), get_remote=True).items()}
-                    ode_shape = ode_outputs[v]['shape']
-                    if ode_shape[0] != self.grid_data.subset_num_nodes['all']:
+                    if self.is_static_ode_output(v, phase):
                         warnings.warn(f'Cannot add ODE output {v} to the timeseries output. It is '
-                                      f'sized such that its first dimension != num_nodes. '
-                                      f'The shape is {ode_shape}.')
+                                      f'sized such that its first dimension != num_nodes.')
                         continue
 
                     try:

--- a/dymos/transcriptions/runge_kutta/runge_kutta.py
+++ b/dymos/transcriptions/runge_kutta/runge_kutta.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 
 import openmdao.api as om
@@ -738,6 +740,16 @@ class RungeKutta(TranscriptionBase):
 
                     # Ignore any variables that we've already added (states, times, controls, etc)
                     if var_type != 'ode':
+                        continue
+
+                    # If the full shape does not start with num_nodes, skip this variable.
+                    ode_outputs = {opts['prom_name']: opts for (k, opts) in
+                                   phase.ode.get_io_metadata(iotypes=('output',), get_remote=True).items()}
+                    ode_shape = ode_outputs[v]['shape']
+                    if ode_shape[0] != phase.ode.options['num_nodes']:
+                        warnings.warn(f'Cannot add ODE output {v} to the timeseries output. It is '
+                                      f'sized such that its first dimension != num_nodes. '
+                                      f'The shape is {ode_shape}.')
                         continue
 
                     try:

--- a/dymos/transcriptions/runge_kutta/runge_kutta.py
+++ b/dymos/transcriptions/runge_kutta/runge_kutta.py
@@ -742,14 +742,9 @@ class RungeKutta(TranscriptionBase):
                     if var_type != 'ode':
                         continue
 
-                    # If the full shape does not start with num_nodes, skip this variable.
-                    ode_outputs = {opts['prom_name']: opts for (k, opts) in
-                                   phase.ode.get_io_metadata(iotypes=('output',), get_remote=True).items()}
-                    ode_shape = ode_outputs[v]['shape']
-                    if ode_shape[0] != phase.ode.options['num_nodes']:
+                    if self.is_static_ode_output(v, phase):
                         warnings.warn(f'Cannot add ODE output {v} to the timeseries output. It is '
-                                      f'sized such that its first dimension != num_nodes. '
-                                      f'The shape is {ode_shape}.')
+                                      f'sized such that its first dimension != num_nodes.')
                         continue
 
                     try:

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -535,14 +535,9 @@ class SolveIVP(TranscriptionBase):
 
                 # Skip the timeseries output if it does not appear to be shaped as a dynamic variable
                 # If the full shape does not start with num_nodes, skip this variable.
-                ode_outputs = {opts['prom_name']: opts for (k, opts) in
-                               phase.ode.get_io_metadata(iotypes=('output',),
-                                                         get_remote=True).items()}
-                ode_shape = ode_outputs[v]['shape']
-                if ode_shape[0] != phase._get_subsystem('ode').options['num_nodes']:
+                if self.is_static_ode_output(v, phase):
                     warnings.warn(f'Cannot add ODE output {v} to the timeseries output. It is '
-                                  f'sized such that its first dimension != num_nodes. '
-                                  f'The shape is {ode_shape}.')
+                                  f'sized such that its first dimension != num_nodes.')
                     continue
 
                 shape, units = get_source_metadata(phase.ode, src=v, user_shape=options['shape'],

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -750,3 +750,34 @@ class TranscriptionBase(object):
         # Note: currently nothing to do, but some inherited future transcription might need some
         # post-configure error checking.
         pass
+
+    def is_static_ode_output(self, var, phase):
+        """
+        Test whether the given output is a static output of the ODE.
+
+        A variable is considered static if it's first dimension is different than the
+        number of nodes in the ODE.
+
+        Parameters
+        ----------
+        var : str
+            The ode-relative path of the variable of interest.
+        phase : dymos.Phase
+            The phase to which this transcription applies.
+
+        Returns
+        -------
+        bool
+            True if the given variable is a static output, otherwise False if it is dynamic.
+
+        Raises
+        ------
+        KeyError
+            KeyError is raised if the given variable isn't present in the ode outputs.
+
+        """
+        ode = phase._get_subsystem(self._rhs_source)
+        ode_outputs = {opts['prom_name']: opts for (k, opts) in
+                       ode.get_io_metadata(iotypes=('output',), get_remote=True).items()}
+        ode_shape = ode_outputs[var]['shape']
+        return ode_shape[0] != ode.options['num_nodes'], ode_shape

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -780,4 +780,4 @@ class TranscriptionBase(object):
         ode_outputs = {opts['prom_name']: opts for (k, opts) in
                        ode.get_io_metadata(iotypes=('output',), get_remote=True).items()}
         ode_shape = ode_outputs[var]['shape']
-        return ode_shape[0] != ode.options['num_nodes'], ode_shape
+        return ode_shape[0] != ode.options['num_nodes']

--- a/mkdocs/docs/faq/add_ode_output_to_timeseries.md
+++ b/mkdocs/docs/faq/add_ode_output_to_timeseries.md
@@ -5,13 +5,11 @@ By default, these timeseries outputs include Dymos phase variables (times, state
 Often, there will be some other intermediate or auxiliary output calculations in the ODE that we want to track over time.
 These can be added to the timeseries outputs using the `add_timeseries_output` method on Phase.
 
+Multiple timeseries outputs can be added at one time by matching a glob pattern.
+For instance, to add all outputs of the ODE to the timeseries, one can use '*' as the
 
-See the [Phase API docs](../api/phase_api.md) for more information.
+
+See the [Timeseries documentation](../features/phases/timeseries.md) for more information.
 
 
 The [commercial aircraft example](../examples/commercial_aircraft/commercial_aircraft.md) uses the `add_timeseries_output` method to add the lift and drag coefficients to the timeseries outputs.
-
-
-!!! info
-    Currently the user is required to specify the units and shape of the outputs being added in the `add_timeseries_output` method.
-    Future versions of OpenMDAO will allow us to infer this information automatically at setup time.

--- a/mkdocs/docs/features/phases/timeseries.md
+++ b/mkdocs/docs/features/phases/timeseries.md
@@ -26,9 +26,17 @@ By default, the timeseries output will include the following variables for every
 |``<phase path>.timeseries.polynomial_control_rates:<p>_rate2``|Second time derivative of polynomial control named u |
 |``<phase path>.timeseries.parameters:<d>``                    |Value of parameter named d                           |
 
+## Adding additional timeseries outputs
+
 In addition to these default values, any output of the ODE can be added to the timeseries output
 using the ``add_timeseries_output`` method on Phase.  These outputs are available as
-``<phase path>.timeseries.<output name>``.
+``<phase path>.timeseries.<output name>``.  A glob pattern can be used with ``add_timeseries_output``
+to add multiple outputs to the timeseries simultaneously.  For instance, just passing '*' as the variable
+name will add all dynamic outputs of the ODE to the timeseries.
+
+Dymos will ignore any ODE oututs that are not sized such that the first dimension is the same as the
+number of nodes in the ODE.  That is, if the output variable doesn't appear to be dynamic, it will not
+be included in the timeseries outputs.
 
 {{ api_doc('dymos.Phase.add_timeseries_output') }}
 


### PR DESCRIPTION
### Summary

If an ODE output is not sized with the number of nodes in its first dimension, it is no longer added to the timeseries output, even if specifically requested by the user.  Dymos now raises a warning when this happens.

### Related Issues

- Resolves #517

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
