### PR TITLE
Removed duplication of inputs to timeseries when multiple outputs may use the same source data.

### DIFF
--- a/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_control.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_control.py
@@ -81,7 +81,7 @@ class BrachistochroneODE(om.ExplicitComponent):
         jacobian['check', 'theta'] = -v * cos_theta / sin_theta**2
 
 
-# @use_tempdirs
+@use_tempdirs
 class TestBrachistochroneIntegratedControl(unittest.TestCase):
 
     @classmethod

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_control.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_control.py
@@ -134,6 +134,8 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         # Solve for the optimal trajectory
         p.run_driver()
 
+        p.model.list_outputs(units=True)
+
         # Test the results
         assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
@@ -212,8 +214,6 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         # Solve for the optimal trajectory
         dm.run_problem(p, simulate=True, make_plots=True)
 
-        p.model.list_outputs(units=True)
-
         sol_case = om.CaseReader('dymos_solution.db').get_case('final')
         sim_case = om.CaseReader('dymos_simulation.db').get_case('final')
 
@@ -239,9 +239,6 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         v_interp = interp1d(time_sim[:, 0], v_sim[:, 0])
         theta_interp = interp1d(time_sim[:, 0], theta_sim[:, 0])
         theta_dot_interp = interp1d(time_sim[:, 0], theta_dot_sim[:, 0])
-
-        with np.printoptions(linewidth=1024):
-            print(np.hstack(np.degrees(theta_dot_sol, theta_dot_sim)))
 
         assert_near_equal(x_interp(time_sol), x_sol, tolerance=1.0E-4)
         assert_near_equal(y_interp(time_sol), y_sol, tolerance=1.0E-4)

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_control.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_control.py
@@ -134,8 +134,6 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         # Solve for the optimal trajectory
         p.run_driver()
 
-        p.model.list_outputs(units=True)
-
         # Test the results
         assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_control.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_control.py
@@ -207,8 +207,7 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         p['traj.phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_input')
         p['traj.phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_input')
         p['traj.phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
-        p['traj.phase0.states:theta'] = np.radians(phase.interpolate(ys=[0.05, 100.0],
-                                                                nodes='state_input'))
+        p['traj.phase0.states:theta'] = np.radians(phase.interpolate(ys=[0.05, 100.0], nodes='state_input'))
         p['traj.phase0.controls:theta_dot'] = phase.interpolate(ys=[50, 50], nodes='control_input')
 
         # Solve for the optimal trajectory

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_control.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_control.py
@@ -81,7 +81,7 @@ class BrachistochroneODE(om.ExplicitComponent):
         jacobian['check', 'theta'] = -v * cos_theta / sin_theta**2
 
 
-@use_tempdirs
+# @use_tempdirs
 class TestBrachistochroneIntegratedControl(unittest.TestCase):
 
     @classmethod
@@ -174,9 +174,12 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
 
+        traj = dm.Trajectory()
+
         phase = dm.Phase(ode_class=BrachistochroneODE, transcription=dm.Radau(num_segments=10))
 
-        p.model.add_subsystem('phase0', phase)
+        traj.add_phase('phase0', phase)
+        p.model.add_subsystem('traj', traj)
 
         phase.set_time_options(initial_bounds=(0, 0), duration_bounds=(.5, 10), units='s')
 
@@ -193,41 +196,43 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         phase.add_objective('time', loc='final', scaler=10)
 
         p.model.linear_solver = om.DirectSolver()
-        p.model.options['assembled_jac_type'] = 'csc'
 
         p.setup()
 
-        p['phase0.t_initial'] = 0.0
-        p['phase0.t_duration'] = 2.0
+        p['traj.phase0.t_initial'] = 0.0
+        p['traj.phase0.t_duration'] = 2.0
 
-        p['phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_input')
-        p['phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_input')
-        p['phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
-        p['phase0.states:theta'] = np.radians(phase.interpolate(ys=[0.05, 100.0],
+        p['traj.phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_input')
+        p['traj.phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_input')
+        p['traj.phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+        p['traj.phase0.states:theta'] = np.radians(phase.interpolate(ys=[0.05, 100.0],
                                                                 nodes='state_input'))
-        p['phase0.controls:theta_dot'] = phase.interpolate(ys=[50, 50], nodes='control_input')
+        p['traj.phase0.controls:theta_dot'] = phase.interpolate(ys=[50, 50], nodes='control_input')
 
         # Solve for the optimal trajectory
-        p.run_driver()
+        dm.run_problem(p, simulate=True, make_plots=True)
+
+        p.model.list_outputs(units=True)
+
+        sol_case = om.CaseReader('dymos_solution.db').get_case('final')
+        sim_case = om.CaseReader('dymos_simulation.db').get_case('final')
 
         # Test the results
-        assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
+        assert_near_equal(sol_case.get_val('traj.phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
-        sim_out = phase.simulate(times_per_seg=20)
+        x_sol = sol_case.get_val('traj.phase0.timeseries.states:x')
+        y_sol = sol_case.get_val('traj.phase0.timeseries.states:y')
+        v_sol = sol_case.get_val('traj.phase0.timeseries.states:v')
+        theta_sol = sol_case.get_val('traj.phase0.timeseries.states:theta')
+        theta_dot_sol = sol_case.get_val('traj.phase0.timeseries.controls:theta_dot')
+        time_sol = sol_case.get_val('traj.phase0.timeseries.time')
 
-        x_sol = p.get_val('phase0.timeseries.states:x')
-        y_sol = p.get_val('phase0.timeseries.states:y')
-        v_sol = p.get_val('phase0.timeseries.states:v')
-        theta_sol = p.get_val('phase0.timeseries.states:theta')
-        theta_dot_sol = p.get_val('phase0.timeseries.controls:theta_dot')
-        time_sol = p.get_val('phase0.timeseries.time')
-
-        x_sim = sim_out.get_val('phase0.timeseries.states:x')
-        y_sim = sim_out.get_val('phase0.timeseries.states:y')
-        v_sim = sim_out.get_val('phase0.timeseries.states:v')
-        theta_sim = sim_out.get_val('phase0.timeseries.states:theta')
-        theta_dot_sim = sim_out.get_val('phase0.timeseries.controls:theta_dot')
-        time_sim = sim_out.get_val('phase0.timeseries.time')
+        x_sim = sim_case.get_val('traj.phase0.timeseries.states:x')
+        y_sim = sim_case.get_val('traj.phase0.timeseries.states:y')
+        v_sim = sim_case.get_val('traj.phase0.timeseries.states:v')
+        theta_sim = sim_case.get_val('traj.phase0.timeseries.states:theta')
+        theta_dot_sim = sim_case.get_val('traj.phase0.timeseries.controls:theta_dot')
+        time_sim = sim_case.get_val('traj.phase0.timeseries.time')
 
         x_interp = interp1d(time_sim[:, 0], x_sim[:, 0])
         y_interp = interp1d(time_sim[:, 0], y_sim[:, 0])
@@ -235,11 +240,14 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         theta_interp = interp1d(time_sim[:, 0], theta_sim[:, 0])
         theta_dot_interp = interp1d(time_sim[:, 0], theta_dot_sim[:, 0])
 
-        assert_near_equal(x_interp(time_sol), x_sol, tolerance=1.0E-5)
-        assert_near_equal(y_interp(time_sol), y_sol, tolerance=1.0E-5)
-        assert_near_equal(v_interp(time_sol), v_sol, tolerance=1.0E-5)
-        assert_near_equal(theta_interp(time_sol), theta_sol, tolerance=1.0E-5)
-        assert_near_equal(theta_dot_interp(time_sol), theta_dot_sol, tolerance=1.0E-5)
+        with np.printoptions(linewidth=1024):
+            print(np.hstack(np.degrees(theta_dot_sol, theta_dot_sim)))
+
+        assert_near_equal(x_interp(time_sol), x_sol, tolerance=1.0E-4)
+        assert_near_equal(y_interp(time_sol), y_sol, tolerance=1.0E-4)
+        assert_near_equal(v_interp(time_sol), v_sol, tolerance=1.0E-4)
+        assert_near_equal(theta_interp(time_sol), theta_sol, tolerance=1.0E-4)
+        assert_near_equal(theta_dot_interp(time_sol), theta_dot_sol, tolerance=1.0E-4)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/examples/brachistochrone/test/test_duplicate_timeseries_inputs.py
+++ b/dymos/examples/brachistochrone/test/test_duplicate_timeseries_inputs.py
@@ -1,0 +1,142 @@
+import io
+from contextlib import redirect_stdout
+import warnings
+import unittest
+
+import numpy as np
+
+import openmdao.api as om
+from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.assert_utils import assert_near_equal
+
+import dymos as dm
+from ..brachistochrone_ode import BrachistochroneODE
+
+
+@use_tempdirs
+class TestDuplicateTimeseriesInput(unittest.TestCase):
+
+    def _make_problem(self, transcription):
+
+        #
+        # Define the OpenMDAO problem
+        #
+        p = om.Problem(model=om.Group())
+
+        #
+        # Define a Trajectory object
+        #
+        traj = dm.Trajectory()
+
+        p.model.add_subsystem('traj', subsys=traj)
+
+        #
+        # Define a Dymos Phase object with GaussLobatto Transcription
+        #
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=transcription(num_segments=10, order=3))
+
+        traj.add_phase(name='phase0', phase=phase)
+
+        #
+        # Set the time options
+        # Time has no targets in our ODE.
+        # We fix the initial time so that the it is not a design variable in the optimization.
+        # The duration of the phase is allowed to be optimized, but is bounded on [0.5, 10].
+        #
+        phase.set_time_options(fix_initial=True, duration_bounds=(1.0, 10.0), units='s')
+
+        #
+        # Set the time options
+        # Initial values of positions and velocity are all fixed.
+        # The final value of position are fixed, but the final velocity is a free variable.
+        # The equations of motion are not functions of position, so 'x' and 'y' have no targets.
+        # The rate source points to the output in the ODE which provides the time derivative of the
+        # given state.
+        phase.add_state('x', fix_initial=True, fix_final=True)
+        phase.add_state('y', fix_initial=True, fix_final=True)
+        phase.add_state('v', fix_initial=True)
+
+        # Define theta as a control.
+        phase.add_control(name='theta', units='rad', lower=0.01, upper=np.pi-0.01, shape=(1,))
+
+        phase.add_timeseries_output('*')
+
+        # Minimize final time.
+        phase.add_objective('time', loc='final')
+
+        # Set the driver.
+        p.driver = om.ScipyOptimizeDriver()
+
+        # Allow OpenMDAO to automatically determine our sparsity pattern.
+        # Doing so can significant speed up the execution of Dymos.
+        p.driver.declare_coloring()
+
+        # Setup the problem
+        p.setup(check=True)
+
+        p.set_val('traj.phase0.t_initial', 0.0, units='s')
+        p.set_val('traj.phase0.t_duration', 5.0, units='s')
+
+        p.set_val('traj.phase0.states:x',
+                  phase.interpolate(ys=[0, 10], nodes='state_input'),
+                  units='m')
+
+        p.set_val('traj.phase0.states:y',
+                  phase.interpolate(ys=[10, 5], nodes='state_input'),
+                  units='m')
+
+        p.set_val('traj.phase0.states:v',
+                  phase.interpolate(ys=[0, 5], nodes='state_input'),
+                  units='m/s')
+
+        p.set_val('traj.phase0.controls:theta',
+                  phase.interpolate(ys=[0.01, 90], nodes='control_input'),
+                  units='deg')
+
+        return p
+
+    def test_duplicate_timeseries_input_gl(self):
+        p = self._make_problem(dm.GaussLobatto)
+
+        with io.StringIO() as buf, redirect_stdout(buf):
+            p.run_driver()
+            output = buf.getvalue()
+
+        # First check that the input duplication does not exist
+        warning_str = 'WARNING: The following components have multiple inputs connected to ' \
+                      'the same source, which can introduce unnecessary data transfer overhead:'
+
+        if warning_str in output:
+            raise AssertionError('Multiple inputs connected to the same source exist')
+
+        # Now check that the outputs are still the same.
+        x_rate_vals = p.get_val('traj.phase0.timeseries.state_rates:x')
+        xdot_vals = p.get_val('traj.phase0.timeseries.xdot')
+
+        print(p.get_val('traj.phase0.timeseries.states:x').T)
+        print(p.get_val('traj.phase0.timeseries.states:y').T)
+        print(p.get_val('traj.phase0.timeseries.states:v').T)
+        print(p.get_val('traj.phase0.timeseries.controls:theta').T)
+
+        assert_near_equal(x_rate_vals, xdot_vals)
+
+    def test_duplicate_timeseries_input_radau(self):
+        p = self._make_problem(dm.Radau)
+
+        with io.StringIO() as buf, redirect_stdout(buf):
+            p.run_model()
+            output = buf.getvalue()
+
+        # First check that the input duplication does not exist
+        warning_str = 'WARNING: The following components have multiple inputs connected to ' \
+                      'the same source, which can introduce unnecessary data transfer overhead:'
+
+        if warning_str in output:
+            raise AssertionError('Multiple inputs connected to the same source exist')
+
+        # Now check that the outputs are still the same.
+        x_rate_vals = p.get_val('traj.phase0.timeseries.state_rates:x')
+        xdot_vals = p.get_val('traj.phase0.timeseries.xdot')
+
+        assert_near_equal(x_rate_vals, xdot_vals)

--- a/dymos/examples/brachistochrone/test/test_timeseries_units.py
+++ b/dymos/examples/brachistochrone/test/test_timeseries_units.py
@@ -1,15 +1,12 @@
-
-import os
 import unittest
 
-import numpy as np
 import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.assert_utils import assert_near_equal
 import dymos as dm
 
 
-# @use_tempdirs
+@use_tempdirs
 class TestTimeseriesUnits(unittest.TestCase):
 
     def _make_problem(self, transcription='gauss-lobatto', num_segments=8, transcription_order=3,

--- a/dymos/examples/brachistochrone/test/test_timeseries_units.py
+++ b/dymos/examples/brachistochrone/test/test_timeseries_units.py
@@ -1,0 +1,113 @@
+
+import os
+import unittest
+
+import numpy as np
+import openmdao.api as om
+from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.assert_utils import assert_near_equal
+import dymos as dm
+
+
+# @use_tempdirs
+class TestTimeseriesUnits(unittest.TestCase):
+
+    def _make_problem(self, transcription='gauss-lobatto', num_segments=8, transcription_order=3,
+                      compressed=True, optimizer='SLSQP', run_driver=True, force_alloc_complex=False,
+                      solve_segments=False):
+
+        p = om.Problem(model=om.Group())
+
+        p.driver = om.pyOptSparseDriver()
+        p.driver.options['optimizer'] = optimizer
+        p.driver.declare_coloring(tol=1.0E-12)
+
+        if transcription == 'gauss-lobatto':
+            t = dm.GaussLobatto(num_segments=num_segments,
+                                order=transcription_order,
+                                compressed=compressed)
+        elif transcription == 'radau-ps':
+            t = dm.Radau(num_segments=num_segments,
+                         order=transcription_order,
+                         compressed=compressed)
+
+        ode = lambda num_nodes: om.ExecComp(['vdot = g * cos(theta)',
+                                             'xdot = v * sin(theta)',
+                                             'ydot = -v * cos(theta)'],
+                                            g={'value': 9.80665, 'units': 'm/s**2'},
+                                            v={'shape': (num_nodes,), 'units': 'm/s'},
+                                            theta={'shape': (num_nodes,), 'units': 'rad'},
+                                            vdot={'shape': (num_nodes,),
+                                                  'units': 'm/s**2',
+                                                  'tags': ['state_rate_source:v']},
+                                            xdot={'shape': (num_nodes,),
+                                                  'units': 'degR',
+                                                  'tags': ['state_rate_source:x']},
+                                            ydot={'shape': (num_nodes,),
+                                                  'units': 'degK',
+                                                  'tags': ['state_rate_source:y']},
+                                            has_diag_partials=True)
+
+        traj = dm.Trajectory()
+        phase = dm.Phase(ode_class=ode, transcription=t)
+        p.model.add_subsystem('traj0', traj)
+        traj.add_phase('phase0', phase)
+
+        phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
+
+        phase.add_state('x', fix_initial=True, fix_final=False, solve_segments=solve_segments)
+        phase.add_state('y', fix_initial=True, fix_final=False, solve_segments=solve_segments)
+
+        # Note that by omitting the targets here Dymos will automatically attempt to connect
+        # to a top-level input named 'v' in the ODE, and connect to nothing if it's not found.
+        phase.add_state('v', fix_initial=True, fix_final=False, solve_segments=solve_segments)
+
+        phase.add_control('theta',
+                          continuity=True, rate_continuity=True,
+                          units='deg', lower=0.01, upper=179.9)
+
+        phase.add_parameter('g', units='m/s**2', dynamic=False)
+
+        phase.add_boundary_constraint('x', loc='final', equals=10)
+        phase.add_boundary_constraint('y', loc='final', equals=5)
+        # Minimize time at the end of the phase
+        phase.add_objective('time_phase', loc='final', scaler=10)
+
+        phase.add_timeseries_output('xdot', units='degF')
+        phase.add_timeseries_output('ydot', units='degC')
+
+        p.setup(check=['unconnected_inputs'], force_alloc_complex=force_alloc_complex)
+
+        p['traj0.phase0.t_initial'] = 0.0
+        p['traj0.phase0.t_duration'] = 2.0
+
+        p['traj0.phase0.states:x'] = phase.interpolate(ys=[0, 10], nodes='state_input')
+        p['traj0.phase0.states:y'] = phase.interpolate(ys=[10, 5], nodes='state_input')
+        p['traj0.phase0.states:v'] = phase.interpolate(ys=[0, 9.9], nodes='state_input')
+        p['traj0.phase0.controls:theta'] = phase.interpolate(ys=[5, 100], nodes='control_input')
+        p['traj0.phase0.parameters:g'] = 9.80665
+
+        dm.run_problem(p, run_driver=run_driver, simulate=True)
+
+        sol_case = om.CaseReader('dymos_solution.db').get_case('final')
+        sim_case = om.CaseReader('dymos_simulation.db').get_case('final')
+
+        assert_near_equal(sol_case.get_val('traj0.phase0.timeseries.xdot', units='degF'),
+                          sol_case.get_val('traj0.phase0.timeseries.state_rates:x', units='degF'))
+
+        assert_near_equal(sol_case.get_val('traj0.phase0.timeseries.ydot', units='degC'),
+                          sol_case.get_val('traj0.phase0.timeseries.state_rates:y', units='degC'))
+
+        assert_near_equal(sim_case.get_val('traj0.phase0.timeseries.xdot', units='degF'),
+                          sim_case.get_val('traj0.phase0.timeseries.state_rates:x', units='degF'))
+
+        assert_near_equal(sim_case.get_val('traj0.phase0.timeseries.ydot', units='degC'),
+                          sim_case.get_val('traj0.phase0.timeseries.state_rates:y', units='degC'))
+
+        return p
+
+    def test_ex_brachistochrone_radau_uncompressed(self):
+        self._make_problem(transcription='radau-ps', compressed=False)
+
+    def test_ex_brachistochrone_gl_uncompressed(self):
+        self._make_problem(transcription='gauss-lobatto', compressed=False)

--- a/dymos/examples/double_integrator/test/test_double_integrator_timeseries_units.py
+++ b/dymos/examples/double_integrator/test/test_double_integrator_timeseries_units.py
@@ -1,0 +1,102 @@
+import itertools
+import os
+import unittest
+
+import openmdao.api as om
+from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
+
+import dymos as dm
+from dymos.examples.double_integrator.double_integrator_ode import DoubleIntegratorODE
+from dymos.utils.testing_utils import assert_timeseries_near_equal
+
+
+def double_integrator_direct_collocation(transcription=dm.GaussLobatto, compressed=True):
+
+    p = om.Problem(model=om.Group())
+    p.driver = om.pyOptSparseDriver()
+    p.driver.declare_coloring()
+
+    t = transcription(num_segments=30, order=3)
+
+    traj = p.model.add_subsystem('traj', dm.Trajectory())
+
+    phase = traj.add_phase('phase0', dm.Phase(ode_class=DoubleIntegratorODE, transcription=t))
+
+    phase.set_time_options(fix_initial=True, fix_duration=True, units='s')
+
+    phase.add_state('v', fix_initial=True, fix_final=True, rate_source='u', units='m/s')
+    phase.add_state('x', fix_initial=True, rate_source='v', units='ft', shape=(1, ))
+
+    phase.add_control('u', units='m/s**2', scaler=0.01, continuity=False, rate_continuity=False,
+                      rate2_continuity=False, shape=(1, ), lower=-1.0, upper=1.0)
+
+    # Maximize distance travelled in one second.
+    phase.add_objective('x', loc='final', scaler=-1)
+
+    p.model.linear_solver = om.DirectSolver()
+
+    p.setup(check=True)
+
+    p.set_val('traj.phase0.t_initial', 0.0)
+    p.set_val('traj.phase0.t_duration', 1.0)
+
+    p.set_val('traj.phase0.states:x', phase.interpolate(ys=[0, 0.25], nodes='state_input'), units='m')
+    p.set_val('traj.phase0.states:v', phase.interpolate(ys=[0, 0], nodes='state_input'), units='m/s')
+    p.set_val('traj.phase0.controls:u', phase.interpolate(ys=[1, -1], nodes='control_input'), units='m/s**2')
+
+    dm.run_problem(p, simulate=True, make_plots=True)
+
+    return p
+
+
+@use_tempdirs
+class TestDoubleIntegratorExample(unittest.TestCase):
+
+    @classmethod
+    def tearDownClass(cls):
+        for filename in ['total_coloring.pkl', 'SLSQP.out', 'SNOPT_print.out']:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    def _assert_results(self, p, traj=True, tol=1.0E-4):
+        if traj:
+            x = p.get_val('traj.phase0.timeseries.states:x')
+            v = p.get_val('traj.phase0.timeseries.states:v')
+        else:
+            x = p.get_val('phase0.timeseries.states:x')
+            v = p.get_val('phase0.timeseries.states:v')
+
+        assert_near_equal(x[0], 0.0, tolerance=tol)
+        assert_near_equal(x[-1], 0.25, tolerance=tol)
+
+        assert_near_equal(v[0], 0.0, tolerance=tol)
+        assert_near_equal(v[-1], 0.0, tolerance=tol)
+
+    def test_timeseries_units_gl(self):
+        double_integrator_direct_collocation(dm.GaussLobatto, compressed=True)
+
+        sol_case = om.CaseReader('dymos_solution.db').get_case('final')
+        sim_case = om.CaseReader('dymos_simulation.db').get_case('final')
+
+        t_sol = sol_case.get_val('traj.phase0.timeseries.time')
+        t_sim = sim_case.get_val('traj.phase0.timeseries.time')
+
+        for var in ['states:x', 'states:v', 'state_rates:x', 'state_rates:v', 'controls:u']:
+            sol = sol_case.get_val(f'traj.phase0.timeseries.{var}')
+            sim = sim_case.get_val(f'traj.phase0.timeseries.{var}')
+            assert_timeseries_near_equal(t_sol, sol, t_sim, sim, tolerance=1.0E-3)
+
+    def test_timeseries_units_radau(self):
+        double_integrator_direct_collocation(dm.Radau, compressed=True)
+
+        sol_case = om.CaseReader('dymos_solution.db').get_case('final')
+        sim_case = om.CaseReader('dymos_simulation.db').get_case('final')
+
+        t_sol = sol_case.get_val('traj.phase0.timeseries.time')
+        t_sim = sim_case.get_val('traj.phase0.timeseries.time')
+
+        for var in ['states:x', 'states:v', 'state_rates:x', 'state_rates:v']:
+            sol = sol_case.get_val(f'traj.phase0.timeseries.{var}')
+            sim = sim_case.get_val(f'traj.phase0.timeseries.{var}')
+            assert_timeseries_near_equal(t_sol, sol, t_sim, sim, tolerance=1.0E-3)

--- a/dymos/examples/double_integrator/test/test_double_integrator_timeseries_units.py
+++ b/dymos/examples/double_integrator/test/test_double_integrator_timeseries_units.py
@@ -96,7 +96,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         t_sol = sol_case.get_val('traj.phase0.timeseries.time')
         t_sim = sim_case.get_val('traj.phase0.timeseries.time')
 
-        for var in ['states:x', 'states:v', 'state_rates:x', 'state_rates:v']:
+        for var in ['states:x', 'states:v', 'state_rates:x']:
             sol = sol_case.get_val(f'traj.phase0.timeseries.{var}')
             sim = sim_case.get_val(f'traj.phase0.timeseries.{var}')
             assert_timeseries_near_equal(t_sol, sol, t_sim, sim, tolerance=1.0E-3)

--- a/dymos/examples/flying_robot/test/test_flying_robot.py
+++ b/dymos/examples/flying_robot/test/test_flying_robot.py
@@ -15,13 +15,12 @@ def flying_robot_direct_collocation(transcription='gauss-lobatto', compressed=Tr
     p = om.Problem(model=om.Group())
     p.driver = om.pyOptSparseDriver()
     p.driver.options['optimizer'] = 'SLSQP'
-    # p.driver.opt_settings['iSumm'] = 6
     p.driver.declare_coloring()
 
     if transcription == 'gauss-lobatto':
-        t = dm.GaussLobatto(num_segments=10, order=5, compressed=compressed)
+        t = dm.GaussLobatto(num_segments=8, order=5, compressed=compressed)
     elif transcription == "radau-ps":
-        t = dm.Radau(num_segments=10, order=5, compressed=compressed)
+        t = dm.Radau(num_segments=8, order=5, compressed=compressed)
     else:
         raise ValueError('invalid transcription')
 

--- a/dymos/examples/racecar/doc/test_doc_racecar.py
+++ b/dymos/examples/racecar/doc/test_doc_racecar.py
@@ -1,12 +1,7 @@
 import unittest
 
-import matplotlib.pyplot as plt
-import matplotlib as mpl
-
 from dymos.utils.doc_utils import save_for_docs
 from openmdao.utils.testing_utils import use_tempdirs
-
-plt.switch_backend('Agg')
 
 
 @use_tempdirs
@@ -17,6 +12,8 @@ class TestRaceCarForDocs(unittest.TestCase):
         import numpy as np
         import openmdao.api as om
         import dymos as dm
+        import matplotlib.pyplot as plt
+        import matplotlib as mpl
 
         from dymos.examples.racecar.combinedODE import CombinedODE
         from dymos.examples.racecar.spline import (get_spline, get_track_points, get_gate_normals,

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -1,5 +1,4 @@
-from collections import Callable
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Sequence, Callable
 import inspect
 import warnings
 

--- a/dymos/transcriptions/common/timeseries_output_comp.py
+++ b/dymos/transcriptions/common/timeseries_output_comp.py
@@ -198,7 +198,11 @@ class PseudospectralTimeseriesOutputComp(TimeseriesOutputCompBase):
 
         # There's a chance that the input for this output was pulled from another variable with
         # different units, so account for that with a conversion.
-        scale, offset = unit_conversion(input_units, units)
+        if None in {input_units, units}:
+            scale = 1.0
+            offset = 0
+        else:
+            scale, offset = unit_conversion(input_units, units)
         self._conversion_factors[output_name] = scale, offset
 
         self.declare_partials(of=output_name,

--- a/dymos/transcriptions/pseudospectral/components/gauss_lobatto_interleave_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/gauss_lobatto_interleave_comp.py
@@ -115,7 +115,11 @@ class GaussLobattoInterleaveComp(om.ExplicitComponent):
 
         # There's a chance that the input for this output was pulled from another variable with
         # different units, so account for that with a conversion.
-        scale, offset = unit_conversion(input_units, units)
+        if None in {input_units, units}:
+            scale = 1.0
+            offset = 0
+        else:
+            scale, offset = unit_conversion(input_units, units)
         self._conversion_factors[self._varnames[name]['all']] = scale, offset
 
         self.declare_partials(of=self._varnames[name]['all'],

--- a/dymos/transcriptions/pseudospectral/components/gauss_lobatto_interleave_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/gauss_lobatto_interleave_comp.py
@@ -1,5 +1,6 @@
 import numpy as np
 import openmdao.api as om
+from openmdao.utils.units import unit_conversion
 
 from ...grid_data import GridData
 from ....options import options as dymos_options
@@ -32,6 +33,11 @@ class GaussLobattoInterleaveComp(om.ExplicitComponent):
         # the corresponding input variable.  This is used to ensure that we don't need to connect
         # the same source to this timeseries multiple times.
         self._sources = {'disc': {}, 'col': {}}
+
+        # Used to track conversion factors for instances when one output that relies on an input
+        # from another variable has potentially different units
+        self._units = {}
+        self._conversion_factors = {}
 
     def add_var(self, name, shape, units, disc_src, col_src):
         """
@@ -80,6 +86,7 @@ class GaussLobattoInterleaveComp(om.ExplicitComponent):
         if disc_src in self._sources['disc']:
             self._varnames[name]['disc'] = self._sources['disc'][disc_src]
             self._varnames[name]['col'] = self._sources['col'][col_src]
+            input_units = self._units[self._varnames[name]['disc']]
         else:
             self.add_input(
                 name=self._varnames[name]['disc'],
@@ -93,6 +100,7 @@ class GaussLobattoInterleaveComp(om.ExplicitComponent):
                 units=units)
             self._sources['disc'][disc_src] = self._varnames[name]['disc']
             self._sources['col'][col_src] = self._varnames[name]['col']
+            input_units = self._units[self._varnames[name]['disc']] = units
             added_source = True
 
         self.add_output(
@@ -105,9 +113,14 @@ class GaussLobattoInterleaveComp(om.ExplicitComponent):
         r = (start_rows[:, np.newaxis] + np.arange(size, dtype=int)).ravel()
         c = np.arange(size * num_disc_nodes, dtype=int)
 
+        # There's a chance that the input for this output was pulled from another variable with
+        # different units, so account for that with a conversion.
+        scale, offset = unit_conversion(input_units, units)
+        self._conversion_factors[self._varnames[name]['all']] = scale, offset
+
         self.declare_partials(of=self._varnames[name]['all'],
                               wrt=self._varnames[name]['disc'],
-                              rows=r, cols=c, val=1.0)
+                              rows=r, cols=c, val=scale)
 
         start_rows = self.options['grid_data'].subset_node_indices['col'] * size
         r = (start_rows[:, np.newaxis] + np.arange(size, dtype=int)).ravel()
@@ -115,7 +128,7 @@ class GaussLobattoInterleaveComp(om.ExplicitComponent):
 
         self.declare_partials(of=self._varnames[name]['all'],
                               wrt=self._varnames[name]['col'],
-                              rows=r, cols=c, val=1.0)
+                              rows=r, cols=c, val=scale)
 
         return added_source
 
@@ -134,5 +147,8 @@ class GaussLobattoInterleaveComp(om.ExplicitComponent):
         col_idxs = self.options['grid_data'].subset_node_indices['col']
 
         for name, varnames in self._varnames.items():
+            scale, offset = self._conversion_factors[self._varnames[name]['all']]
             outputs[varnames['all']][disc_idxs] = inputs[varnames['disc']]
             outputs[varnames['all']][col_idxs] = inputs[varnames['col']]
+            outputs[varnames['all']] *= scale
+            outputs[varnames['all']] += offset

--- a/dymos/transcriptions/pseudospectral/components/test/test_gauss_lobatto_interleave_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_gauss_lobatto_interleave_comp.py
@@ -53,9 +53,9 @@ class TestGaussLobattoInterleaveComp(unittest.TestCase):
         glic = self.p.model.add_subsystem('interleave_comp',
                                           subsys=GaussLobattoInterleaveComp(grid_data=gd))
 
-        glic.add_var('u', **state_options['u'])
-        glic.add_var('v', **state_options['v'])
-        glic.add_var('vehicle_cg', **ode_outputs['vehicle_cg'])
+        glic.add_var('u', **state_options['u'], disc_src='state_disc:u', col_src='state_col:u')
+        glic.add_var('v', **state_options['v'], disc_src='state_disc:v', col_src='state_col:v')
+        glic.add_var('vehicle_cg', **ode_outputs['vehicle_cg'], disc_src='ode_disc:cg', col_src='ode_col:cg')
 
         self.p.model.connect('state_disc:u', 'interleave_comp.disc_values:u')
         self.p.model.connect('state_disc:v', 'interleave_comp.disc_values:v')

--- a/dymos/transcriptions/pseudospectral/gauss_lobatto.py
+++ b/dymos/transcriptions/pseudospectral/gauss_lobatto.py
@@ -233,11 +233,11 @@ class GaussLobatto(PseudospectralBase):
             targets = get_targets(ode=phase.rhs_disc, name=name, user_targets=options['targets'])
 
             if targets:
-                phase.connect('states:{0}'.format(name),
-                              ['rhs_disc.{0}'.format(tgt) for tgt in targets],
+                phase.connect(f'states:{name}',
+                              [f'rhs_disc.{tgt}' for tgt in targets],
                               src_indices=src_idxs)
-                phase.connect('state_interp.state_col:{0}'.format(name),
-                              ['rhs_col.{0}'.format(tgt) for tgt in targets])
+                phase.connect(f'state_interp.state_col:{name}',
+                              [f'rhs_col.{tgt}' for tgt in targets])
 
             rate_src = options['rate_source']
             if rate_src in phase.parameter_options:
@@ -252,14 +252,14 @@ class GaussLobatto(PseudospectralBase):
                 phase.promotes('state_interp',
                                inputs=[(f'staterate_disc:{name}', f'parameters:{rate_src}')],
                                src_indices=src_idxs, flat_src_indices=True, src_shape=shape)
-                phase.promotes('interleave_comp',
-                               inputs=[(f'disc_values:state_rates:{name}', f'parameters:{rate_src}')],
-                               src_indices=src_idxs, flat_src_indices=True, src_shape=shape)
-                src_idxs = np.tile(np.arange(0, param_size, dtype=int), ncn)
-                src_idxs = np.reshape(src_idxs, (ncn,) + shape)
-                phase.promotes('interleave_comp',
-                               inputs=[(f'col_values:state_rates:{name}', f'parameters:{rate_src}')],
-                               src_indices=src_idxs, flat_src_indices=True, src_shape=shape)
+                # phase.promotes('interleave_comp',
+                #                inputs=[(f'disc_values:state_rates:{name}', f'parameters:{rate_src}')],
+                #                src_indices=src_idxs, flat_src_indices=True, src_shape=shape)
+                # src_idxs = np.tile(np.arange(0, param_size, dtype=int), ncn)
+                # src_idxs = np.reshape(src_idxs, (ncn,) + shape)
+                # phase.promotes('interleave_comp',
+                #                inputs=[(f'col_values:state_rates:{name}', f'parameters:{rate_src}')],
+                #                src_indices=src_idxs, flat_src_indices=True, src_shape=shape)
             else:
                 rate_path, disc_src_idxs = self.get_rate_source_path(name, nodes='state_disc',
                                                                      phase=phase)
@@ -267,15 +267,15 @@ class GaussLobatto(PseudospectralBase):
                               'state_interp.staterate_disc:{0}'.format(name),
                               src_indices=disc_src_idxs)
 
-                phase.connect(rate_path,
-                              'interleave_comp.disc_values:state_rates:{0}'.format(name),
-                              src_indices=disc_src_idxs)
-
-                rate_path, col_src_idxs = self.get_rate_source_path(name, nodes='col', phase=phase)
-
-                phase.connect(rate_path,
-                              'interleave_comp.col_values:state_rates:{0}'.format(name),
-                              src_indices=col_src_idxs)
+                # phase.connect(rate_path,
+                #               'interleave_comp.disc_values:state_rates:{0}'.format(name),
+                #               src_indices=disc_src_idxs)
+                #
+                # rate_path, col_src_idxs = self.get_rate_source_path(name, nodes='col', phase=phase)
+                #
+                # phase.connect(rate_path,
+                #               'interleave_comp.col_values:state_rates:{0}'.format(name),
+                #               src_indices=col_src_idxs)
 
         self.configure_interleave_comp(phase)
 
@@ -288,28 +288,77 @@ class GaussLobatto(PseudospectralBase):
         phase : dymos.Phase
             The phase object to which this transcription instance applies.
         """
+        interleave_comp = phase._get_subsystem('interleave_comp')
         map_input_indices_to_disc = self.grid_data.input_maps['state_input_to_disc']
 
         time_units = phase.time_options['units']
-        #
-        # First do the states
-        #
+
         for state_name, options in phase.state_options.items():
             shape = options['shape']
             units = options['units']
+            rate_src = options['rate_source']
 
-            interleave_comp = phase._get_subsystem('interleave_comp')
+            # Add the state values to the interleave comp
+            src_added = interleave_comp.add_var(f'states:{state_name}', shape, units,
+                                                disc_src=f'states:{state_name}',
+                                                col_src=f'state_interp.state_col:{state_name}')
 
-            interleave_comp.add_var('states:{0}'.format(state_name), shape, units)
-            interleave_comp.add_var('state_rates:{0}'.format(state_name), shape,
-                                    get_rate_units(options['units'], time_units))
+            if src_added:
+                phase.connect(f'states:{state_name}',
+                              f'interleave_comp.disc_values:states:{state_name}',
+                              src_indices=om.slicer[map_input_indices_to_disc, ...])
 
-            phase.connect('states:{0}'.format(state_name),
-                          'interleave_comp.disc_values:states:{0}'.format(state_name),
-                          src_indices=om.slicer[map_input_indices_to_disc, ...])
+                phase.connect(f'state_interp.state_col:{state_name}',
+                              f'interleave_comp.col_values:states:{state_name}')
 
-            phase.connect('state_interp.state_col:{0}'.format(state_name),
-                          'interleave_comp.col_values:states:{0}'.format(state_name))
+            # Add the state rates to the interleave comp
+
+            if rate_src in phase.parameter_options:
+                rate_path_disc = rate_path_col = f'parameters:{rate_src}'
+            else:
+                rate_path_disc, disc_src_idxs = self.get_rate_source_path(state_name,
+                                                                          nodes='state_disc',
+                                                                          phase=phase)
+                rate_path_col, col_src_idxs = self.get_rate_source_path(state_name,
+                                                                        nodes='col',
+                                                                        phase=phase)
+
+            src_added = interleave_comp.add_var(f'state_rates:{state_name}', shape,
+                                                units=get_rate_units(options['units'], time_units),
+                                                disc_src=rate_path_disc, col_src=rate_path_col)
+
+            if src_added:
+                if rate_src in phase.parameter_options:
+                    # If the rate source is a parameter, which is an input, we need to promote
+                    # f_computed to the parameter name instead of connecting to it.
+                    shape = phase.parameter_options[rate_src]['shape']
+                    param_size = np.prod(shape)
+                    ndn = self.grid_data.subset_num_nodes['disc']
+                    ncn = self.grid_data.subset_num_nodes['col']
+                    src_idxs = np.tile(np.arange(0, param_size, dtype=int), ndn)
+                    src_idxs = np.reshape(src_idxs, (ndn,) + shape)
+                    phase.promotes('interleave_comp',
+                                   inputs=[(f'disc_values:state_rates:{state_name}', f'parameters:{rate_src}')],
+                                   src_indices=src_idxs, flat_src_indices=True, src_shape=shape)
+                    src_idxs = np.tile(np.arange(0, param_size, dtype=int), ncn)
+                    src_idxs = np.reshape(src_idxs, (ncn,) + shape)
+                    phase.promotes('interleave_comp',
+                                   inputs=[(f'col_values:state_rates:{state_name}', f'parameters:{rate_src}')],
+                                   src_indices=src_idxs, flat_src_indices=True, src_shape=shape)
+                else:
+                    rate_path_disc, disc_src_idxs = self.get_rate_source_path(state_name,
+                                                                              nodes='state_disc',
+                                                                              phase=phase)
+                    phase.connect(rate_path_disc,
+                                  f'interleave_comp.disc_values:state_rates:{state_name}',
+                                  src_indices=disc_src_idxs)
+
+                    rate_path_col, col_src_idxs = self.get_rate_source_path(state_name,
+                                                                            nodes='col',
+                                                                            phase=phase)
+                    phase.connect(rate_path_col,
+                                  f'interleave_comp.col_values:state_rates:{state_name}',
+                                  src_indices=col_src_idxs)
 
     def setup_defects(self, phase):
         """
@@ -443,11 +492,15 @@ class GaussLobatto(PseudospectralBase):
                     shape = (1,) if len(ode_outputs[var]['shape']) == 1 else ode_outputs[var]['shape'][1:]
                     units = ode_outputs[var]['units'] if con_units is None else con_units
 
-                    if interleave_comp.add_var(con_name, shape, units):
-                        phase.connect(src_name='rhs_disc.{0}'.format(var),
-                                      tgt_name='interleave_comp.disc_values:{0}'.format(con_name))
-                        phase.connect(src_name='rhs_col.{0}'.format(var),
-                                      tgt_name='interleave_comp.col_values:{0}'.format(con_name))
+                    src_added = interleave_comp.add_var(con_name, shape, units,
+                                                        disc_src=f'rhs_disc.{var}',
+                                                        col_src=f'rhs_col.{var}')
+
+                    if src_added:
+                        phase.connect(src_name=f'rhs_disc.{var}',
+                                      tgt_name=f'interleave_comp.disc_values:{con_name}')
+                        phase.connect(src_name=f'rhs_col.{var}',
+                                      tgt_name=f'interleave_comp.col_values:{con_name}')
                 else:
                     raise ValueError(f'Path-constrained variable {var} is not a known variable in'
                                      f' the phase {phase.pathname} nor is it a known output of '
@@ -468,8 +521,8 @@ class GaussLobatto(PseudospectralBase):
             timeseries_comp = phase._get_subsystem(timeseries_name)
             time_units = phase.time_options['units']
 
-            timeseries_comp._add_output_configure('time', units=time_units, shape=(1,))
-            timeseries_comp._add_output_configure('time_phase', units=time_units, shape=(1,))
+            timeseries_comp._add_output_configure('time', units=time_units, shape=(1,), src='time')
+            timeseries_comp._add_output_configure('time_phase', units=time_units, shape=(1,), src='time_phase')
 
             phase.connect(src_name='time', tgt_name=f'{timeseries_name}.input_values:time')
             phase.connect(src_name='time_phase', tgt_name=f'{timeseries_name}.input_values:time_phase')
@@ -478,12 +531,14 @@ class GaussLobatto(PseudospectralBase):
                 timeseries_comp._add_output_configure(f'states:{state_name}',
                                                       shape=options['shape'],
                                                       units=options['units'],
-                                                      desc=options['desc'])
+                                                      desc=options['desc'],
+                                                      src=f'interleave_comp.all_values:states:{state_name}')
 
                 timeseries_comp._add_output_configure(f'state_rates:{state_name}',
                                                       shape=options['shape'],
                                                       units=get_rate_units(options['units'], time_units),
-                                                      desc=f'time-derivative of state {state_name}')
+                                                      desc=f'time-derivative of state {state_name}',
+                                                      src=f'interleave_comp.all_values:state_rates:{state_name}')
 
                 phase.connect(src_name=f'interleave_comp.all_values:states:{state_name}',
                               tgt_name=f'{timeseries_name}.input_values:states:{state_name}')
@@ -498,7 +553,8 @@ class GaussLobatto(PseudospectralBase):
                 timeseries_comp._add_output_configure(f'controls:{control_name}',
                                                       shape=options['shape'],
                                                       units=control_units,
-                                                      desc=options['desc'])
+                                                      desc=options['desc'],
+                                                      src=f'control_values:{control_name}')
 
                 phase.connect(src_name=f'control_values:{control_name}',
                               tgt_name=f'{timeseries_name}.input_values:controls:{control_name}')
@@ -508,7 +564,8 @@ class GaussLobatto(PseudospectralBase):
                                                       shape=options['shape'],
                                                       units=get_rate_units(control_units,
                                                                            time_units, deriv=1),
-                                                      desc=f'first time-derivative of {control_name}')
+                                                      desc=f'first time-derivative of {control_name}',
+                                                      src=f'control_rates:{control_name}_rate')
 
                 phase.connect(src_name=f'control_rates:{control_name}_rate',
                               tgt_name=f'{timeseries_name}.input_values:control_rates:{control_name}_rate')
@@ -518,7 +575,8 @@ class GaussLobatto(PseudospectralBase):
                                                       shape=options['shape'],
                                                       units=get_rate_units(control_units,
                                                                            time_units, deriv=2),
-                                                      desc=f'second time-derivative of {control_name}')
+                                                      desc=f'second time-derivative of {control_name}',
+                                                      src=f'control_rates:{control_name}_rate2')
 
                 phase.connect(src_name=f'control_rates:{control_name}_rate2',
                               tgt_name=f'{timeseries_name}.input_values:control_rates:{control_name}_rate2')
@@ -534,7 +592,8 @@ class GaussLobatto(PseudospectralBase):
                 timeseries_comp._add_output_configure(f'polynomial_controls:{control_name}',
                                                       shape=options['shape'],
                                                       units=control_units,
-                                                      desc=options['desc'])
+                                                      desc=options['desc'],
+                                                      src=f'polynomial_control_values:{control_name}')
 
                 # Control rates
                 phase.connect(src_name=f'polynomial_control_rates:{control_name}_rate',
@@ -545,7 +604,8 @@ class GaussLobatto(PseudospectralBase):
                                                       shape=options['shape'],
                                                       units=get_rate_units(control_units,
                                                                            time_units, deriv=1),
-                                                      desc=f'first time-derivative of {control_name}')
+                                                      desc=f'first time-derivative of {control_name}',
+                                                      src=f'polynomial_control_rates:{control_name}_rate')
 
                 # Control second derivatives
                 phase.connect(src_name=f'polynomial_control_rates:{control_name}_rate2',
@@ -556,7 +616,8 @@ class GaussLobatto(PseudospectralBase):
                                                       shape=options['shape'],
                                                       units=get_rate_units(control_units,
                                                                            time_units, deriv=2),
-                                                      desc=f'second time-derivative of {control_name}')
+                                                      desc=f'second time-derivative of {control_name}',
+                                                      src=f'polynomial_control_rates:{control_name}_rate2')
 
             for param_name, options in phase.parameter_options.items():
                 if options['include_timeseries']:
@@ -568,7 +629,8 @@ class GaussLobatto(PseudospectralBase):
                     timeseries_comp._add_output_configure(prom_name,
                                                           desc='',
                                                           shape=options['shape'],
-                                                          units=options['units'])
+                                                          units=options['units'],
+                                                          src=prom_name)
 
                     src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
                     src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
@@ -622,7 +684,8 @@ class GaussLobatto(PseudospectralBase):
                                          f' the ODE.')
 
                     try:
-                        timeseries_comp._add_output_configure(output_name, units, shape)
+                        timeseries_comp._add_output_configure(output_name, units, shape,
+                                                              src=f'interleave_comp.all_values:{output_name}')
                     except ValueError as e:  # OK if it already exists
                         if 'already exists' in str(e):
                             continue
@@ -630,7 +693,10 @@ class GaussLobatto(PseudospectralBase):
                             raise e
 
                     interleave_comp = phase._get_subsystem('interleave_comp')
-                    if interleave_comp.add_var(output_name, shape, units):
+                    src_added = interleave_comp.add_var(output_name, shape, units,
+                                                        disc_src=f'rhs_disc.{v}',
+                                                        col_src=f'rhs_col.{v}')
+                    if src_added:
                         phase.connect(src_name=f'rhs_disc.{v}',
                                       tgt_name=f'interleave_comp.disc_values:{output_name}')
                         phase.connect(src_name=f'rhs_col.{v}',

--- a/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
+++ b/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
@@ -516,7 +516,7 @@ class Radau(PseudospectralBase):
                         continue
 
                     # If the full shape does not start with num_nodes, skip this variable.
-                    if self.is_static_ode_output(v, phase):
+                    if self.is_static_ode_output(v, phase, gd.subset_num_nodes['all']):
                         warnings.warn(f'Cannot add ODE output {v} to the timeseries output. It is '
                                       f'sized such that its first dimension != num_nodes.')
                         continue
@@ -530,17 +530,11 @@ class Radau(PseudospectralBase):
                                          f' the phase {phase.pathname} nor is it a known output of '
                                          f' the ODE.')
 
-                    try:
-                        add_connecction = timeseries_comp._add_output_configure(output_name, units,
-                                                                                shape, desc='',
-                                                                                src=f'rhs_all.{v}')
-                    except ValueError as e:  # OK if it already exists
-                        if 'already exists' in str(e):
-                            continue
-                        else:
-                            raise e
+                    add_connection = timeseries_comp._add_output_configure(output_name, units,
+                                                                           shape, desc='',
+                                                                           src=f'rhs_all.{v}')
 
-                    if add_connecction:
+                    if add_connection:
                         phase.connect(src_name=f'rhs_all.{v}',
                                       tgt_name=f'{timeseries_name}.input_values:{output_name}')
 

--- a/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
+++ b/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
@@ -320,34 +320,34 @@ class Radau(PseudospectralBase):
         for timeseries_name in phase._timeseries:
             timeseries_comp = phase._get_subsystem(timeseries_name)
 
-            phase.connect(src_name='time', tgt_name=f'{timeseries_name}.input_values:time')
-            phase.connect(src_name='time_phase', tgt_name=f'{timeseries_name}.input_values:time_phase')
-
             timeseries_comp._add_output_configure('time',
                                                   shape=(1,),
                                                   units=time_units,
-                                                  desc='')
+                                                  desc='',
+                                                  src='time')
 
             timeseries_comp._add_output_configure('time_phase',
                                                   shape=(1,),
                                                   units=time_units,
-                                                  desc='')
+                                                  desc='',
+                                                  src='time_pahse')
+
+            phase.connect(src_name='time', tgt_name=f'{timeseries_name}.input_values:time')
+
+            phase.connect(src_name='time_phase', tgt_name=f'{timeseries_name}.input_values:time_phase')
 
             for state_name, options in phase.state_options.items():
-                timeseries_comp._add_output_configure(f'states:{state_name}',
-                                                      shape=options['shape'],
-                                                      units=options['units'],
-                                                      desc=options['desc'])
 
-                timeseries_comp._add_output_configure(f'state_rates:{state_name}',
-                                                      shape=options['shape'],
-                                                      units=get_rate_units(options['units'], time_units),
-                                                      desc=f'rate of state {state_name}')
-
-                src_rows = gd.input_maps['state_input_to_disc']
-                phase.connect(src_name=f'states:{state_name}',
-                              tgt_name=f'{timeseries_name}.input_values:states:{state_name}',
-                              src_indices=om.slicer[src_rows, ...])
+                added_src = timeseries_comp._add_output_configure(f'states:{state_name}',
+                                                                  shape=options['shape'],
+                                                                  units=options['units'],
+                                                                  desc=options['desc'],
+                                                                  src=f'states:{state_name}')
+                if added_src:
+                    src_rows = gd.input_maps['state_input_to_disc']
+                    phase.connect(src_name=f'states:{state_name}',
+                                  tgt_name=f'{timeseries_name}.input_values:states:{state_name}',
+                                  src_indices=om.slicer[src_rows, ...])
 
                 rate_src = options['rate_source']
                 if rate_src in phase.parameter_options:
@@ -358,49 +358,74 @@ class Radau(PseudospectralBase):
                     param_size = np.prod(shape)
                     src_idxs = np.tile(np.arange(0, param_size, dtype=int), nn)
                     src_idxs = np.reshape(src_idxs, (nn,) + shape)
-                    phase.promotes(f'{timeseries_name}',
-                                   inputs=[(f'input_values:state_rates:{state_name}',
-                                            f'parameters:{rate_src}')],
-                                   src_indices=src_idxs, flat_src_indices=True, src_shape=shape)
+                    rate_src_path = f'parameters:{rate_src}'
+
+                    added_src = timeseries_comp._add_output_configure(f'state_rates:{state_name}',
+                                                                      shape=options['shape'],
+                                                                      units=get_rate_units(
+                                                                          options['units'],
+                                                                          time_units),
+                                                                      desc=f'rate of state {state_name}',
+                                                                      src=rate_src_path)
+
+                    if added_src:
+                        phase.promotes(f'{timeseries_name}',
+                                       inputs=[(f'input_values:state_rates:{state_name}',
+                                                f'parameters:{rate_src}')],
+                                       src_indices=src_idxs, flat_src_indices=True, src_shape=shape)
+
                 else:
                     rate_src_path, src_idxs = self.get_rate_source_path(state_name, 'all', phase)
-                    phase.connect(src_name=rate_src_path,
-                                  tgt_name=f'{timeseries_name}.input_values:state_rates:{state_name}',
-                                  src_indices=src_idxs)
+
+                    added_src = timeseries_comp._add_output_configure(f'state_rates:{state_name}',
+                                                                      shape=options['shape'],
+                                                                      units=get_rate_units(
+                                                                          options['units'],
+                                                                          time_units),
+                                                                      desc=f'rate of state {state_name}',
+                                                                      src=rate_src_path)
+                    if added_src:
+                        phase.connect(src_name=rate_src_path,
+                                      tgt_name=f'{timeseries_name}.input_values:state_rates:{state_name}',
+                                      src_indices=src_idxs)
 
             for control_name, options in phase.control_options.items():
                 control_units = options['units']
                 src_rows = gd.subset_node_indices['all']
                 src_idxs = get_src_indices_by_row(src_rows, options['shape'])
 
-                timeseries_comp._add_output_configure(f'controls:{control_name}',
-                                                      shape=options['shape'],
-                                                      units=control_units,
-                                                      desc=options['desc'])
-
-                phase.connect(src_name=f'control_values:{control_name}',
-                              tgt_name=f'{timeseries_name}.input_values:controls:{control_name}',
-                              src_indices=src_idxs, flat_src_indices=True)
+                added_src = timeseries_comp._add_output_configure(f'controls:{control_name}',
+                                                                  shape=options['shape'],
+                                                                  units=control_units,
+                                                                  desc=options['desc'],
+                                                                  src=f'control_values:{control_name}')
+                if added_src:
+                    phase.connect(src_name=f'control_values:{control_name}',
+                                  tgt_name=f'{timeseries_name}.input_values:controls:{control_name}',
+                                  src_indices=src_idxs, flat_src_indices=True)
 
                 # Control rates
-                timeseries_comp._add_output_configure(f'control_rates:{control_name}_rate',
-                                                      shape=options['shape'],
-                                                      units=get_rate_units(control_units,
-                                                                           time_units, deriv=1),
-                                                      desc=f'first time-derivative of {control_name}')
-
-                phase.connect(src_name=f'control_rates:{control_name}_rate',
-                              tgt_name=f'{timeseries_name}.input_values:control_rates:{control_name}_rate')
+                added_src = timeseries_comp._add_output_configure(f'control_rates:{control_name}_rate',
+                                                                  shape=options['shape'],
+                                                                  units=get_rate_units(control_units,
+                                                                                       time_units, deriv=1),
+                                                                  desc=f'first time-derivative of {control_name}',
+                                                                  src=f'control_rates:{control_name}_rate')
+                if added_src:
+                    phase.connect(src_name=f'control_rates:{control_name}_rate',
+                                  tgt_name=f'{timeseries_name}.input_values:control_rates:{control_name}_rate')
 
                 # Control second derivatives
-                timeseries_comp._add_output_configure(f'control_rates:{control_name}_rate2',
-                                                      shape=options['shape'],
-                                                      units=get_rate_units(control_units,
-                                                                           time_units, deriv=2),
-                                                      desc=f'second time-derivative of {control_name}')
+                added_src = timeseries_comp._add_output_configure(f'control_rates:{control_name}_rate2',
+                                                                  shape=options['shape'],
+                                                                  units=get_rate_units(control_units,
+                                                                                       time_units, deriv=2),
+                                                                  desc=f'second time-derivative of {control_name}',
+                                                                  src=f'control_rates:{control_name}_rate2')
 
-                phase.connect(src_name=f'control_rates:{control_name}_rate2',
-                              tgt_name=f'{timeseries_name}.input_values:control_rates:{control_name}_rate2')
+                if added_src:
+                    phase.connect(src_name=f'control_rates:{control_name}_rate2',
+                                  tgt_name=f'{timeseries_name}.input_values:control_rates:{control_name}_rate2')
 
             for control_name, options in phase.polynomial_control_options.items():
                 src_rows = gd.subset_node_indices['all']
@@ -408,34 +433,38 @@ class Radau(PseudospectralBase):
                 control_units = options['units']
 
                 # Control values
-                timeseries_comp._add_output_configure(f'polynomial_controls:{control_name}',
-                                                      shape=options['shape'],
-                                                      units=control_units,
-                                                      desc=options['desc'])
+                added_src = timeseries_comp._add_output_configure(f'polynomial_controls:{control_name}',
+                                                                  shape=options['shape'],
+                                                                  units=control_units,
+                                                                  desc=options['desc'],
+                                                                  src=f'polynomial_control_values:{control_name}')
 
-                phase.connect(src_name=f'polynomial_control_values:{control_name}',
-                              tgt_name=f'{timeseries_name}.input_values:polynomial_controls:{control_name}',
-                              src_indices=src_idxs, flat_src_indices=True)
+                if added_src:
+                    phase.connect(src_name=f'polynomial_control_values:{control_name}',
+                                  tgt_name=f'{timeseries_name}.input_values:polynomial_controls:{control_name}',
+                                  src_indices=src_idxs, flat_src_indices=True)
 
                 # Control rates
-                timeseries_comp._add_output_configure(f'polynomial_control_rates:{control_name}_rate',
-                                                      shape=options['shape'],
-                                                      units=get_rate_units(control_units,
-                                                                           time_units, deriv=1),
-                                                      desc=f'first time-derivative of {control_name}')
-
-                phase.connect(src_name=f'polynomial_control_rates:{control_name}_rate',
-                              tgt_name=f'{timeseries_name}.input_values:polynomial_control_rates:{control_name}_rate')
+                added_src = timeseries_comp._add_output_configure(f'polynomial_control_rates:{control_name}_rate',
+                                                                  shape=options['shape'],
+                                                                  units=get_rate_units(control_units,
+                                                                                       time_units, deriv=1),
+                                                                  desc=f'first time-derivative of {control_name}',
+                                                                  src=f'polynomial_control_rates:{control_name}_rate')
+                if added_src:
+                    phase.connect(src_name=f'polynomial_control_rates:{control_name}_rate',
+                                  tgt_name=f'{timeseries_name}.input_values:polynomial_control_rates:{control_name}_rate')
 
                 # Control second derivatives
-                timeseries_comp._add_output_configure(f'polynomial_control_rates:{control_name}_rate2',
-                                                      shape=options['shape'],
-                                                      units=get_rate_units(control_units,
-                                                                           time_units, deriv=2),
-                                                      desc=f'second time-derivative of {control_name}')
-
-                phase.connect(src_name=f'polynomial_control_rates:{control_name}_rate2',
-                              tgt_name=f'{timeseries_name}.input_values:polynomial_control_rates:{control_name}_rate2')
+                added_src = timeseries_comp._add_output_configure(f'polynomial_control_rates:{control_name}_rate2',
+                                                                  shape=options['shape'],
+                                                                  units=get_rate_units(control_units,
+                                                                                       time_units, deriv=2),
+                                                                  desc=f'second time-derivative of {control_name}',
+                                                                  src=f'polynomial_control_rates:{control_name}_rate2')
+                if added_src:
+                    phase.connect(src_name=f'polynomial_control_rates:{control_name}_rate2',
+                                  tgt_name=f'{timeseries_name}.input_values:polynomial_control_rates:{control_name}_rate2')
 
             for param_name, options in phase.parameter_options.items():
                 if options['include_timeseries']:
@@ -444,16 +473,17 @@ class Radau(PseudospectralBase):
 
                     # Add output.
                     timeseries_comp = phase._get_subsystem(timeseries_name)
-                    timeseries_comp._add_output_configure(prom_name,
-                                                          desc='',
-                                                          shape=options['shape'],
-                                                          units=options['units'])
+                    added_src = timeseries_comp._add_output_configure(prom_name,
+                                                                      desc='',
+                                                                      shape=options['shape'],
+                                                                      units=options['units'],
+                                                                      src=prom_name)
+                    if added_src:
+                        src_idxs_raw = np.zeros(gd.subset_num_nodes['all'], dtype=int)
+                        src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
 
-                    src_idxs_raw = np.zeros(gd.subset_num_nodes['all'], dtype=int)
-                    src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
-
-                    phase.promotes(timeseries_name, inputs=[(tgt_name, prom_name)],
-                                   src_indices=src_idxs, flat_src_indices=True)
+                        phase.promotes(timeseries_name, inputs=[(tgt_name, prom_name)],
+                                       src_indices=src_idxs, flat_src_indices=True)
 
             for var, options in phase._timeseries[timeseries_name]['outputs'].items():
                 output_name = options['output_name']
@@ -501,16 +531,18 @@ class Radau(PseudospectralBase):
                                          f' the ODE.')
 
                     try:
-                        timeseries_comp._add_output_configure(output_name, units, shape, desc='')
+                        add_connecction = timeseries_comp._add_output_configure(output_name, units,
+                                                                                shape, desc='',
+                                                                                src=f'rhs_all.{v}')
                     except ValueError as e:  # OK if it already exists
                         if 'already exists' in str(e):
                             continue
                         else:
                             raise e
 
-                    phase.connect(src_name='rhs_all.{0}'.format(v),
-                                  tgt_name='{0}.input_values:{1}'.format(timeseries_name,
-                                                                         output_name))
+                    if add_connecction:
+                        phase.connect(src_name=f'rhs_all.{v}',
+                                      tgt_name=f'{timeseries_name}.input_values:{output_name}')
 
     def get_rate_source_path(self, state_name, nodes, phase):
         """

--- a/dymos/transcriptions/runge_kutta/components/runge_kutta_timeseries_comp.py
+++ b/dymos/transcriptions/runge_kutta/components/runge_kutta_timeseries_comp.py
@@ -88,7 +88,7 @@ class RungeKuttaTimeseriesOutputComp(TimeseriesOutputCompBase):
 
         self.add_output(name, shape=(output_num_nodes,) + shape, units=units, desc=desc)
 
-        self._vars.append((input_name, name, shape))
+        self._vars[name] = (input_name, name, shape)
 
         size = np.prod(shape)
         val_jac = np.zeros((output_num_nodes, size, input_num_nodes, size))
@@ -117,6 +117,6 @@ class RungeKuttaTimeseriesOutputComp(TimeseriesOutputCompBase):
         outputs : `Vector`
             `Vector` containing outputs.
         """
-        for (input_name, output_name, _) in self._vars:
+        for (input_name, output_name, _) in self._vars.values():
             outputs[output_name] = np.tensordot(self.interpolation_matrix, inputs[input_name],
                                                 axes=(1, 0))

--- a/dymos/transcriptions/runge_kutta/runge_kutta.py
+++ b/dymos/transcriptions/runge_kutta/runge_kutta.py
@@ -876,7 +876,7 @@ class RungeKutta(TranscriptionBase):
                     if var_type != 'ode':
                         continue
 
-                    if self.is_static_ode_output(v, phase, self.ode):
+                    if self.is_static_ode_output(v, phase, 2*self.options['num_segments']):
                         warnings.warn(f'Cannot add ODE output {v} to the timeseries output. It is '
                                       f'sized such that its first dimension != num_nodes.')
                         continue

--- a/dymos/transcriptions/runge_kutta/runge_kutta.py
+++ b/dymos/transcriptions/runge_kutta/runge_kutta.py
@@ -876,7 +876,7 @@ class RungeKutta(TranscriptionBase):
                     if var_type != 'ode':
                         continue
 
-                    if self.is_static_ode_output(v, phase):
+                    if self.is_static_ode_output(v, phase, self.ode):
                         warnings.warn(f'Cannot add ODE output {v} to the timeseries output. It is '
                                       f'sized such that its first dimension != num_nodes.')
                         continue

--- a/dymos/transcriptions/solve_ivp/components/solve_ivp_timeseries_comp.py
+++ b/dymos/transcriptions/solve_ivp/components/solve_ivp_timeseries_comp.py
@@ -58,7 +58,7 @@ class SolveIVPTimeseriesOutputComp(TimeseriesOutputCompBase):
         """
         num_nodes = self.num_nodes
 
-        input_name = 'all_values:{0}'.format(name)
+        input_name = f'all_values:{name}'
         self.add_input(input_name,
                        shape=(num_nodes,) + shape,
                        units=units, desc=desc)
@@ -68,7 +68,7 @@ class SolveIVPTimeseriesOutputComp(TimeseriesOutputCompBase):
                         shape=(num_nodes,) + shape,
                         units=units, desc=desc)
 
-        self._vars.append((input_name, output_name, shape))
+        self._vars[name] = (input_name, output_name, shape)
 
     def compute(self, inputs, outputs):
         """
@@ -81,5 +81,5 @@ class SolveIVPTimeseriesOutputComp(TimeseriesOutputCompBase):
         outputs : `Vector`
             `Vector` containing outputs.
         """
-        for (input_name, output_name, _) in self._vars:
+        for (input_name, output_name, _) in self._vars.values():
             outputs[output_name] = inputs[input_name]

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -250,11 +250,11 @@ class SolveIVP(TranscriptionBase):
                                                 output_nodes_per_seg=self.options['output_nodes_per_seg']))
 
         if self.options['output_nodes_per_seg'] is None:
-            num_output_nodes = gd.subset_num_nodes['all']
+            self.num_output_nodes = gd.subset_num_nodes['all']
         else:
-            num_output_nodes = num_seg * self.options['output_nodes_per_seg']
+            self.num_output_nodes = num_seg * self.options['output_nodes_per_seg']
 
-        phase.add_subsystem('ode', phase.options['ode_class'](num_nodes=num_output_nodes,
+        phase.add_subsystem('ode', phase.options['ode_class'](num_nodes=self.num_output_nodes,
                                                               **phase.options['ode_init_kwargs']))
 
     def configure_ode(self, phase):
@@ -722,7 +722,7 @@ class SolveIVP(TranscriptionBase):
 
                 # Skip the timeseries output if it does not appear to be shaped as a dynamic variable
                 # If the full shape does not start with num_nodes, skip this variable.
-                if self.is_static_ode_output(v, phase):
+                if self.is_static_ode_output(v, phase, self.num_output_nodes):
                     warnings.warn(f'Cannot add ODE output {v} to the timeseries output. It is '
                                   f'sized such that its first dimension != num_nodes.')
                     continue

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -851,7 +851,7 @@ class TranscriptionBase(object):
         phase : dymos.Phase
             The phase to which this transcription applies.
         num_nodes : int
-            The number of nodes in the ODE
+            The number of nodes in the ODE.
 
         Returns
         -------

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -837,7 +837,7 @@ class TranscriptionBase(object):
         raise NotImplementedError('Transcription {0} does not implement method '
                                   'get_parameter_connections.'.format(self.__class__.__name__))
 
-    def is_static_ode_output(self, var, phase):
+    def is_static_ode_output(self, var, phase, num_nodes):
         """
         Test whether the given output is a static output of the ODE.
 
@@ -850,6 +850,8 @@ class TranscriptionBase(object):
             The ode-relative path of the variable of interest.
         phase : dymos.Phase
             The phase to which this transcription applies.
+        num_nodes : int
+            The number of nodes in the ODE
 
         Returns
         -------
@@ -865,4 +867,4 @@ class TranscriptionBase(object):
         ode_outputs = {opts['prom_name']: opts for (k, opts) in
                        ode.get_io_metadata(iotypes=('output',), get_remote=True).items()}
         ode_shape = ode_outputs[var]['shape']
-        return ode_shape[0] != ode.options['num_nodes']
+        return ode_shape[0] != num_nodes


### PR DESCRIPTION
### Summary

The `TimeseriesOutputComp` and `GaussLobattoInterleaveComp` have the possibility of duplicating data inputs.  For instance, the timeseries may include the state rate for `x` which is also the state values for `v` in the double integrator example.

To fix this, the `_add_output_configure` method for these components now includes the source which is to be connected to the input of the variable.  If this source has already been connected, we don't bother doing it a second time.

There is a corner case that can happen when a state is specified to be in a particular set of units, but its outputs are in another.  For instance,  if state `x` has units of `m` but its rate has units of `ft/s`, then the rate source would output units of `m/s` but the corresponding input would be in `ft/s`.  To fix this, we cache the units of each input used, and perform a unit conversion in the timeseries and interleave components.

### Related Issues

- Resolves #539

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
