### PR TITLE
Make ode_class on Phase non-recordable

### DIFF
--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -95,7 +95,8 @@ class Phase(om.Group):
         Declare instantiation options for the phase.
         """
         self.options.declare('ode_class', default=None,
-                             desc='System defining the ODE')
+                             desc='System defining the ODE',
+                             recordable=False)
         self.options.declare('ode_init_kwargs', types=dict, default={},
                              desc='Keyword arguments provided when initializing the ODE System')
         self.options.declare('transcription', types=TranscriptionBase,


### PR DESCRIPTION
### Summary

No need to record the ode_class option on Phase. Also since users can make their own ODE classes, they could potentially break recording

### Related Issues

- Resolves #554 

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
