### PR TITLE
Add more benchmarks for performance testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -155,7 +155,7 @@ script:
 - export OMPI_MCA_rmaps_base_oversubscribe=1
 - testflo $dymos_path -n 1 --show_skipped --coverage --coverpkg dymos;
 - testflo -n 1 joss/test --pre_announce
-- testflo -b -n 1 benchmark --pre_announce
+- testflo -b benchmark --pre_announce
 # change to mkdocs path and build the documentation
 - cd mkdocs;
 - mkdocs build --verbose --clean

--- a/benchmark/benchmark_balanced_field.py
+++ b/benchmark/benchmark_balanced_field.py
@@ -1,0 +1,272 @@
+import unittest
+from openmdao.utils.testing_utils import use_tempdirs
+
+import openmdao.api as om
+from openmdao.utils.general_utils import set_pyoptsparse_opt
+from openmdao.utils.assert_utils import assert_near_equal
+import dymos as dm
+from dymos.examples.balanced_field.balanced_field_ode import BalancedFieldODEComp
+
+
+def _run_balanced_field_length_problem(tx=dm.GaussLobatto, timeseries=True, sim=True, solvesegs=False):
+    p = om.Problem()
+
+    _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
+
+    p.driver = om.pyOptSparseDriver()
+    p.driver.declare_coloring()
+
+    # Use IPOPT if available, with fallback to SLSQP
+    p.driver.options['optimizer'] = optimizer
+    p.driver.options['print_results'] = False
+    if optimizer == 'IPOPT':
+        p.driver.opt_settings['print_level'] = 5
+
+    # First Phase: Brake release to V1 - both engines operable
+    br_to_v1 = dm.Phase(ode_class=BalancedFieldODEComp,
+                        transcription=tx(num_segments=3, solve_segments=solvesegs),
+                        ode_init_kwargs={'mode': 'runway'})
+    br_to_v1.set_time_options(fix_initial=True, duration_bounds=(1, 1000), duration_ref=10.0)
+    br_to_v1.add_state('r', fix_initial=True, lower=0, ref=1000.0, defect_ref=1000.0)
+    br_to_v1.add_state('v', fix_initial=True, lower=0, ref=100.0, defect_ref=100.0)
+    br_to_v1.add_parameter('alpha', val=0.0, opt=False, units='deg')
+
+    if timeseries:
+        br_to_v1.add_timeseries_output('*')
+
+    # Second Phase: Rejected takeoff at V1 - no engines operable
+    rto = dm.Phase(ode_class=BalancedFieldODEComp,
+                   transcription=dm.Radau(num_segments=3, solve_segments=solvesegs),
+                   ode_init_kwargs={'mode': 'runway'})
+    rto.set_time_options(fix_initial=False, duration_bounds=(1, 1000), duration_ref=1.0)
+    rto.add_state('r', fix_initial=False, lower=0, ref=1000.0, defect_ref=1000.0)
+    rto.add_state('v', fix_initial=False, lower=0, ref=100.0, defect_ref=100.0)
+    rto.add_parameter('alpha', val=0.0, opt=False, units='deg')
+
+    if timeseries:
+        rto.add_timeseries_output('*')
+
+    # Third Phase: V1 to Vr - single engine operable
+    v1_to_vr = dm.Phase(ode_class=BalancedFieldODEComp,
+                        transcription=dm.Radau(num_segments=3, solve_segments=solvesegs),
+                        ode_init_kwargs={'mode': 'runway'})
+    v1_to_vr.set_time_options(fix_initial=False, duration_bounds=(1, 1000), duration_ref=1.0)
+    v1_to_vr.add_state('r', fix_initial=False, lower=0, ref=1000.0, defect_ref=1000.0)
+    v1_to_vr.add_state('v', fix_initial=False, lower=0, ref=100.0, defect_ref=100.0)
+    v1_to_vr.add_parameter('alpha', val=0.0, opt=False, units='deg')
+
+    if timeseries:
+        v1_to_vr.add_timeseries_output('*')
+
+    # Fourth Phase: Rotate - single engine operable
+    rotate = dm.Phase(ode_class=BalancedFieldODEComp,
+                      transcription=dm.Radau(num_segments=3, solve_segments=solvesegs),
+                      ode_init_kwargs={'mode': 'runway'})
+    rotate.set_time_options(fix_initial=False, duration_bounds=(1.0, 5), duration_ref=1.0)
+    rotate.add_state('r', fix_initial=False, lower=0, ref=1000.0, defect_ref=1000.0)
+    rotate.add_state('v', fix_initial=False, lower=0, ref=100.0, defect_ref=100.0)
+    rotate.add_polynomial_control('alpha', order=1, opt=True, units='deg', lower=0, upper=10,
+                                  ref=10, val=[0, 10])
+
+    if timeseries:
+        rotate.add_timeseries_output('*')
+
+    # Fifth Phase: Climb to target speed and altitude at end of runway.
+    climb = dm.Phase(ode_class=BalancedFieldODEComp, transcription=dm.Radau(num_segments=5),
+                     ode_init_kwargs={'mode': 'climb'})
+    climb.set_time_options(fix_initial=False, duration_bounds=(1, 100), duration_ref=1.0)
+    climb.add_state('r', fix_initial=False, lower=0, ref=1000.0, defect_ref=1000.0)
+    climb.add_state('h', fix_initial=True, lower=0, ref=1.0, defect_ref=1.0)
+    climb.add_state('v', fix_initial=False, lower=0, ref=100.0, defect_ref=100.0)
+    climb.add_state('gam', fix_initial=True, lower=0, ref=0.05, defect_ref=0.05)
+    climb.add_control('alpha', opt=True, units='deg', lower=-10, upper=15, ref=10)
+
+    if timeseries:
+        climb.add_timeseries_output('*')
+
+    # Instantiate the trajectory and add phases
+    traj = dm.Trajectory()
+    p.model.add_subsystem('traj', traj)
+    traj.add_phase('br_to_v1', br_to_v1)
+    traj.add_phase('rto', rto)
+    traj.add_phase('v1_to_vr', v1_to_vr)
+    traj.add_phase('rotate', rotate)
+    traj.add_phase('climb', climb)
+
+    # Add parameters common to multiple phases to the trajectory
+    traj.add_parameter('m', val=174200., opt=False, units='lbm',
+                       desc='aircraft mass',
+                       targets={'br_to_v1': ['m'], 'v1_to_vr': ['m'], 'rto': ['m'],
+                                'rotate': ['m'], 'climb': ['m']})
+
+    traj.add_parameter('T_nominal', val=27000 * 2, opt=False, units='lbf', dynamic=False,
+                       desc='nominal aircraft thrust',
+                       targets={'br_to_v1': ['T']})
+
+    traj.add_parameter('T_engine_out', val=27000, opt=False, units='lbf', dynamic=False,
+                       desc='thrust under a single engine',
+                       targets={'v1_to_vr': ['T'], 'rotate': ['T'], 'climb': ['T']})
+
+    traj.add_parameter('T_shutdown', val=0.0, opt=False, units='lbf', dynamic=False,
+                       desc='thrust when engines are shut down for rejected takeoff',
+                       targets={'rto': ['T']})
+
+    traj.add_parameter('mu_r_nominal', val=0.03, opt=False, units=None, dynamic=False,
+                       desc='nominal runway friction coefficient',
+                       targets={'br_to_v1': ['mu_r'], 'v1_to_vr': ['mu_r'], 'rotate': ['mu_r']})
+
+    traj.add_parameter('mu_r_braking', val=0.3, opt=False, units=None, dynamic=False,
+                       desc='runway friction coefficient under braking',
+                       targets={'rto': ['mu_r']})
+
+    traj.add_parameter('h_runway', val=0., opt=False, units='ft',
+                       desc='runway altitude',
+                       targets={'br_to_v1': ['h'], 'v1_to_vr': ['h'], 'rto': ['h'],
+                                'rotate': ['h']})
+
+    traj.add_parameter('rho', val=1.225, opt=False, units='kg/m**3', dynamic=False,
+                       desc='atmospheric density',
+                       targets={'br_to_v1': ['rho'], 'v1_to_vr': ['rho'], 'rto': ['rho'],
+                                'rotate': ['rho']})
+
+    traj.add_parameter('S', val=124.7, opt=False, units='m**2', dynamic=False,
+                       desc='aerodynamic reference area',
+                       targets={'br_to_v1': ['S'], 'v1_to_vr': ['S'], 'rto': ['S'],
+                                'rotate': ['S'], 'climb': ['S']})
+
+    traj.add_parameter('CD0', val=0.03, opt=False, units=None, dynamic=False,
+                       desc='zero-lift drag coefficient',
+                       targets={f'{phase}': ['CD0'] for phase in ['br_to_v1', 'v1_to_vr',
+                                                                  'rto', 'rotate' 'climb']})
+
+    traj.add_parameter('AR', val=9.45, opt=False, units=None, dynamic=False,
+                       desc='wing aspect ratio',
+                       targets={f'{phase}': ['AR'] for phase in ['br_to_v1', 'v1_to_vr',
+                                                                 'rto', 'rotate' 'climb']})
+
+    traj.add_parameter('e', val=801, opt=False, units=None, dynamic=False,
+                       desc='Oswald span efficiency factor',
+                       targets={f'{phase}': ['e'] for phase in ['br_to_v1', 'v1_to_vr',
+                                                                'rto', 'rotate' 'climb']})
+
+    traj.add_parameter('span', val=35.7, opt=False, units='m', dynamic=False,
+                       desc='wingspan',
+                       targets={f'{phase}': ['span'] for phase in ['br_to_v1', 'v1_to_vr',
+                                                                   'rto', 'rotate' 'climb']})
+
+    traj.add_parameter('h_w', val=1.0, opt=False, units='m', dynamic=False,
+                       desc='height of wing above CG',
+                       targets={f'{phase}': ['h_w'] for phase in ['br_to_v1', 'v1_to_vr',
+                                                                  'rto', 'rotate' 'climb']})
+
+    traj.add_parameter('CL0', val=0.5, opt=False, units=None, dynamic=False,
+                       desc='zero-alpha lift coefficient',
+                       targets={f'{phase}': ['CL0'] for phase in ['br_to_v1', 'v1_to_vr',
+                                                                  'rto', 'rotate' 'climb']})
+
+    traj.add_parameter('CL_max', val=2.0, opt=False, units=None, dynamic=False,
+                       desc='maximum lift coefficient for linear fit',
+                       targets={f'{phase}': ['CL_max'] for phase in ['br_to_v1', 'v1_to_vr',
+                                                                     'rto', 'rotate' 'climb']})
+
+    traj.add_parameter('alpha_max', val=10.0, opt=False, units='deg', dynamic=False,
+                       desc='angle of attack at maximum lift',
+                       targets={f'{phase}': ['alpha_max'] for phase in ['br_to_v1', 'v1_to_vr',
+                                                                        'rto', 'rotate' 'climb']})
+
+    # Standard "end of first phase to beginning of second phase" linkages
+    # Alpha changes from being a parameter in v1_to_vr to a polynomial control
+    # in rotate, to a dynamic control in `climb`.
+    traj.link_phases(['br_to_v1', 'v1_to_vr'], vars=['time', 'r', 'v'])
+    traj.link_phases(['v1_to_vr', 'rotate'], vars=['time', 'r', 'v', 'alpha'])
+    traj.link_phases(['rotate', 'climb'], vars=['time', 'r', 'v', 'alpha'])
+    traj.link_phases(['br_to_v1', 'rto'], vars=['time', 'r', 'v'])
+
+    # Less common "final value of r must be the match at ends of two phases".
+    traj.add_linkage_constraint(phase_a='rto', var_a='r', loc_a='final',
+                                phase_b='climb', var_b='r', loc_b='final',
+                                ref=1000)
+
+    # Define the constraints and objective for the optimal control problem
+    v1_to_vr.add_boundary_constraint('v_over_v_stall', loc='final', lower=1.2, ref=100)
+
+    rto.add_boundary_constraint('v', loc='final', equals=0., ref=100, linear=True)
+
+    rotate.add_boundary_constraint('F_r', loc='final', equals=0, ref=100000)
+
+    climb.add_boundary_constraint('h', loc='final', equals=35, ref=35, units='ft', linear=True)
+    climb.add_boundary_constraint('gam', loc='final', equals=5, ref=5, units='deg', linear=True)
+    climb.add_path_constraint('gam', lower=0, upper=5, ref=5, units='deg')
+    climb.add_boundary_constraint('v_over_v_stall', loc='final', lower=1.25, ref=1.25)
+
+    rto.add_objective('r', loc='final', ref=1000.0)
+
+    #
+    # Setup the problem and set the initial guess
+    #
+    p.setup(check=True)
+
+    p.set_val('traj.br_to_v1.t_initial', 0)
+    p.set_val('traj.br_to_v1.t_duration', 35)
+    p.set_val('traj.br_to_v1.states:r', br_to_v1.interpolate(ys=[0, 2500.0], nodes='state_input'))
+    p.set_val('traj.br_to_v1.states:v', br_to_v1.interpolate(ys=[0, 100.0], nodes='state_input'))
+    p.set_val('traj.br_to_v1.parameters:alpha', 0, units='deg')
+
+    p.set_val('traj.v1_to_vr.t_initial', 35)
+    p.set_val('traj.v1_to_vr.t_duration', 35)
+    p.set_val('traj.v1_to_vr.states:r', v1_to_vr.interpolate(ys=[2500, 300.0], nodes='state_input'))
+    p.set_val('traj.v1_to_vr.states:v', v1_to_vr.interpolate(ys=[100, 110.0], nodes='state_input'))
+    p.set_val('traj.v1_to_vr.parameters:alpha', 0.0, units='deg')
+
+    p.set_val('traj.rto.t_initial', 35)
+    p.set_val('traj.rto.t_duration', 35)
+    p.set_val('traj.rto.states:r', rto.interpolate(ys=[2500, 5000.0], nodes='state_input'))
+    p.set_val('traj.rto.states:v', rto.interpolate(ys=[110, 0], nodes='state_input'))
+    p.set_val('traj.rto.parameters:alpha', 0.0, units='deg')
+
+    p.set_val('traj.rotate.t_initial', 70)
+    p.set_val('traj.rotate.t_duration', 5)
+    p.set_val('traj.rotate.states:r', rotate.interpolate(ys=[1750, 1800.0], nodes='state_input'))
+    p.set_val('traj.rotate.states:v', rotate.interpolate(ys=[80, 85.0], nodes='state_input'))
+    p.set_val('traj.rotate.polynomial_controls:alpha', 0.0, units='deg')
+
+    p.set_val('traj.climb.t_initial', 75)
+    p.set_val('traj.climb.t_duration', 15)
+    p.set_val('traj.climb.states:r', climb.interpolate(ys=[5000, 5500.0], nodes='state_input'),
+              units='ft')
+    p.set_val('traj.climb.states:v', climb.interpolate(ys=[160, 170.0], nodes='state_input'),
+              units='kn')
+    p.set_val('traj.climb.states:h', climb.interpolate(ys=[0, 35.0], nodes='state_input'),
+              units='ft')
+    p.set_val('traj.climb.states:gam', climb.interpolate(ys=[0, 5.0], nodes='state_input'),
+              units='deg')
+    p.set_val('traj.climb.controls:alpha', 5.0, units='deg')
+
+    dm.run_problem(p, run_driver=True, simulate=sim)
+
+    # Test this example in Dymos' continuous integration
+    assert_near_equal(p.get_val('traj.rto.states:r')[-1], 2188.2, tolerance=0.01)
+
+
+@use_tempdirs
+class BenchmarkBalancedFieldLength(unittest.TestCase):
+
+    def benchmark_gausslobatto_notimeseries_nosim_nosolveseg(self):
+        _run_balanced_field_length_problem(tx=dm.GaussLobatto, timeseries=False, sim=False,
+                                           solvesegs=False)
+
+    def benchmark_gausslobatto_notimeseries_sim_nosolveseg(self):
+        _run_balanced_field_length_problem(tx=dm.GaussLobatto, timeseries=False, sim=True,
+                                           solvesegs=False)
+
+    def benchmark_gausslobatto_timeseries_nosim_nosolveseg(self):
+        _run_balanced_field_length_problem(tx=dm.GaussLobatto, timeseries=True, sim=False,
+                                           solvesegs=False)
+
+    def benchmark_radau_timeseries_nosim_nosolveseg(self):
+            _run_balanced_field_length_problem(tx=dm.Radau, timeseries=True, sim=False,
+                                               solvesegs=False)
+
+    def benchmark_radau_notimeseries_nosim_solveseg(self):
+        _run_balanced_field_length_problem(tx=dm.Radau, timeseries=False, sim=False,
+                                           solvesegs='forward')

--- a/benchmark/benchmark_brachistochrone.py
+++ b/benchmark/benchmark_brachistochrone.py
@@ -4,6 +4,7 @@ import unittest
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import set_pyoptsparse_opt
+from openmdao.utils.testing_utils import use_tempdirs
 import dymos as dm
 from dymos.examples.brachistochrone import BrachistochroneODE
 
@@ -72,6 +73,7 @@ def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, tran
     return p
 
 
+@use_tempdirs
 class BenchmarkBrachistochrone(unittest.TestCase):
     """ Benchmarks for various permutations of the brachistochrone problem."""
 

--- a/benchmark/benchmark_racecar.py
+++ b/benchmark/benchmark_racecar.py
@@ -11,656 +11,181 @@ from dymos.examples.racecar.spline import get_spline, get_track_points
 from dymos.examples.racecar.tracks import ovaltrack  # track curvature imports
 
 
+def _run_racecar_problem(transcription, timeseries=False):
+    # change track here and in curvature.py. Tracks are defined in tracks.py
+    track = ovaltrack
+
+    # generate nodes along the centerline for curvature calculation (different
+    # than collocation nodes)
+    points = get_track_points(track)
+
+    # fit the centerline spline.
+    finespline, gates, gatesd, curv, slope = get_spline(points, s=0.0)
+    # by default 10000 points
+    s_final = track.get_total_length()
+
+    # Define the OpenMDAO problem
+    p = om.Problem(model=om.Group())
+
+    # Define a Trajectory object
+    traj = dm.Trajectory()
+    p.model.add_subsystem('traj', subsys=traj)
+
+    # Define a Dymos Phase object with radau Transcription
+    phase = dm.Phase(ode_class=CombinedODE,
+                     transcription=transcription(num_segments=50, order=3, compressed=True))
+
+    traj.add_phase(name='phase0', phase=phase)
+
+    # Set the time options, in this problem we perform a change of variables. So 'time' is
+    # actually 's' (distance along the track centerline)
+    # This is done to fix the collocation nodes in space, which saves us the calculation of
+    # the rate of change of curvature.
+    # The state equations are written with respect to time, the variable change occurs in
+    # timeODE.py
+    phase.set_time_options(fix_initial=True, fix_duration=True, duration_val=s_final,
+                           targets=['curv.s'], units='m', duration_ref=s_final,
+                           duration_ref0=10)
+
+    # Define states
+    phase.add_state('t', fix_initial=True, fix_final=False, units='s', lower=0,
+                    rate_source='dt_ds', ref=100)  # time
+    phase.add_state('n', fix_initial=False, fix_final=False, units='m', upper=4.0, lower=-4.0,
+                    rate_source='dn_ds', targets=['n'],
+                    ref=4.0)  # normal distance to centerline. The bounds on n define the
+    # width of the track
+    phase.add_state('V', fix_initial=False, fix_final=False, units='m/s', ref=40, ref0=5,
+                    rate_source='dV_ds', targets=['V'])  # velocity
+    phase.add_state('alpha', fix_initial=False, fix_final=False, units='rad',
+                    rate_source='dalpha_ds', targets=['alpha'],
+                    ref=0.15)  # vehicle heading angle with respect to centerline
+    phase.add_state('lambda', fix_initial=False, fix_final=False, units='rad',
+                    rate_source='dlambda_ds', targets=['lambda'],
+                    ref=0.01)  # vehicle slip angle, or angle between the axis of the vehicle
+    # and velocity vector (all cars drift a little)
+    phase.add_state('omega', fix_initial=False, fix_final=False, units='rad/s',
+                    rate_source='domega_ds', targets=['omega'], ref=0.3)  # yaw rate
+    phase.add_state('ax', fix_initial=False, fix_final=False, units='m/s**2',
+                    rate_source='dax_ds', targets=['ax'], ref=8)  # longitudinal acceleration
+    phase.add_state('ay', fix_initial=False, fix_final=False, units='m/s**2',
+                    rate_source='day_ds', targets=['ay'], ref=8)  # lateral acceleration
+
+    # Define Controls
+    phase.add_control(name='delta', units='rad', lower=None, upper=None, fix_initial=False,
+                      fix_final=False, targets=['delta'], ref=0.04)  # steering angle
+    phase.add_control(name='thrust', units=None, fix_initial=False, fix_final=False, targets=[
+        'thrust'])  # the thrust controls the longitudinal force of the rear tires and is
+    # positive while accelerating, negative while braking
+
+    # Performance Constraints
+    pmax = 960000  # W
+    phase.add_path_constraint('power', upper=pmax, ref=100000)  # engine power limit
+
+    # The following four constraints are the tire friction limits, with 'rr' designating the
+    # rear right wheel etc. This limit is computed in tireConstraintODE.py
+    phase.add_path_constraint('c_rr', upper=1)
+    phase.add_path_constraint('c_rl', upper=1)
+    phase.add_path_constraint('c_fr', upper=1)
+    phase.add_path_constraint('c_fl', upper=1)
+
+    # Some of the vehicle design parameters are available to set here. Other parameters can
+    # be found in their respective ODE files.
+    phase.add_parameter('M', val=800.0, units='kg', opt=False,
+                        targets=['car.M', 'tire.M', 'tireconstraint.M', 'normal.M'],
+                        dynamic=False)  # vehicle mass
+    phase.add_parameter('beta', val=0.62, units=None, opt=False, targets=['tire.beta'],
+                        dynamic=False)  # brake bias
+    phase.add_parameter('CoP', val=1.6, units='m', opt=False, targets=['normal.CoP'],
+                        dynamic=False)  # center of pressure location
+    phase.add_parameter('h', val=0.3, units='m', opt=False, targets=['normal.h'],
+                        dynamic=False)  # center of gravity height
+    phase.add_parameter('chi', val=0.5, units=None, opt=False, targets=['normal.chi'],
+                        dynamic=False)  # roll stiffness
+    phase.add_parameter('ClA', val=4.0, units='m**2', opt=False, targets=['normal.ClA'],
+                        dynamic=False)  # downforce coefficient*area
+    phase.add_parameter('CdA', val=2.0, units='m**2', opt=False, targets=['car.CdA'],
+                        dynamic=False)  # drag coefficient*area
+
+    # Minimize final time.
+    # note that we use the 'state' time instead of Dymos 'time'
+    phase.add_objective('t', loc='final')
+
+    # Add output timeseries
+    if timeseries:
+        phase.add_timeseries_output('*')
+
+    # Link the states at the start and end of the phase in order to ensure a continous lap
+    traj.link_phases(phases=['phase0', 'phase0'],
+                     vars=['V', 'n', 'alpha', 'omega', 'lambda', 'ax', 'ay'],
+                     locs=('final', 'initial'))
+
+    # Set the driver. IPOPT or SNOPT are recommended but SLSQP might work.
+    p.driver = om.pyOptSparseDriver(optimizer='IPOPT')
+
+    p.driver.opt_settings['mu_init'] = 1e-3
+    p.driver.opt_settings['max_iter'] = 500
+    p.driver.opt_settings['acceptable_tol'] = 1e-3
+    p.driver.opt_settings['constr_viol_tol'] = 1e-3
+    p.driver.opt_settings['compl_inf_tol'] = 1e-3
+    p.driver.opt_settings['acceptable_iter'] = 0
+    p.driver.opt_settings['tol'] = 1e-3
+    p.driver.opt_settings['nlp_scaling_method'] = 'none'
+    p.driver.opt_settings['print_level'] = 5
+    p.driver.opt_settings['nlp_scaling_method'] = 'gradient-based'  # for faster convergence
+
+    # Allow OpenMDAO to automatically determine our sparsity pattern.
+    # Doing so can significant speed up the execution of Dymos.
+    p.driver.declare_coloring()
+
+    # Setup the problem
+    p.setup(check=True)  # force_alloc_complex=True
+    # Now that the OpenMDAO problem is setup, we can set the values of the states.
+
+    # States
+    p.set_val('traj.phase0.states:V', phase.interpolate(ys=[20, 20], nodes='state_input'),
+              units='m/s')  # non-zero velocity in order to protect against 1/0 errors.
+    p.set_val('traj.phase0.states:lambda',
+              phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+              units='rad')  # all other states start at 0
+    p.set_val('traj.phase0.states:omega', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+              units='rad/s')
+    p.set_val('traj.phase0.states:alpha', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+              units='rad')
+    p.set_val('traj.phase0.states:ax', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+              units='m/s**2')
+    p.set_val('traj.phase0.states:ay', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+              units='m/s**2')
+    p.set_val('traj.phase0.states:n', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+              units='m')
+    p.set_val('traj.phase0.states:t', phase.interpolate(ys=[0.0, 100.0], nodes='state_input'),
+              units='s')  # initial guess for what the final time should be
+
+    # Controls
+    p.set_val('traj.phase0.controls:delta',
+              phase.interpolate(ys=[0.0, 0.0], nodes='control_input'), units='rad')
+    p.set_val('traj.phase0.controls:thrust',
+              phase.interpolate(ys=[0.1, 0.1], nodes='control_input'),
+              units=None)  # a small amount of thrust can speed up convergence
+
+    dm.run_problem(p, run_driver=True, simulate=False, make_plots=False)
+    print('Optimization finished')
+
+    t = p.get_val('traj.phase0.timeseries.states:t')
+    assert_near_equal(t[-1], 22.2657, tolerance=0.01)
+
+
 @use_tempdirs
 class BenchmarkRacecar(unittest.TestCase):
     """ Benchmarks for various permutations of the racecar problem."""
 
     def benchmark_gausslobatto_notimeseries(self):
-
-        # change track here and in curvature.py. Tracks are defined in tracks.py
-        track = ovaltrack
-
-        # generate nodes along the centerline for curvature calculation (different
-        # than collocation nodes)
-        points = get_track_points(track)
-
-        # fit the centerline spline.
-        finespline, gates, gatesd, curv, slope = get_spline(points, s=0.0)
-        # by default 10000 points
-        s_final = track.get_total_length()
-
-        # Define the OpenMDAO problem
-        p = om.Problem(model=om.Group())
-
-        # Define a Trajectory object
-        traj = dm.Trajectory()
-        p.model.add_subsystem('traj', subsys=traj)
-
-        # Define a Dymos Phase object with GaussLobatto Transcription
-        phase = dm.Phase(ode_class=CombinedODE,
-                         transcription=dm.GaussLobatto(num_segments=50, order=3, compressed=True))
-
-        traj.add_phase(name='phase0', phase=phase)
-
-        # Set the time options, in this problem we perform a change of variables. So 'time' is
-        # actually 's' (distance along the track centerline)
-        # This is done to fix the collocation nodes in space, which saves us the calculation of
-        # the rate of change of curvature.
-        # The state equations are written with respect to time, the variable change occurs in
-        # timeODE.py
-        phase.set_time_options(fix_initial=True, fix_duration=True, duration_val=s_final,
-                               targets=['curv.s'], units='m', duration_ref=s_final,
-                               duration_ref0=10)
-
-        # Define states
-        phase.add_state('t', fix_initial=True, fix_final=False, units='s', lower=0,
-                        rate_source='dt_ds', ref=100)  # time
-        phase.add_state('n', fix_initial=False, fix_final=False, units='m', upper=4.0, lower=-4.0,
-                        rate_source='dn_ds', targets=['n'],
-                        ref=4.0)  # normal distance to centerline. The bounds on n define the
-        # width of the track
-        phase.add_state('V', fix_initial=False, fix_final=False, units='m/s', ref=40, ref0=5,
-                        rate_source='dV_ds', targets=['V'])  # velocity
-        phase.add_state('alpha', fix_initial=False, fix_final=False, units='rad',
-                        rate_source='dalpha_ds', targets=['alpha'],
-                        ref=0.15)  # vehicle heading angle with respect to centerline
-        phase.add_state('lambda', fix_initial=False, fix_final=False, units='rad',
-                        rate_source='dlambda_ds', targets=['lambda'],
-                        ref=0.01)  # vehicle slip angle, or angle between the axis of the vehicle
-        # and velocity vector (all cars drift a little)
-        phase.add_state('omega', fix_initial=False, fix_final=False, units='rad/s',
-                        rate_source='domega_ds', targets=['omega'], ref=0.3)  # yaw rate
-        phase.add_state('ax', fix_initial=False, fix_final=False, units='m/s**2',
-                        rate_source='dax_ds', targets=['ax'], ref=8)  # longitudinal acceleration
-        phase.add_state('ay', fix_initial=False, fix_final=False, units='m/s**2',
-                        rate_source='day_ds', targets=['ay'], ref=8)  # lateral acceleration
-
-        # Define Controls
-        phase.add_control(name='delta', units='rad', lower=None, upper=None, fix_initial=False,
-                          fix_final=False, targets=['delta'], ref=0.04)  # steering angle
-        phase.add_control(name='thrust', units=None, fix_initial=False, fix_final=False, targets=[
-            'thrust'])  # the thrust controls the longitudinal force of the rear tires and is
-        # positive while accelerating, negative while braking
-
-        # Performance Constraints
-        pmax = 960000  # W
-        phase.add_path_constraint('power', upper=pmax, ref=100000)  # engine power limit
-
-        # The following four constraints are the tire friction limits, with 'rr' designating the
-        # rear right wheel etc. This limit is computed in tireConstraintODE.py
-        phase.add_path_constraint('c_rr', upper=1)
-        phase.add_path_constraint('c_rl', upper=1)
-        phase.add_path_constraint('c_fr', upper=1)
-        phase.add_path_constraint('c_fl', upper=1)
-
-        # Some of the vehicle design parameters are available to set here. Other parameters can
-        # be found in their respective ODE files.
-        phase.add_parameter('M', val=800.0, units='kg', opt=False,
-                            targets=['car.M', 'tire.M', 'tireconstraint.M', 'normal.M'],
-                            dynamic=False)  # vehicle mass
-        phase.add_parameter('beta', val=0.62, units=None, opt=False, targets=['tire.beta'],
-                            dynamic=False)  # brake bias
-        phase.add_parameter('CoP', val=1.6, units='m', opt=False, targets=['normal.CoP'],
-                            dynamic=False)  # center of pressure location
-        phase.add_parameter('h', val=0.3, units='m', opt=False, targets=['normal.h'],
-                            dynamic=False)  # center of gravity height
-        phase.add_parameter('chi', val=0.5, units=None, opt=False, targets=['normal.chi'],
-                            dynamic=False)  # roll stiffness
-        phase.add_parameter('ClA', val=4.0, units='m**2', opt=False, targets=['normal.ClA'],
-                            dynamic=False)  # downforce coefficient*area
-        phase.add_parameter('CdA', val=2.0, units='m**2', opt=False, targets=['car.CdA'],
-                            dynamic=False)  # drag coefficient*area
-
-        # Minimize final time.
-        # note that we use the 'state' time instead of Dymos 'time'
-        phase.add_objective('t', loc='final')
-
-        # Add output timeseries
-        # phase.add_timeseries_output('*')
-
-        # Link the states at the start and end of the phase in order to ensure a continous lap
-        traj.link_phases(phases=['phase0', 'phase0'],
-                         vars=['V', 'n', 'alpha', 'omega', 'lambda', 'ax', 'ay'],
-                         locs=('final', 'initial'))
-
-        # Set the driver. IPOPT or SNOPT are recommended but SLSQP might work.
-        p.driver = om.pyOptSparseDriver(optimizer='IPOPT')
-
-        p.driver.opt_settings['mu_init'] = 1e-3
-        p.driver.opt_settings['max_iter'] = 500
-        p.driver.opt_settings['acceptable_tol'] = 1e-3
-        p.driver.opt_settings['constr_viol_tol'] = 1e-3
-        p.driver.opt_settings['compl_inf_tol'] = 1e-3
-        p.driver.opt_settings['acceptable_iter'] = 0
-        p.driver.opt_settings['tol'] = 1e-3
-        p.driver.opt_settings['nlp_scaling_method'] = 'none'
-        p.driver.opt_settings['print_level'] = 5
-        p.driver.opt_settings['nlp_scaling_method'] = 'gradient-based'  # for faster convergence
-
-        # Allow OpenMDAO to automatically determine our sparsity pattern.
-        # Doing so can significant speed up the execution of Dymos.
-        p.driver.declare_coloring()
-
-        # Setup the problem
-        p.setup(check=True)  # force_alloc_complex=True
-        # Now that the OpenMDAO problem is setup, we can set the values of the states.
-
-        # States
-        p.set_val('traj.phase0.states:V', phase.interpolate(ys=[20, 20], nodes='state_input'),
-                  units='m/s')  # non-zero velocity in order to protect against 1/0 errors.
-        p.set_val('traj.phase0.states:lambda',
-                  phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='rad')  # all other states start at 0
-        p.set_val('traj.phase0.states:omega', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='rad/s')
-        p.set_val('traj.phase0.states:alpha', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='rad')
-        p.set_val('traj.phase0.states:ax', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='m/s**2')
-        p.set_val('traj.phase0.states:ay', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='m/s**2')
-        p.set_val('traj.phase0.states:n', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='m')
-        p.set_val('traj.phase0.states:t', phase.interpolate(ys=[0.0, 100.0], nodes='state_input'),
-                  units='s')  # initial guess for what the final time should be
-
-        # Controls
-        p.set_val('traj.phase0.controls:delta',
-                  phase.interpolate(ys=[0.0, 0.0], nodes='control_input'), units='rad')
-        p.set_val('traj.phase0.controls:thrust',
-                  phase.interpolate(ys=[0.1, 0.1], nodes='control_input'),
-                  units=None)  # a small amount of thrust can speed up convergence
-
-        dm.run_problem(p, run_driver=True, simulate=False, make_plots=False)
-        print('Optimization finished')
-
-        t = p.get_val('traj.phase0.timeseries.states:t')
-        assert_near_equal(t[-1], 22.2657, tolerance=0.01)
-
+        _run_racecar_problem(dm.GaussLobatto, timeseres=False)
 
     def benchmark_gausslobatto_timeseries(self):
-
-        # change track here and in curvature.py. Tracks are defined in tracks.py
-        track = ovaltrack
-
-        # generate nodes along the centerline for curvature calculation (different
-        # than collocation nodes)
-        points = get_track_points(track)
-
-        # fit the centerline spline.
-        finespline, gates, gatesd, curv, slope = get_spline(points, s=0.0)
-        # by default 10000 points
-        s_final = track.get_total_length()
-
-        # Define the OpenMDAO problem
-        p = om.Problem(model=om.Group())
-
-        # Define a Trajectory object
-        traj = dm.Trajectory()
-        p.model.add_subsystem('traj', subsys=traj)
-
-        # Define a Dymos Phase object with GaussLobatto Transcription
-        phase = dm.Phase(ode_class=CombinedODE,
-                         transcription=dm.GaussLobatto(num_segments=50, order=3, compressed=True))
-
-        traj.add_phase(name='phase0', phase=phase)
-
-        # Set the time options, in this problem we perform a change of variables. So 'time' is
-        # actually 's' (distance along the track centerline)
-        # This is done to fix the collocation nodes in space, which saves us the calculation of
-        # the rate of change of curvature.
-        # The state equations are written with respect to time, the variable change occurs in
-        # timeODE.py
-        phase.set_time_options(fix_initial=True, fix_duration=True, duration_val=s_final,
-                               targets=['curv.s'], units='m', duration_ref=s_final,
-                               duration_ref0=10)
-
-        # Define states
-        phase.add_state('t', fix_initial=True, fix_final=False, units='s', lower=0,
-                        rate_source='dt_ds', ref=100)  # time
-        phase.add_state('n', fix_initial=False, fix_final=False, units='m', upper=4.0, lower=-4.0,
-                        rate_source='dn_ds', targets=['n'],
-                        ref=4.0)  # normal distance to centerline. The bounds on n define the
-        # width of the track
-        phase.add_state('V', fix_initial=False, fix_final=False, units='m/s', ref=40, ref0=5,
-                        rate_source='dV_ds', targets=['V'])  # velocity
-        phase.add_state('alpha', fix_initial=False, fix_final=False, units='rad',
-                        rate_source='dalpha_ds', targets=['alpha'],
-                        ref=0.15)  # vehicle heading angle with respect to centerline
-        phase.add_state('lambda', fix_initial=False, fix_final=False, units='rad',
-                        rate_source='dlambda_ds', targets=['lambda'],
-                        ref=0.01)  # vehicle slip angle, or angle between the axis of the vehicle
-        # and velocity vector (all cars drift a little)
-        phase.add_state('omega', fix_initial=False, fix_final=False, units='rad/s',
-                        rate_source='domega_ds', targets=['omega'], ref=0.3)  # yaw rate
-        phase.add_state('ax', fix_initial=False, fix_final=False, units='m/s**2',
-                        rate_source='dax_ds', targets=['ax'], ref=8)  # longitudinal acceleration
-        phase.add_state('ay', fix_initial=False, fix_final=False, units='m/s**2',
-                        rate_source='day_ds', targets=['ay'], ref=8)  # lateral acceleration
-
-        # Define Controls
-        phase.add_control(name='delta', units='rad', lower=None, upper=None, fix_initial=False,
-                          fix_final=False, targets=['delta'], ref=0.04)  # steering angle
-        phase.add_control(name='thrust', units=None, fix_initial=False, fix_final=False, targets=[
-            'thrust'])  # the thrust controls the longitudinal force of the rear tires and is
-        # positive while accelerating, negative while braking
-
-        # Performance Constraints
-        pmax = 960000  # W
-        phase.add_path_constraint('power', upper=pmax, ref=100000)  # engine power limit
-
-        # The following four constraints are the tire friction limits, with 'rr' designating the
-        # rear right wheel etc. This limit is computed in tireConstraintODE.py
-        phase.add_path_constraint('c_rr', upper=1)
-        phase.add_path_constraint('c_rl', upper=1)
-        phase.add_path_constraint('c_fr', upper=1)
-        phase.add_path_constraint('c_fl', upper=1)
-
-        # Some of the vehicle design parameters are available to set here. Other parameters can
-        # be found in their respective ODE files.
-        phase.add_parameter('M', val=800.0, units='kg', opt=False,
-                            targets=['car.M', 'tire.M', 'tireconstraint.M', 'normal.M'],
-                            dynamic=False)  # vehicle mass
-        phase.add_parameter('beta', val=0.62, units=None, opt=False, targets=['tire.beta'],
-                            dynamic=False)  # brake bias
-        phase.add_parameter('CoP', val=1.6, units='m', opt=False, targets=['normal.CoP'],
-                            dynamic=False)  # center of pressure location
-        phase.add_parameter('h', val=0.3, units='m', opt=False, targets=['normal.h'],
-                            dynamic=False)  # center of gravity height
-        phase.add_parameter('chi', val=0.5, units=None, opt=False, targets=['normal.chi'],
-                            dynamic=False)  # roll stiffness
-        phase.add_parameter('ClA', val=4.0, units='m**2', opt=False, targets=['normal.ClA'],
-                            dynamic=False)  # downforce coefficient*area
-        phase.add_parameter('CdA', val=2.0, units='m**2', opt=False, targets=['car.CdA'],
-                            dynamic=False)  # drag coefficient*area
-
-        # Minimize final time.
-        # note that we use the 'state' time instead of Dymos 'time'
-        phase.add_objective('t', loc='final')
-
-        # Add output timeseries
-        phase.add_timeseries_output('*')
-
-        # Link the states at the start and end of the phase in order to ensure a continous lap
-        traj.link_phases(phases=['phase0', 'phase0'],
-                         vars=['V', 'n', 'alpha', 'omega', 'lambda', 'ax', 'ay'],
-                         locs=('final', 'initial'))
-
-        # Set the driver. IPOPT or SNOPT are recommended but SLSQP might work.
-        p.driver = om.pyOptSparseDriver(optimizer='IPOPT')
-
-        p.driver.opt_settings['mu_init'] = 1e-3
-        p.driver.opt_settings['max_iter'] = 500
-        p.driver.opt_settings['acceptable_tol'] = 1e-3
-        p.driver.opt_settings['constr_viol_tol'] = 1e-3
-        p.driver.opt_settings['compl_inf_tol'] = 1e-3
-        p.driver.opt_settings['acceptable_iter'] = 0
-        p.driver.opt_settings['tol'] = 1e-3
-        p.driver.opt_settings['nlp_scaling_method'] = 'none'
-        p.driver.opt_settings['print_level'] = 5
-        p.driver.opt_settings['nlp_scaling_method'] = 'gradient-based'  # for faster convergence
-
-        # Allow OpenMDAO to automatically determine our sparsity pattern.
-        # Doing so can significant speed up the execution of Dymos.
-        p.driver.declare_coloring()
-
-        # Setup the problem
-        p.setup(check=True)  # force_alloc_complex=True
-        # Now that the OpenMDAO problem is setup, we can set the values of the states.
-
-        # States
-        p.set_val('traj.phase0.states:V', phase.interpolate(ys=[20, 20], nodes='state_input'),
-                  units='m/s')  # non-zero velocity in order to protect against 1/0 errors.
-        p.set_val('traj.phase0.states:lambda',
-                  phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='rad')  # all other states start at 0
-        p.set_val('traj.phase0.states:omega', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='rad/s')
-        p.set_val('traj.phase0.states:alpha', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='rad')
-        p.set_val('traj.phase0.states:ax', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='m/s**2')
-        p.set_val('traj.phase0.states:ay', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='m/s**2')
-        p.set_val('traj.phase0.states:n', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='m')
-        p.set_val('traj.phase0.states:t', phase.interpolate(ys=[0.0, 100.0], nodes='state_input'),
-                  units='s')  # initial guess for what the final time should be
-
-        # Controls
-        p.set_val('traj.phase0.controls:delta',
-                  phase.interpolate(ys=[0.0, 0.0], nodes='control_input'), units='rad')
-        p.set_val('traj.phase0.controls:thrust',
-                  phase.interpolate(ys=[0.1, 0.1], nodes='control_input'),
-                  units=None)  # a small amount of thrust can speed up convergence
-
-        dm.run_problem(p, run_driver=True, simulate=False, make_plots=False)
-        print('Optimization finished')
-
-        t = p.get_val('traj.phase0.timeseries.states:t')
-        assert_near_equal(t[-1], 22.2657, tolerance=0.01)
+        _run_racecar_problem(dm.GaussLobatto, timeseries=True)
 
     def benchmark_radau_notimeseries(self):
-
-        # change track here and in curvature.py. Tracks are defined in tracks.py
-        track = ovaltrack
-
-        # generate nodes along the centerline for curvature calculation (different
-        # than collocation nodes)
-        points = get_track_points(track)
-
-        # fit the centerline spline.
-        finespline, gates, gatesd, curv, slope = get_spline(points, s=0.0)
-        # by default 10000 points
-        s_final = track.get_total_length()
-
-        # Define the OpenMDAO problem
-        p = om.Problem(model=om.Group())
-
-        # Define a Trajectory object
-        traj = dm.Trajectory()
-        p.model.add_subsystem('traj', subsys=traj)
-
-        # Define a Dymos Phase object with radau Transcription
-        phase = dm.Phase(ode_class=CombinedODE,
-                         transcription=dm.Radau(num_segments=50, order=3, compressed=True))
-
-        traj.add_phase(name='phase0', phase=phase)
-
-        # Set the time options, in this problem we perform a change of variables. So 'time' is
-        # actually 's' (distance along the track centerline)
-        # This is done to fix the collocation nodes in space, which saves us the calculation of
-        # the rate of change of curvature.
-        # The state equations are written with respect to time, the variable change occurs in
-        # timeODE.py
-        phase.set_time_options(fix_initial=True, fix_duration=True, duration_val=s_final,
-                               targets=['curv.s'], units='m', duration_ref=s_final,
-                               duration_ref0=10)
-
-        # Define states
-        phase.add_state('t', fix_initial=True, fix_final=False, units='s', lower=0,
-                        rate_source='dt_ds', ref=100)  # time
-        phase.add_state('n', fix_initial=False, fix_final=False, units='m', upper=4.0, lower=-4.0,
-                        rate_source='dn_ds', targets=['n'],
-                        ref=4.0)  # normal distance to centerline. The bounds on n define the
-        # width of the track
-        phase.add_state('V', fix_initial=False, fix_final=False, units='m/s', ref=40, ref0=5,
-                        rate_source='dV_ds', targets=['V'])  # velocity
-        phase.add_state('alpha', fix_initial=False, fix_final=False, units='rad',
-                        rate_source='dalpha_ds', targets=['alpha'],
-                        ref=0.15)  # vehicle heading angle with respect to centerline
-        phase.add_state('lambda', fix_initial=False, fix_final=False, units='rad',
-                        rate_source='dlambda_ds', targets=['lambda'],
-                        ref=0.01)  # vehicle slip angle, or angle between the axis of the vehicle
-        # and velocity vector (all cars drift a little)
-        phase.add_state('omega', fix_initial=False, fix_final=False, units='rad/s',
-                        rate_source='domega_ds', targets=['omega'], ref=0.3)  # yaw rate
-        phase.add_state('ax', fix_initial=False, fix_final=False, units='m/s**2',
-                        rate_source='dax_ds', targets=['ax'], ref=8)  # longitudinal acceleration
-        phase.add_state('ay', fix_initial=False, fix_final=False, units='m/s**2',
-                        rate_source='day_ds', targets=['ay'], ref=8)  # lateral acceleration
-
-        # Define Controls
-        phase.add_control(name='delta', units='rad', lower=None, upper=None, fix_initial=False,
-                          fix_final=False, targets=['delta'], ref=0.04)  # steering angle
-        phase.add_control(name='thrust', units=None, fix_initial=False, fix_final=False, targets=[
-            'thrust'])  # the thrust controls the longitudinal force of the rear tires and is
-        # positive while accelerating, negative while braking
-
-        # Performance Constraints
-        pmax = 960000  # W
-        phase.add_path_constraint('power', upper=pmax, ref=100000)  # engine power limit
-
-        # The following four constraints are the tire friction limits, with 'rr' designating the
-        # rear right wheel etc. This limit is computed in tireConstraintODE.py
-        phase.add_path_constraint('c_rr', upper=1)
-        phase.add_path_constraint('c_rl', upper=1)
-        phase.add_path_constraint('c_fr', upper=1)
-        phase.add_path_constraint('c_fl', upper=1)
-
-        # Some of the vehicle design parameters are available to set here. Other parameters can
-        # be found in their respective ODE files.
-        phase.add_parameter('M', val=800.0, units='kg', opt=False,
-                            targets=['car.M', 'tire.M', 'tireconstraint.M', 'normal.M'],
-                            dynamic=False)  # vehicle mass
-        phase.add_parameter('beta', val=0.62, units=None, opt=False, targets=['tire.beta'],
-                            dynamic=False)  # brake bias
-        phase.add_parameter('CoP', val=1.6, units='m', opt=False, targets=['normal.CoP'],
-                            dynamic=False)  # center of pressure location
-        phase.add_parameter('h', val=0.3, units='m', opt=False, targets=['normal.h'],
-                            dynamic=False)  # center of gravity height
-        phase.add_parameter('chi', val=0.5, units=None, opt=False, targets=['normal.chi'],
-                            dynamic=False)  # roll stiffness
-        phase.add_parameter('ClA', val=4.0, units='m**2', opt=False, targets=['normal.ClA'],
-                            dynamic=False)  # downforce coefficient*area
-        phase.add_parameter('CdA', val=2.0, units='m**2', opt=False, targets=['car.CdA'],
-                            dynamic=False)  # drag coefficient*area
-
-        # Minimize final time.
-        # note that we use the 'state' time instead of Dymos 'time'
-        phase.add_objective('t', loc='final')
-
-        # Add output timeseries
-        # phase.add_timeseries_output('*')
-
-        # Link the states at the start and end of the phase in order to ensure a continous lap
-        traj.link_phases(phases=['phase0', 'phase0'],
-                         vars=['V', 'n', 'alpha', 'omega', 'lambda', 'ax', 'ay'],
-                         locs=('final', 'initial'))
-
-        # Set the driver. IPOPT or SNOPT are recommended but SLSQP might work.
-        p.driver = om.pyOptSparseDriver(optimizer='IPOPT')
-
-        p.driver.opt_settings['mu_init'] = 1e-3
-        p.driver.opt_settings['max_iter'] = 500
-        p.driver.opt_settings['acceptable_tol'] = 1e-3
-        p.driver.opt_settings['constr_viol_tol'] = 1e-3
-        p.driver.opt_settings['compl_inf_tol'] = 1e-3
-        p.driver.opt_settings['acceptable_iter'] = 0
-        p.driver.opt_settings['tol'] = 1e-3
-        p.driver.opt_settings['nlp_scaling_method'] = 'none'
-        p.driver.opt_settings['print_level'] = 5
-        p.driver.opt_settings['nlp_scaling_method'] = 'gradient-based'  # for faster convergence
-
-        # Allow OpenMDAO to automatically determine our sparsity pattern.
-        # Doing so can significant speed up the execution of Dymos.
-        p.driver.declare_coloring()
-
-        # Setup the problem
-        p.setup(check=True)  # force_alloc_complex=True
-        # Now that the OpenMDAO problem is setup, we can set the values of the states.
-
-        # States
-        p.set_val('traj.phase0.states:V', phase.interpolate(ys=[20, 20], nodes='state_input'),
-                  units='m/s')  # non-zero velocity in order to protect against 1/0 errors.
-        p.set_val('traj.phase0.states:lambda',
-                  phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='rad')  # all other states start at 0
-        p.set_val('traj.phase0.states:omega', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='rad/s')
-        p.set_val('traj.phase0.states:alpha', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='rad')
-        p.set_val('traj.phase0.states:ax', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='m/s**2')
-        p.set_val('traj.phase0.states:ay', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='m/s**2')
-        p.set_val('traj.phase0.states:n', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='m')
-        p.set_val('traj.phase0.states:t', phase.interpolate(ys=[0.0, 100.0], nodes='state_input'),
-                  units='s')  # initial guess for what the final time should be
-
-        # Controls
-        p.set_val('traj.phase0.controls:delta',
-                  phase.interpolate(ys=[0.0, 0.0], nodes='control_input'), units='rad')
-        p.set_val('traj.phase0.controls:thrust',
-                  phase.interpolate(ys=[0.1, 0.1], nodes='control_input'),
-                  units=None)  # a small amount of thrust can speed up convergence
-
-        dm.run_problem(p, run_driver=True, simulate=False, make_plots=False)
-        print('Optimization finished')
-
-        t = p.get_val('traj.phase0.timeseries.states:t')
-        assert_near_equal(t[-1], 22.2657, tolerance=0.01)
-
+        _run_racecar_problem(dm.Radau, timeseres=False)
 
     def benchmark_radau_timeseries(self):
-
-        # change track here and in curvature.py. Tracks are defined in tracks.py
-        track = ovaltrack
-
-        # generate nodes along the centerline for curvature calculation (different
-        # than collocation nodes)
-        points = get_track_points(track)
-
-        # fit the centerline spline.
-        finespline, gates, gatesd, curv, slope = get_spline(points, s=0.0)
-        # by default 10000 points
-        s_final = track.get_total_length()
-
-        # Define the OpenMDAO problem
-        p = om.Problem(model=om.Group())
-
-        # Define a Trajectory object
-        traj = dm.Trajectory()
-        p.model.add_subsystem('traj', subsys=traj)
-
-        # Define a Dymos Phase object with radau Transcription
-        phase = dm.Phase(ode_class=CombinedODE,
-                         transcription=dm.Radau(num_segments=50, order=3, compressed=True))
-
-        traj.add_phase(name='phase0', phase=phase)
-
-        # Set the time options, in this problem we perform a change of variables. So 'time' is
-        # actually 's' (distance along the track centerline)
-        # This is done to fix the collocation nodes in space, which saves us the calculation of
-        # the rate of change of curvature.
-        # The state equations are written with respect to time, the variable change occurs in
-        # timeODE.py
-        phase.set_time_options(fix_initial=True, fix_duration=True, duration_val=s_final,
-                               targets=['curv.s'], units='m', duration_ref=s_final,
-                               duration_ref0=10)
-
-        # Define states
-        phase.add_state('t', fix_initial=True, fix_final=False, units='s', lower=0,
-                        rate_source='dt_ds', ref=100)  # time
-        phase.add_state('n', fix_initial=False, fix_final=False, units='m', upper=4.0, lower=-4.0,
-                        rate_source='dn_ds', targets=['n'],
-                        ref=4.0)  # normal distance to centerline. The bounds on n define the
-        # width of the track
-        phase.add_state('V', fix_initial=False, fix_final=False, units='m/s', ref=40, ref0=5,
-                        rate_source='dV_ds', targets=['V'])  # velocity
-        phase.add_state('alpha', fix_initial=False, fix_final=False, units='rad',
-                        rate_source='dalpha_ds', targets=['alpha'],
-                        ref=0.15)  # vehicle heading angle with respect to centerline
-        phase.add_state('lambda', fix_initial=False, fix_final=False, units='rad',
-                        rate_source='dlambda_ds', targets=['lambda'],
-                        ref=0.01)  # vehicle slip angle, or angle between the axis of the vehicle
-        # and velocity vector (all cars drift a little)
-        phase.add_state('omega', fix_initial=False, fix_final=False, units='rad/s',
-                        rate_source='domega_ds', targets=['omega'], ref=0.3)  # yaw rate
-        phase.add_state('ax', fix_initial=False, fix_final=False, units='m/s**2',
-                        rate_source='dax_ds', targets=['ax'], ref=8)  # longitudinal acceleration
-        phase.add_state('ay', fix_initial=False, fix_final=False, units='m/s**2',
-                        rate_source='day_ds', targets=['ay'], ref=8)  # lateral acceleration
-
-        # Define Controls
-        phase.add_control(name='delta', units='rad', lower=None, upper=None, fix_initial=False,
-                          fix_final=False, targets=['delta'], ref=0.04)  # steering angle
-        phase.add_control(name='thrust', units=None, fix_initial=False, fix_final=False, targets=[
-            'thrust'])  # the thrust controls the longitudinal force of the rear tires and is
-        # positive while accelerating, negative while braking
-
-        # Performance Constraints
-        pmax = 960000  # W
-        phase.add_path_constraint('power', upper=pmax, ref=100000)  # engine power limit
-
-        # The following four constraints are the tire friction limits, with 'rr' designating the
-        # rear right wheel etc. This limit is computed in tireConstraintODE.py
-        phase.add_path_constraint('c_rr', upper=1)
-        phase.add_path_constraint('c_rl', upper=1)
-        phase.add_path_constraint('c_fr', upper=1)
-        phase.add_path_constraint('c_fl', upper=1)
-
-        # Some of the vehicle design parameters are available to set here. Other parameters can
-        # be found in their respective ODE files.
-        phase.add_parameter('M', val=800.0, units='kg', opt=False,
-                            targets=['car.M', 'tire.M', 'tireconstraint.M', 'normal.M'],
-                            dynamic=False)  # vehicle mass
-        phase.add_parameter('beta', val=0.62, units=None, opt=False, targets=['tire.beta'],
-                            dynamic=False)  # brake bias
-        phase.add_parameter('CoP', val=1.6, units='m', opt=False, targets=['normal.CoP'],
-                            dynamic=False)  # center of pressure location
-        phase.add_parameter('h', val=0.3, units='m', opt=False, targets=['normal.h'],
-                            dynamic=False)  # center of gravity height
-        phase.add_parameter('chi', val=0.5, units=None, opt=False, targets=['normal.chi'],
-                            dynamic=False)  # roll stiffness
-        phase.add_parameter('ClA', val=4.0, units='m**2', opt=False, targets=['normal.ClA'],
-                            dynamic=False)  # downforce coefficient*area
-        phase.add_parameter('CdA', val=2.0, units='m**2', opt=False, targets=['car.CdA'],
-                            dynamic=False)  # drag coefficient*area
-
-        # Minimize final time.
-        # note that we use the 'state' time instead of Dymos 'time'
-        phase.add_objective('t', loc='final')
-
-        # Add output timeseries
-        phase.add_timeseries_output('*')
-
-        # Link the states at the start and end of the phase in order to ensure a continous lap
-        traj.link_phases(phases=['phase0', 'phase0'],
-                         vars=['V', 'n', 'alpha', 'omega', 'lambda', 'ax', 'ay'],
-                         locs=('final', 'initial'))
-
-        # Set the driver. IPOPT or SNOPT are recommended but SLSQP might work.
-        p.driver = om.pyOptSparseDriver(optimizer='IPOPT')
-
-        p.driver.opt_settings['mu_init'] = 1e-3
-        p.driver.opt_settings['max_iter'] = 500
-        p.driver.opt_settings['acceptable_tol'] = 1e-3
-        p.driver.opt_settings['constr_viol_tol'] = 1e-3
-        p.driver.opt_settings['compl_inf_tol'] = 1e-3
-        p.driver.opt_settings['acceptable_iter'] = 0
-        p.driver.opt_settings['tol'] = 1e-3
-        p.driver.opt_settings['nlp_scaling_method'] = 'none'
-        p.driver.opt_settings['print_level'] = 5
-        p.driver.opt_settings['nlp_scaling_method'] = 'gradient-based'  # for faster convergence
-
-        # Allow OpenMDAO to automatically determine our sparsity pattern.
-        # Doing so can significant speed up the execution of Dymos.
-        p.driver.declare_coloring()
-
-        # Setup the problem
-        p.setup(check=True)  # force_alloc_complex=True
-        # Now that the OpenMDAO problem is setup, we can set the values of the states.
-
-        # States
-        p.set_val('traj.phase0.states:V', phase.interpolate(ys=[20, 20], nodes='state_input'),
-                  units='m/s')  # non-zero velocity in order to protect against 1/0 errors.
-        p.set_val('traj.phase0.states:lambda',
-                  phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='rad')  # all other states start at 0
-        p.set_val('traj.phase0.states:omega', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='rad/s')
-        p.set_val('traj.phase0.states:alpha', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='rad')
-        p.set_val('traj.phase0.states:ax', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='m/s**2')
-        p.set_val('traj.phase0.states:ay', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='m/s**2')
-        p.set_val('traj.phase0.states:n', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
-                  units='m')
-        p.set_val('traj.phase0.states:t', phase.interpolate(ys=[0.0, 100.0], nodes='state_input'),
-                  units='s')  # initial guess for what the final time should be
-
-        # Controls
-        p.set_val('traj.phase0.controls:delta',
-                  phase.interpolate(ys=[0.0, 0.0], nodes='control_input'), units='rad')
-        p.set_val('traj.phase0.controls:thrust',
-                  phase.interpolate(ys=[0.1, 0.1], nodes='control_input'),
-                  units=None)  # a small amount of thrust can speed up convergence
-
-        dm.run_problem(p, run_driver=True, simulate=False, make_plots=False)
-        print('Optimization finished')
-
-        t = p.get_val('traj.phase0.timeseries.states:t')
-        assert_near_equal(t[-1], 22.2657, tolerance=0.01)
+        _run_racecar_problem(dm.Radau, timeseres=True)

--- a/benchmark/benchmark_racecar.py
+++ b/benchmark/benchmark_racecar.py
@@ -1,0 +1,666 @@
+import unittest
+
+from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.assert_utils import assert_near_equal
+
+import openmdao.api as om
+import dymos as dm
+
+from dymos.examples.racecar.combinedODE import CombinedODE
+from dymos.examples.racecar.spline import get_spline, get_track_points
+from dymos.examples.racecar.tracks import ovaltrack  # track curvature imports
+
+
+@use_tempdirs
+class BenchmarkRacecar(unittest.TestCase):
+    """ Benchmarks for various permutations of the racecar problem."""
+
+    def benchmark_gausslobatto_notimeseries(self):
+
+        # change track here and in curvature.py. Tracks are defined in tracks.py
+        track = ovaltrack
+
+        # generate nodes along the centerline for curvature calculation (different
+        # than collocation nodes)
+        points = get_track_points(track)
+
+        # fit the centerline spline.
+        finespline, gates, gatesd, curv, slope = get_spline(points, s=0.0)
+        # by default 10000 points
+        s_final = track.get_total_length()
+
+        # Define the OpenMDAO problem
+        p = om.Problem(model=om.Group())
+
+        # Define a Trajectory object
+        traj = dm.Trajectory()
+        p.model.add_subsystem('traj', subsys=traj)
+
+        # Define a Dymos Phase object with GaussLobatto Transcription
+        phase = dm.Phase(ode_class=CombinedODE,
+                         transcription=dm.GaussLobatto(num_segments=50, order=3, compressed=True))
+
+        traj.add_phase(name='phase0', phase=phase)
+
+        # Set the time options, in this problem we perform a change of variables. So 'time' is
+        # actually 's' (distance along the track centerline)
+        # This is done to fix the collocation nodes in space, which saves us the calculation of
+        # the rate of change of curvature.
+        # The state equations are written with respect to time, the variable change occurs in
+        # timeODE.py
+        phase.set_time_options(fix_initial=True, fix_duration=True, duration_val=s_final,
+                               targets=['curv.s'], units='m', duration_ref=s_final,
+                               duration_ref0=10)
+
+        # Define states
+        phase.add_state('t', fix_initial=True, fix_final=False, units='s', lower=0,
+                        rate_source='dt_ds', ref=100)  # time
+        phase.add_state('n', fix_initial=False, fix_final=False, units='m', upper=4.0, lower=-4.0,
+                        rate_source='dn_ds', targets=['n'],
+                        ref=4.0)  # normal distance to centerline. The bounds on n define the
+        # width of the track
+        phase.add_state('V', fix_initial=False, fix_final=False, units='m/s', ref=40, ref0=5,
+                        rate_source='dV_ds', targets=['V'])  # velocity
+        phase.add_state('alpha', fix_initial=False, fix_final=False, units='rad',
+                        rate_source='dalpha_ds', targets=['alpha'],
+                        ref=0.15)  # vehicle heading angle with respect to centerline
+        phase.add_state('lambda', fix_initial=False, fix_final=False, units='rad',
+                        rate_source='dlambda_ds', targets=['lambda'],
+                        ref=0.01)  # vehicle slip angle, or angle between the axis of the vehicle
+        # and velocity vector (all cars drift a little)
+        phase.add_state('omega', fix_initial=False, fix_final=False, units='rad/s',
+                        rate_source='domega_ds', targets=['omega'], ref=0.3)  # yaw rate
+        phase.add_state('ax', fix_initial=False, fix_final=False, units='m/s**2',
+                        rate_source='dax_ds', targets=['ax'], ref=8)  # longitudinal acceleration
+        phase.add_state('ay', fix_initial=False, fix_final=False, units='m/s**2',
+                        rate_source='day_ds', targets=['ay'], ref=8)  # lateral acceleration
+
+        # Define Controls
+        phase.add_control(name='delta', units='rad', lower=None, upper=None, fix_initial=False,
+                          fix_final=False, targets=['delta'], ref=0.04)  # steering angle
+        phase.add_control(name='thrust', units=None, fix_initial=False, fix_final=False, targets=[
+            'thrust'])  # the thrust controls the longitudinal force of the rear tires and is
+        # positive while accelerating, negative while braking
+
+        # Performance Constraints
+        pmax = 960000  # W
+        phase.add_path_constraint('power', upper=pmax, ref=100000)  # engine power limit
+
+        # The following four constraints are the tire friction limits, with 'rr' designating the
+        # rear right wheel etc. This limit is computed in tireConstraintODE.py
+        phase.add_path_constraint('c_rr', upper=1)
+        phase.add_path_constraint('c_rl', upper=1)
+        phase.add_path_constraint('c_fr', upper=1)
+        phase.add_path_constraint('c_fl', upper=1)
+
+        # Some of the vehicle design parameters are available to set here. Other parameters can
+        # be found in their respective ODE files.
+        phase.add_parameter('M', val=800.0, units='kg', opt=False,
+                            targets=['car.M', 'tire.M', 'tireconstraint.M', 'normal.M'],
+                            dynamic=False)  # vehicle mass
+        phase.add_parameter('beta', val=0.62, units=None, opt=False, targets=['tire.beta'],
+                            dynamic=False)  # brake bias
+        phase.add_parameter('CoP', val=1.6, units='m', opt=False, targets=['normal.CoP'],
+                            dynamic=False)  # center of pressure location
+        phase.add_parameter('h', val=0.3, units='m', opt=False, targets=['normal.h'],
+                            dynamic=False)  # center of gravity height
+        phase.add_parameter('chi', val=0.5, units=None, opt=False, targets=['normal.chi'],
+                            dynamic=False)  # roll stiffness
+        phase.add_parameter('ClA', val=4.0, units='m**2', opt=False, targets=['normal.ClA'],
+                            dynamic=False)  # downforce coefficient*area
+        phase.add_parameter('CdA', val=2.0, units='m**2', opt=False, targets=['car.CdA'],
+                            dynamic=False)  # drag coefficient*area
+
+        # Minimize final time.
+        # note that we use the 'state' time instead of Dymos 'time'
+        phase.add_objective('t', loc='final')
+
+        # Add output timeseries
+        # phase.add_timeseries_output('*')
+
+        # Link the states at the start and end of the phase in order to ensure a continous lap
+        traj.link_phases(phases=['phase0', 'phase0'],
+                         vars=['V', 'n', 'alpha', 'omega', 'lambda', 'ax', 'ay'],
+                         locs=('final', 'initial'))
+
+        # Set the driver. IPOPT or SNOPT are recommended but SLSQP might work.
+        p.driver = om.pyOptSparseDriver(optimizer='IPOPT')
+
+        p.driver.opt_settings['mu_init'] = 1e-3
+        p.driver.opt_settings['max_iter'] = 500
+        p.driver.opt_settings['acceptable_tol'] = 1e-3
+        p.driver.opt_settings['constr_viol_tol'] = 1e-3
+        p.driver.opt_settings['compl_inf_tol'] = 1e-3
+        p.driver.opt_settings['acceptable_iter'] = 0
+        p.driver.opt_settings['tol'] = 1e-3
+        p.driver.opt_settings['nlp_scaling_method'] = 'none'
+        p.driver.opt_settings['print_level'] = 5
+        p.driver.opt_settings['nlp_scaling_method'] = 'gradient-based'  # for faster convergence
+
+        # Allow OpenMDAO to automatically determine our sparsity pattern.
+        # Doing so can significant speed up the execution of Dymos.
+        p.driver.declare_coloring()
+
+        # Setup the problem
+        p.setup(check=True)  # force_alloc_complex=True
+        # Now that the OpenMDAO problem is setup, we can set the values of the states.
+
+        # States
+        p.set_val('traj.phase0.states:V', phase.interpolate(ys=[20, 20], nodes='state_input'),
+                  units='m/s')  # non-zero velocity in order to protect against 1/0 errors.
+        p.set_val('traj.phase0.states:lambda',
+                  phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='rad')  # all other states start at 0
+        p.set_val('traj.phase0.states:omega', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='rad/s')
+        p.set_val('traj.phase0.states:alpha', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='rad')
+        p.set_val('traj.phase0.states:ax', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='m/s**2')
+        p.set_val('traj.phase0.states:ay', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='m/s**2')
+        p.set_val('traj.phase0.states:n', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='m')
+        p.set_val('traj.phase0.states:t', phase.interpolate(ys=[0.0, 100.0], nodes='state_input'),
+                  units='s')  # initial guess for what the final time should be
+
+        # Controls
+        p.set_val('traj.phase0.controls:delta',
+                  phase.interpolate(ys=[0.0, 0.0], nodes='control_input'), units='rad')
+        p.set_val('traj.phase0.controls:thrust',
+                  phase.interpolate(ys=[0.1, 0.1], nodes='control_input'),
+                  units=None)  # a small amount of thrust can speed up convergence
+
+        dm.run_problem(p, run_driver=True, simulate=False, make_plots=False)
+        print('Optimization finished')
+
+        t = p.get_val('traj.phase0.timeseries.states:t')
+        assert_near_equal(t[-1], 22.2657, tolerance=0.01)
+
+
+    def benchmark_gausslobatto_timeseries(self):
+
+        # change track here and in curvature.py. Tracks are defined in tracks.py
+        track = ovaltrack
+
+        # generate nodes along the centerline for curvature calculation (different
+        # than collocation nodes)
+        points = get_track_points(track)
+
+        # fit the centerline spline.
+        finespline, gates, gatesd, curv, slope = get_spline(points, s=0.0)
+        # by default 10000 points
+        s_final = track.get_total_length()
+
+        # Define the OpenMDAO problem
+        p = om.Problem(model=om.Group())
+
+        # Define a Trajectory object
+        traj = dm.Trajectory()
+        p.model.add_subsystem('traj', subsys=traj)
+
+        # Define a Dymos Phase object with GaussLobatto Transcription
+        phase = dm.Phase(ode_class=CombinedODE,
+                         transcription=dm.GaussLobatto(num_segments=50, order=3, compressed=True))
+
+        traj.add_phase(name='phase0', phase=phase)
+
+        # Set the time options, in this problem we perform a change of variables. So 'time' is
+        # actually 's' (distance along the track centerline)
+        # This is done to fix the collocation nodes in space, which saves us the calculation of
+        # the rate of change of curvature.
+        # The state equations are written with respect to time, the variable change occurs in
+        # timeODE.py
+        phase.set_time_options(fix_initial=True, fix_duration=True, duration_val=s_final,
+                               targets=['curv.s'], units='m', duration_ref=s_final,
+                               duration_ref0=10)
+
+        # Define states
+        phase.add_state('t', fix_initial=True, fix_final=False, units='s', lower=0,
+                        rate_source='dt_ds', ref=100)  # time
+        phase.add_state('n', fix_initial=False, fix_final=False, units='m', upper=4.0, lower=-4.0,
+                        rate_source='dn_ds', targets=['n'],
+                        ref=4.0)  # normal distance to centerline. The bounds on n define the
+        # width of the track
+        phase.add_state('V', fix_initial=False, fix_final=False, units='m/s', ref=40, ref0=5,
+                        rate_source='dV_ds', targets=['V'])  # velocity
+        phase.add_state('alpha', fix_initial=False, fix_final=False, units='rad',
+                        rate_source='dalpha_ds', targets=['alpha'],
+                        ref=0.15)  # vehicle heading angle with respect to centerline
+        phase.add_state('lambda', fix_initial=False, fix_final=False, units='rad',
+                        rate_source='dlambda_ds', targets=['lambda'],
+                        ref=0.01)  # vehicle slip angle, or angle between the axis of the vehicle
+        # and velocity vector (all cars drift a little)
+        phase.add_state('omega', fix_initial=False, fix_final=False, units='rad/s',
+                        rate_source='domega_ds', targets=['omega'], ref=0.3)  # yaw rate
+        phase.add_state('ax', fix_initial=False, fix_final=False, units='m/s**2',
+                        rate_source='dax_ds', targets=['ax'], ref=8)  # longitudinal acceleration
+        phase.add_state('ay', fix_initial=False, fix_final=False, units='m/s**2',
+                        rate_source='day_ds', targets=['ay'], ref=8)  # lateral acceleration
+
+        # Define Controls
+        phase.add_control(name='delta', units='rad', lower=None, upper=None, fix_initial=False,
+                          fix_final=False, targets=['delta'], ref=0.04)  # steering angle
+        phase.add_control(name='thrust', units=None, fix_initial=False, fix_final=False, targets=[
+            'thrust'])  # the thrust controls the longitudinal force of the rear tires and is
+        # positive while accelerating, negative while braking
+
+        # Performance Constraints
+        pmax = 960000  # W
+        phase.add_path_constraint('power', upper=pmax, ref=100000)  # engine power limit
+
+        # The following four constraints are the tire friction limits, with 'rr' designating the
+        # rear right wheel etc. This limit is computed in tireConstraintODE.py
+        phase.add_path_constraint('c_rr', upper=1)
+        phase.add_path_constraint('c_rl', upper=1)
+        phase.add_path_constraint('c_fr', upper=1)
+        phase.add_path_constraint('c_fl', upper=1)
+
+        # Some of the vehicle design parameters are available to set here. Other parameters can
+        # be found in their respective ODE files.
+        phase.add_parameter('M', val=800.0, units='kg', opt=False,
+                            targets=['car.M', 'tire.M', 'tireconstraint.M', 'normal.M'],
+                            dynamic=False)  # vehicle mass
+        phase.add_parameter('beta', val=0.62, units=None, opt=False, targets=['tire.beta'],
+                            dynamic=False)  # brake bias
+        phase.add_parameter('CoP', val=1.6, units='m', opt=False, targets=['normal.CoP'],
+                            dynamic=False)  # center of pressure location
+        phase.add_parameter('h', val=0.3, units='m', opt=False, targets=['normal.h'],
+                            dynamic=False)  # center of gravity height
+        phase.add_parameter('chi', val=0.5, units=None, opt=False, targets=['normal.chi'],
+                            dynamic=False)  # roll stiffness
+        phase.add_parameter('ClA', val=4.0, units='m**2', opt=False, targets=['normal.ClA'],
+                            dynamic=False)  # downforce coefficient*area
+        phase.add_parameter('CdA', val=2.0, units='m**2', opt=False, targets=['car.CdA'],
+                            dynamic=False)  # drag coefficient*area
+
+        # Minimize final time.
+        # note that we use the 'state' time instead of Dymos 'time'
+        phase.add_objective('t', loc='final')
+
+        # Add output timeseries
+        phase.add_timeseries_output('*')
+
+        # Link the states at the start and end of the phase in order to ensure a continous lap
+        traj.link_phases(phases=['phase0', 'phase0'],
+                         vars=['V', 'n', 'alpha', 'omega', 'lambda', 'ax', 'ay'],
+                         locs=('final', 'initial'))
+
+        # Set the driver. IPOPT or SNOPT are recommended but SLSQP might work.
+        p.driver = om.pyOptSparseDriver(optimizer='IPOPT')
+
+        p.driver.opt_settings['mu_init'] = 1e-3
+        p.driver.opt_settings['max_iter'] = 500
+        p.driver.opt_settings['acceptable_tol'] = 1e-3
+        p.driver.opt_settings['constr_viol_tol'] = 1e-3
+        p.driver.opt_settings['compl_inf_tol'] = 1e-3
+        p.driver.opt_settings['acceptable_iter'] = 0
+        p.driver.opt_settings['tol'] = 1e-3
+        p.driver.opt_settings['nlp_scaling_method'] = 'none'
+        p.driver.opt_settings['print_level'] = 5
+        p.driver.opt_settings['nlp_scaling_method'] = 'gradient-based'  # for faster convergence
+
+        # Allow OpenMDAO to automatically determine our sparsity pattern.
+        # Doing so can significant speed up the execution of Dymos.
+        p.driver.declare_coloring()
+
+        # Setup the problem
+        p.setup(check=True)  # force_alloc_complex=True
+        # Now that the OpenMDAO problem is setup, we can set the values of the states.
+
+        # States
+        p.set_val('traj.phase0.states:V', phase.interpolate(ys=[20, 20], nodes='state_input'),
+                  units='m/s')  # non-zero velocity in order to protect against 1/0 errors.
+        p.set_val('traj.phase0.states:lambda',
+                  phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='rad')  # all other states start at 0
+        p.set_val('traj.phase0.states:omega', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='rad/s')
+        p.set_val('traj.phase0.states:alpha', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='rad')
+        p.set_val('traj.phase0.states:ax', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='m/s**2')
+        p.set_val('traj.phase0.states:ay', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='m/s**2')
+        p.set_val('traj.phase0.states:n', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='m')
+        p.set_val('traj.phase0.states:t', phase.interpolate(ys=[0.0, 100.0], nodes='state_input'),
+                  units='s')  # initial guess for what the final time should be
+
+        # Controls
+        p.set_val('traj.phase0.controls:delta',
+                  phase.interpolate(ys=[0.0, 0.0], nodes='control_input'), units='rad')
+        p.set_val('traj.phase0.controls:thrust',
+                  phase.interpolate(ys=[0.1, 0.1], nodes='control_input'),
+                  units=None)  # a small amount of thrust can speed up convergence
+
+        dm.run_problem(p, run_driver=True, simulate=False, make_plots=False)
+        print('Optimization finished')
+
+        t = p.get_val('traj.phase0.timeseries.states:t')
+        assert_near_equal(t[-1], 22.2657, tolerance=0.01)
+
+    def benchmark_radau_notimeseries(self):
+
+        # change track here and in curvature.py. Tracks are defined in tracks.py
+        track = ovaltrack
+
+        # generate nodes along the centerline for curvature calculation (different
+        # than collocation nodes)
+        points = get_track_points(track)
+
+        # fit the centerline spline.
+        finespline, gates, gatesd, curv, slope = get_spline(points, s=0.0)
+        # by default 10000 points
+        s_final = track.get_total_length()
+
+        # Define the OpenMDAO problem
+        p = om.Problem(model=om.Group())
+
+        # Define a Trajectory object
+        traj = dm.Trajectory()
+        p.model.add_subsystem('traj', subsys=traj)
+
+        # Define a Dymos Phase object with radau Transcription
+        phase = dm.Phase(ode_class=CombinedODE,
+                         transcription=dm.Radau(num_segments=50, order=3, compressed=True))
+
+        traj.add_phase(name='phase0', phase=phase)
+
+        # Set the time options, in this problem we perform a change of variables. So 'time' is
+        # actually 's' (distance along the track centerline)
+        # This is done to fix the collocation nodes in space, which saves us the calculation of
+        # the rate of change of curvature.
+        # The state equations are written with respect to time, the variable change occurs in
+        # timeODE.py
+        phase.set_time_options(fix_initial=True, fix_duration=True, duration_val=s_final,
+                               targets=['curv.s'], units='m', duration_ref=s_final,
+                               duration_ref0=10)
+
+        # Define states
+        phase.add_state('t', fix_initial=True, fix_final=False, units='s', lower=0,
+                        rate_source='dt_ds', ref=100)  # time
+        phase.add_state('n', fix_initial=False, fix_final=False, units='m', upper=4.0, lower=-4.0,
+                        rate_source='dn_ds', targets=['n'],
+                        ref=4.0)  # normal distance to centerline. The bounds on n define the
+        # width of the track
+        phase.add_state('V', fix_initial=False, fix_final=False, units='m/s', ref=40, ref0=5,
+                        rate_source='dV_ds', targets=['V'])  # velocity
+        phase.add_state('alpha', fix_initial=False, fix_final=False, units='rad',
+                        rate_source='dalpha_ds', targets=['alpha'],
+                        ref=0.15)  # vehicle heading angle with respect to centerline
+        phase.add_state('lambda', fix_initial=False, fix_final=False, units='rad',
+                        rate_source='dlambda_ds', targets=['lambda'],
+                        ref=0.01)  # vehicle slip angle, or angle between the axis of the vehicle
+        # and velocity vector (all cars drift a little)
+        phase.add_state('omega', fix_initial=False, fix_final=False, units='rad/s',
+                        rate_source='domega_ds', targets=['omega'], ref=0.3)  # yaw rate
+        phase.add_state('ax', fix_initial=False, fix_final=False, units='m/s**2',
+                        rate_source='dax_ds', targets=['ax'], ref=8)  # longitudinal acceleration
+        phase.add_state('ay', fix_initial=False, fix_final=False, units='m/s**2',
+                        rate_source='day_ds', targets=['ay'], ref=8)  # lateral acceleration
+
+        # Define Controls
+        phase.add_control(name='delta', units='rad', lower=None, upper=None, fix_initial=False,
+                          fix_final=False, targets=['delta'], ref=0.04)  # steering angle
+        phase.add_control(name='thrust', units=None, fix_initial=False, fix_final=False, targets=[
+            'thrust'])  # the thrust controls the longitudinal force of the rear tires and is
+        # positive while accelerating, negative while braking
+
+        # Performance Constraints
+        pmax = 960000  # W
+        phase.add_path_constraint('power', upper=pmax, ref=100000)  # engine power limit
+
+        # The following four constraints are the tire friction limits, with 'rr' designating the
+        # rear right wheel etc. This limit is computed in tireConstraintODE.py
+        phase.add_path_constraint('c_rr', upper=1)
+        phase.add_path_constraint('c_rl', upper=1)
+        phase.add_path_constraint('c_fr', upper=1)
+        phase.add_path_constraint('c_fl', upper=1)
+
+        # Some of the vehicle design parameters are available to set here. Other parameters can
+        # be found in their respective ODE files.
+        phase.add_parameter('M', val=800.0, units='kg', opt=False,
+                            targets=['car.M', 'tire.M', 'tireconstraint.M', 'normal.M'],
+                            dynamic=False)  # vehicle mass
+        phase.add_parameter('beta', val=0.62, units=None, opt=False, targets=['tire.beta'],
+                            dynamic=False)  # brake bias
+        phase.add_parameter('CoP', val=1.6, units='m', opt=False, targets=['normal.CoP'],
+                            dynamic=False)  # center of pressure location
+        phase.add_parameter('h', val=0.3, units='m', opt=False, targets=['normal.h'],
+                            dynamic=False)  # center of gravity height
+        phase.add_parameter('chi', val=0.5, units=None, opt=False, targets=['normal.chi'],
+                            dynamic=False)  # roll stiffness
+        phase.add_parameter('ClA', val=4.0, units='m**2', opt=False, targets=['normal.ClA'],
+                            dynamic=False)  # downforce coefficient*area
+        phase.add_parameter('CdA', val=2.0, units='m**2', opt=False, targets=['car.CdA'],
+                            dynamic=False)  # drag coefficient*area
+
+        # Minimize final time.
+        # note that we use the 'state' time instead of Dymos 'time'
+        phase.add_objective('t', loc='final')
+
+        # Add output timeseries
+        # phase.add_timeseries_output('*')
+
+        # Link the states at the start and end of the phase in order to ensure a continous lap
+        traj.link_phases(phases=['phase0', 'phase0'],
+                         vars=['V', 'n', 'alpha', 'omega', 'lambda', 'ax', 'ay'],
+                         locs=('final', 'initial'))
+
+        # Set the driver. IPOPT or SNOPT are recommended but SLSQP might work.
+        p.driver = om.pyOptSparseDriver(optimizer='IPOPT')
+
+        p.driver.opt_settings['mu_init'] = 1e-3
+        p.driver.opt_settings['max_iter'] = 500
+        p.driver.opt_settings['acceptable_tol'] = 1e-3
+        p.driver.opt_settings['constr_viol_tol'] = 1e-3
+        p.driver.opt_settings['compl_inf_tol'] = 1e-3
+        p.driver.opt_settings['acceptable_iter'] = 0
+        p.driver.opt_settings['tol'] = 1e-3
+        p.driver.opt_settings['nlp_scaling_method'] = 'none'
+        p.driver.opt_settings['print_level'] = 5
+        p.driver.opt_settings['nlp_scaling_method'] = 'gradient-based'  # for faster convergence
+
+        # Allow OpenMDAO to automatically determine our sparsity pattern.
+        # Doing so can significant speed up the execution of Dymos.
+        p.driver.declare_coloring()
+
+        # Setup the problem
+        p.setup(check=True)  # force_alloc_complex=True
+        # Now that the OpenMDAO problem is setup, we can set the values of the states.
+
+        # States
+        p.set_val('traj.phase0.states:V', phase.interpolate(ys=[20, 20], nodes='state_input'),
+                  units='m/s')  # non-zero velocity in order to protect against 1/0 errors.
+        p.set_val('traj.phase0.states:lambda',
+                  phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='rad')  # all other states start at 0
+        p.set_val('traj.phase0.states:omega', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='rad/s')
+        p.set_val('traj.phase0.states:alpha', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='rad')
+        p.set_val('traj.phase0.states:ax', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='m/s**2')
+        p.set_val('traj.phase0.states:ay', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='m/s**2')
+        p.set_val('traj.phase0.states:n', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='m')
+        p.set_val('traj.phase0.states:t', phase.interpolate(ys=[0.0, 100.0], nodes='state_input'),
+                  units='s')  # initial guess for what the final time should be
+
+        # Controls
+        p.set_val('traj.phase0.controls:delta',
+                  phase.interpolate(ys=[0.0, 0.0], nodes='control_input'), units='rad')
+        p.set_val('traj.phase0.controls:thrust',
+                  phase.interpolate(ys=[0.1, 0.1], nodes='control_input'),
+                  units=None)  # a small amount of thrust can speed up convergence
+
+        dm.run_problem(p, run_driver=True, simulate=False, make_plots=False)
+        print('Optimization finished')
+
+        t = p.get_val('traj.phase0.timeseries.states:t')
+        assert_near_equal(t[-1], 22.2657, tolerance=0.01)
+
+
+    def benchmark_radau_timeseries(self):
+
+        # change track here and in curvature.py. Tracks are defined in tracks.py
+        track = ovaltrack
+
+        # generate nodes along the centerline for curvature calculation (different
+        # than collocation nodes)
+        points = get_track_points(track)
+
+        # fit the centerline spline.
+        finespline, gates, gatesd, curv, slope = get_spline(points, s=0.0)
+        # by default 10000 points
+        s_final = track.get_total_length()
+
+        # Define the OpenMDAO problem
+        p = om.Problem(model=om.Group())
+
+        # Define a Trajectory object
+        traj = dm.Trajectory()
+        p.model.add_subsystem('traj', subsys=traj)
+
+        # Define a Dymos Phase object with radau Transcription
+        phase = dm.Phase(ode_class=CombinedODE,
+                         transcription=dm.Radau(num_segments=50, order=3, compressed=True))
+
+        traj.add_phase(name='phase0', phase=phase)
+
+        # Set the time options, in this problem we perform a change of variables. So 'time' is
+        # actually 's' (distance along the track centerline)
+        # This is done to fix the collocation nodes in space, which saves us the calculation of
+        # the rate of change of curvature.
+        # The state equations are written with respect to time, the variable change occurs in
+        # timeODE.py
+        phase.set_time_options(fix_initial=True, fix_duration=True, duration_val=s_final,
+                               targets=['curv.s'], units='m', duration_ref=s_final,
+                               duration_ref0=10)
+
+        # Define states
+        phase.add_state('t', fix_initial=True, fix_final=False, units='s', lower=0,
+                        rate_source='dt_ds', ref=100)  # time
+        phase.add_state('n', fix_initial=False, fix_final=False, units='m', upper=4.0, lower=-4.0,
+                        rate_source='dn_ds', targets=['n'],
+                        ref=4.0)  # normal distance to centerline. The bounds on n define the
+        # width of the track
+        phase.add_state('V', fix_initial=False, fix_final=False, units='m/s', ref=40, ref0=5,
+                        rate_source='dV_ds', targets=['V'])  # velocity
+        phase.add_state('alpha', fix_initial=False, fix_final=False, units='rad',
+                        rate_source='dalpha_ds', targets=['alpha'],
+                        ref=0.15)  # vehicle heading angle with respect to centerline
+        phase.add_state('lambda', fix_initial=False, fix_final=False, units='rad',
+                        rate_source='dlambda_ds', targets=['lambda'],
+                        ref=0.01)  # vehicle slip angle, or angle between the axis of the vehicle
+        # and velocity vector (all cars drift a little)
+        phase.add_state('omega', fix_initial=False, fix_final=False, units='rad/s',
+                        rate_source='domega_ds', targets=['omega'], ref=0.3)  # yaw rate
+        phase.add_state('ax', fix_initial=False, fix_final=False, units='m/s**2',
+                        rate_source='dax_ds', targets=['ax'], ref=8)  # longitudinal acceleration
+        phase.add_state('ay', fix_initial=False, fix_final=False, units='m/s**2',
+                        rate_source='day_ds', targets=['ay'], ref=8)  # lateral acceleration
+
+        # Define Controls
+        phase.add_control(name='delta', units='rad', lower=None, upper=None, fix_initial=False,
+                          fix_final=False, targets=['delta'], ref=0.04)  # steering angle
+        phase.add_control(name='thrust', units=None, fix_initial=False, fix_final=False, targets=[
+            'thrust'])  # the thrust controls the longitudinal force of the rear tires and is
+        # positive while accelerating, negative while braking
+
+        # Performance Constraints
+        pmax = 960000  # W
+        phase.add_path_constraint('power', upper=pmax, ref=100000)  # engine power limit
+
+        # The following four constraints are the tire friction limits, with 'rr' designating the
+        # rear right wheel etc. This limit is computed in tireConstraintODE.py
+        phase.add_path_constraint('c_rr', upper=1)
+        phase.add_path_constraint('c_rl', upper=1)
+        phase.add_path_constraint('c_fr', upper=1)
+        phase.add_path_constraint('c_fl', upper=1)
+
+        # Some of the vehicle design parameters are available to set here. Other parameters can
+        # be found in their respective ODE files.
+        phase.add_parameter('M', val=800.0, units='kg', opt=False,
+                            targets=['car.M', 'tire.M', 'tireconstraint.M', 'normal.M'],
+                            dynamic=False)  # vehicle mass
+        phase.add_parameter('beta', val=0.62, units=None, opt=False, targets=['tire.beta'],
+                            dynamic=False)  # brake bias
+        phase.add_parameter('CoP', val=1.6, units='m', opt=False, targets=['normal.CoP'],
+                            dynamic=False)  # center of pressure location
+        phase.add_parameter('h', val=0.3, units='m', opt=False, targets=['normal.h'],
+                            dynamic=False)  # center of gravity height
+        phase.add_parameter('chi', val=0.5, units=None, opt=False, targets=['normal.chi'],
+                            dynamic=False)  # roll stiffness
+        phase.add_parameter('ClA', val=4.0, units='m**2', opt=False, targets=['normal.ClA'],
+                            dynamic=False)  # downforce coefficient*area
+        phase.add_parameter('CdA', val=2.0, units='m**2', opt=False, targets=['car.CdA'],
+                            dynamic=False)  # drag coefficient*area
+
+        # Minimize final time.
+        # note that we use the 'state' time instead of Dymos 'time'
+        phase.add_objective('t', loc='final')
+
+        # Add output timeseries
+        phase.add_timeseries_output('*')
+
+        # Link the states at the start and end of the phase in order to ensure a continous lap
+        traj.link_phases(phases=['phase0', 'phase0'],
+                         vars=['V', 'n', 'alpha', 'omega', 'lambda', 'ax', 'ay'],
+                         locs=('final', 'initial'))
+
+        # Set the driver. IPOPT or SNOPT are recommended but SLSQP might work.
+        p.driver = om.pyOptSparseDriver(optimizer='IPOPT')
+
+        p.driver.opt_settings['mu_init'] = 1e-3
+        p.driver.opt_settings['max_iter'] = 500
+        p.driver.opt_settings['acceptable_tol'] = 1e-3
+        p.driver.opt_settings['constr_viol_tol'] = 1e-3
+        p.driver.opt_settings['compl_inf_tol'] = 1e-3
+        p.driver.opt_settings['acceptable_iter'] = 0
+        p.driver.opt_settings['tol'] = 1e-3
+        p.driver.opt_settings['nlp_scaling_method'] = 'none'
+        p.driver.opt_settings['print_level'] = 5
+        p.driver.opt_settings['nlp_scaling_method'] = 'gradient-based'  # for faster convergence
+
+        # Allow OpenMDAO to automatically determine our sparsity pattern.
+        # Doing so can significant speed up the execution of Dymos.
+        p.driver.declare_coloring()
+
+        # Setup the problem
+        p.setup(check=True)  # force_alloc_complex=True
+        # Now that the OpenMDAO problem is setup, we can set the values of the states.
+
+        # States
+        p.set_val('traj.phase0.states:V', phase.interpolate(ys=[20, 20], nodes='state_input'),
+                  units='m/s')  # non-zero velocity in order to protect against 1/0 errors.
+        p.set_val('traj.phase0.states:lambda',
+                  phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='rad')  # all other states start at 0
+        p.set_val('traj.phase0.states:omega', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='rad/s')
+        p.set_val('traj.phase0.states:alpha', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='rad')
+        p.set_val('traj.phase0.states:ax', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='m/s**2')
+        p.set_val('traj.phase0.states:ay', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='m/s**2')
+        p.set_val('traj.phase0.states:n', phase.interpolate(ys=[0.0, 0.0], nodes='state_input'),
+                  units='m')
+        p.set_val('traj.phase0.states:t', phase.interpolate(ys=[0.0, 100.0], nodes='state_input'),
+                  units='s')  # initial guess for what the final time should be
+
+        # Controls
+        p.set_val('traj.phase0.controls:delta',
+                  phase.interpolate(ys=[0.0, 0.0], nodes='control_input'), units='rad')
+        p.set_val('traj.phase0.controls:thrust',
+                  phase.interpolate(ys=[0.1, 0.1], nodes='control_input'),
+                  units=None)  # a small amount of thrust can speed up convergence
+
+        dm.run_problem(p, run_driver=True, simulate=False, make_plots=False)
+        print('Optimization finished')
+
+        t = p.get_val('traj.phase0.timeseries.states:t')
+        assert_near_equal(t[-1], 22.2657, tolerance=0.01)

--- a/benchmark/benchmark_racecar.py
+++ b/benchmark/benchmark_racecar.py
@@ -179,13 +179,13 @@ class BenchmarkRacecar(unittest.TestCase):
     """ Benchmarks for various permutations of the racecar problem."""
 
     def benchmark_gausslobatto_notimeseries(self):
-        _run_racecar_problem(dm.GaussLobatto, timeseres=False)
+        _run_racecar_problem(dm.GaussLobatto, timeseries=False)
 
     def benchmark_gausslobatto_timeseries(self):
         _run_racecar_problem(dm.GaussLobatto, timeseries=True)
 
     def benchmark_radau_notimeseries(self):
-        _run_racecar_problem(dm.Radau, timeseres=False)
+        _run_racecar_problem(dm.Radau, timeseries=False)
 
     def benchmark_radau_timeseries(self):
-        _run_racecar_problem(dm.Radau, timeseres=True)
+        _run_racecar_problem(dm.Radau, timeseries=True)

--- a/dymos/examples/balanced_field/doc/test_doc_balanced_field_length.py
+++ b/dymos/examples/balanced_field/doc/test_doc_balanced_field_length.py
@@ -3,14 +3,15 @@ from openmdao.utils.testing_utils import use_tempdirs
 from dymos.utils.doc_utils import save_for_docs
 
 
+@use_tempdirs
 class TestBalancedFieldLengthForDocs(unittest.TestCase):
 
     @save_for_docs
-    @use_tempdirs
     def test_balanced_field_length_for_docs(self):
         import matplotlib.pyplot as plt
         import openmdao.api as om
         from openmdao.utils.general_utils import set_pyoptsparse_opt
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
         from dymos.examples.balanced_field.balanced_field_ode import BalancedFieldODEComp
 
@@ -230,6 +231,9 @@ class TestBalancedFieldLengthForDocs(unittest.TestCase):
         p.set_val('traj.climb.controls:alpha', 5.0, units='deg')
 
         dm.run_problem(p, run_driver=True, simulate=True)
+
+        # Test this example in Dymos' continuous integration
+        assert_near_equal(p.get_val('traj.rto.states:r')[-1], 2188.2, tolerance=0.01)
 
         sim_case = om.CaseReader('dymos_solution.db').get_case('final')
 

--- a/dymos/examples/racecar/doc/test_doc_racecar.py
+++ b/dymos/examples/racecar/doc/test_doc_racecar.py
@@ -16,6 +16,7 @@ class TestRaceCarForDocs(unittest.TestCase):
     def test_racecar_for_docs(self):
         import numpy as np
         import openmdao.api as om
+        from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
 
         from dymos.examples.racecar.combinedODE import CombinedODE
@@ -182,6 +183,9 @@ class TestRaceCarForDocs(unittest.TestCase):
 
         dm.run_problem(p, run_driver=True)
         print('Optimization finished')
+
+        # Test this example in Dymos' continuous integration process
+        assert_near_equal(p.get_val('traj.phase0.timeseries.states:t')[-1], 22.2657, tolerance=0.01)
 
         # Get optimized time series
         n = p.get_val('traj.phase0.timeseries.states:n')


### PR DESCRIPTION
### Summary

Adds a few permutations of the racecar and balanced field problems to help guage performance impacts of changes in the future.

### Related Issues

- Resolves #540 

Given the time it takes to run all of these benchmarks, the commercial aircraft example is omitted and fewer permutations of the testing matrix are included.

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
