### PR TITLE
I553 remove deprecated specifiers for linking phases

### DIFF
--- a/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
@@ -239,21 +239,13 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
         # Link Phases
         traj.link_phases(phases=['burn1', 'coast', 'burn2'],
                          vars=['time', 'r', 'vr', 'vt', 'deltav'])
-        traj.link_phases(phases=['burn1', 'burn2'], vars=['accel'], locs=('++', '--'))
+        traj.link_phases(phases=['burn1', 'burn2'], vars=['accel'],
+                         locs=('final', 'initial'))
 
         # Finish Problem Setup
         p.model.linear_solver = om.DirectSolver()
 
-        with warnings.catch_warnings(record=True) as ctx:
-            warnings.simplefilter('always')
-            p.setup(check=True, force_alloc_complex=True)
-
-            expected_warning = "The use of two-character location strings " \
-                               "('--', '-+', '+-', '++')\n is deprecated.  Use 'initial' to specify " \
-                               "the value at the beginning of a phase and 'final' to specify the " \
-                               "value at the end of a phase."
-
-            self.assertIn(expected_warning, [str(w.message) for w in ctx])
+        p.setup(check=True, force_alloc_complex=True)
 
         # Set Initial Guesses
         p.set_val('traj.parameters:c', value=1.5)

--- a/dymos/trajectory/options.py
+++ b/dymos/trajectory/options.py
@@ -25,10 +25,10 @@ class LinkageOptionsDictionary(om.OptionsDictionary):
         self.declare(name='var_b', types=str,
                      desc='name of the second variable in the linkage')
 
-        self.declare(name='loc_a', values=('initial', 'final', '--', '-+', '+-', '++'),
+        self.declare(name='loc_a', values=('initial', 'final'),
                      desc='location of the first variable in the linkage (\'initial\' or \'final\')')
 
-        self.declare(name='loc_b', values=('initial', 'final', '--', '-+', '+-', '++'),
+        self.declare(name='loc_b', values=('initial', 'final'),
                      desc='location of the second variable in the linkage (\'initial\' or \'final\')')
 
         self.declare(name='sign_a', types=Number, default=1.0,

--- a/dymos/trajectory/phase_linkage_comp.py
+++ b/dymos/trajectory/phase_linkage_comp.py
@@ -67,13 +67,8 @@ class PhaseLinkageComp(om.ExplicitComponent):
         var_a = lnk['constraint_name'] if lnk['constraint_name'] else lnk['var_a'].split('.')[-1]
         var_b = lnk['constraint_name'] if lnk['constraint_name'] else lnk['var_b'].split('.')[-1]
 
-        if lnk['loc_a'] in {'++', '--', '-+', '+-'} or lnk['loc_b'] in {'++', '--', '-+', '+-'}:
-            warn_deprecation("The use of two-character location strings ('--', '-+', '+-', '++')\n"
-                             " is deprecated.  Use 'initial' to specify the value at the beginning"
-                             " of a phase and 'final' to specify the value at the end of a phase.")
-
-        loc_a = lnk['loc_a'] = 'initial' if lnk['loc_a'] in {'initial', '--', '-+'} else 'final'
-        loc_b = lnk['loc_b'] = 'initial' if lnk['loc_b'] in {'initial', '--', '-+'} else 'final'
+        loc_a = lnk['loc_a']
+        loc_b = lnk['loc_b']
 
         input_a = f'{phase_a}:{var_a}'
         input_b = f'{phase_b}:{var_b}'

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -695,8 +695,8 @@ class Trajectory(om.Group):
 
             for var_pair, options in var_dict.items():
                 var_a, var_b = var_pair
-                loc_a = 'initial' if options['loc_a'] in {'initial', '--', '-+'} else 'final'
-                loc_b = 'initial' if options['loc_b'] in {'initial', '--', '-+'} else 'final'
+                loc_a = options['loc_a']
+                loc_b = options['loc_b']
 
                 self._update_linkage_options_configure(options)
 

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -900,7 +900,7 @@ class Trajectory(om.Group):
         complex behavior (branching phases, phases only continuous in some variables, etc).
 
         The location at which the variables should be coupled in the two phases are provided
-        with a two character string:
+        with one of two strings:
 
         - 'final' specifies the value at the end of the phase (at time t_initial + t_duration)
         - 'initial' specifies the value at the start of the phase (at time t_initial)
@@ -913,7 +913,7 @@ class Trajectory(om.Group):
             The variables in the phases to be linked, or '*'.  Providing '*' will time and all
             states.  Linking control values or rates requires them to be listed explicitly.
         locs : tuple of str
-            A two-element tuple of the two-character location specification.  For every pair in
+            A two-element tuple of a location specification.  For every pair in
             phases, the location specification refers to which location in the first phase is
             connected to which location in the second phase.  If the user wishes to specify
             different locations for different phase pairings, those phase pairings must be made

--- a/mkdocs/docs/features/trajectories/trajectories.md
+++ b/mkdocs/docs/features/trajectories/trajectories.md
@@ -67,6 +67,55 @@ The acceleration needs to be zero in the coast phase, but continuous between `bu
 {{ api_doc('dymos.Trajectory.link_phases') }}
 
 
+## Examples of using the `link_phases` method
+
+**Typical Phase Linkage Sequence**
+
+A typical phase linkage sequence, where all phases use the same ODE (and therefore have
+the same states), are simply linked sequentially in time.
+
+``` python
+t.link_phases(['phase1', 'phase2', 'phase3'])
+```
+
+**Adding an Additional Linkage**
+
+If the user wants some control variable, `u`, to be continuous in value between `phase2` and
+`phase3` only, they could indicate that with the following code:
+
+``` python
+t.link_phases(['phase2', 'phase3'], vars=['u'])
+```
+
+**Branching Trajectories**
+
+For a more complex example, consider the case where there are two phases which branch off
+from the same point, such as the case of a jettisoned stage.  The nominal trajectory
+consists of the phase sequence `['a', 'b', 'c']`.  Let phase `['d']` be the phase that tracks
+the jettisoned component to its impact with the ground.  The linkages in this case
+would be defined as:
+
+``` python
+t.link_phases(['a', 'b', 'c'])
+t.link_phases(['b', 'd'])
+```
+
+**Specifying Linkage Locations**
+
+Phase linkages assume that, for each pair, the state/control values at the end (`'final'`)
+of the first phase are linked to the state/control values at the start of the second phase
+(`'initial'`).
+
+The user can override this behavior, but they must specify a pair of location strings for
+each pair given in `phases`.  For instance, in the following example phases `a` and `b`
+have the same initial time and state, but phase `c` follows phase `b`.  Note since there
+are three phases provided, there are two linkages and thus two pairs of location
+specifiers given.
+
+``` python
+t.link_phases(['a', 'b', 'c'], locs=[('initial', 'initial'), ('final', 'initial')])
+```
+
 ##  Trajectory-Level Parameters
 
 Often times, there are parameters which apply to the entirety of a trajectory that potentially need to be optimized.


### PR DESCRIPTION
### Summary

Remove the deprecated two-character location specification codes for linkages.

Also added some examples of calls to link_phases to the docs.

### Related Issues

- Resolves #553 

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
