### PR TITLE
removed unnecessary latex include

### DIFF
--- a/joss/paper.md
+++ b/joss/paper.md
@@ -24,8 +24,6 @@ affiliations:
     index: 2
 date: 26 June 2020
 bibliography: paper.bib
-header-includes:
-    - \usepackage{setspace}
 ---
 
 # Summary


### PR DESCRIPTION
### Summary

Removed unnecessary latex include from JOSS paper header that was preventing https://whedon.theoj.org/ from building the paper.

### Related Issues

None

### Status

- [ ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
