### PR TITLE
Remove deprecated feature: add_input_parameter

### DIFF
--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -1059,42 +1059,6 @@ class Phase(om.Group):
         self.set_parameter_options(name, val, units, opt, desc, lower, upper,
                                    scaler, adder, ref0, ref, targets, shape, dynamic, include_timeseries)
 
-    def add_input_parameter(self, name, val=_unspecified, units=_unspecified, targets=_unspecified,
-                            desc=_unspecified, shape=_unspecified, dynamic=_unspecified,
-                            include_timeseries=_unspecified):
-        """
-        Add an input parameter to the phase.
-
-        This method is deprecated. Use add_parameter instead.
-
-        Parameters
-        ----------
-        name : str
-            Name of the ODE parameter to be controlled via this input parameter.
-        val : float or ndarray
-            Default value of the input parameter at all nodes.
-        units : str or None or 0
-            Units in which the input parameter is defined.  If 0, use the units declared
-            for the parameter in the ODE.
-        targets : Sequence of str or None
-            Targets in the ODE to which this parameter is connected.
-        desc : str
-            A description of the input parameter.
-        shape : Sequence of str or None
-            The shape of the input parameter.
-        dynamic : bool
-            True if the targets in the ODE may be dynamic (if the inputs are sized to the number
-            of nodes) else False.
-        include_timeseries : bool
-            True if the static input parameters should be included in output timeseries, else False.
-        """
-        msg = "DesignParameters and InputParameters are being replaced by Parameters in  " + \
-            "Dymos 1.0.0. Please use add_parameter or set_parameter_options to remove this " + \
-            "deprecation warning."
-        warn_deprecation(msg)
-        self.add_parameter(name, val=val, units=units, desc=desc, targets=targets, shape=shape,
-                           dynamic=dynamic, include_timeseries=include_timeseries)
-
     def set_input_parameter_options(self, name, val=_unspecified, units=_unspecified, targets=_unspecified,
                                     desc=_unspecified, shape=_unspecified, dynamic=_unspecified,
                                     include_timeseries=_unspecified):

--- a/dymos/trajectory/test/test_trajectory_input_parameters.py
+++ b/dymos/trajectory/test/test_trajectory_input_parameters.py
@@ -27,8 +27,8 @@ def make_traj(transcription='gauss-lobatto', transcription_order=3, compressed=F
         traj.add_parameter('c', opt=False, val=1.5, units='DU/TU',
                            targets={'burn1': ['c'], 'burn2': ['c']})
     elif param_mode == 'param_sequence_missing_phase_deprecated':
-        traj.add_input_parameter('c', val=1.5, units='DU/TU',
-                                 targets={'burn1': ['c'], 'burn2': ['c']})
+        traj.add_parameter('c', val=1.5, units='DU/TU',
+                           targets={'burn1': ['c'], 'burn2': ['c']})
     elif param_mode == 'param_no_targets':
         traj.add_parameter('c', val=1.5, units='DU/TU')
 

--- a/dymos/trajectory/test/test_trajectory_input_parameters.py
+++ b/dymos/trajectory/test/test_trajectory_input_parameters.py
@@ -26,9 +26,6 @@ def make_traj(transcription='gauss-lobatto', transcription_order=3, compressed=F
     elif param_mode == 'param_sequence_missing_phase':
         traj.add_parameter('c', opt=False, val=1.5, units='DU/TU',
                            targets={'burn1': ['c'], 'burn2': ['c']})
-    elif param_mode == 'param_sequence_missing_phase_deprecated':
-        traj.add_parameter('c', val=1.5, units='DU/TU',
-                           targets={'burn1': ['c'], 'burn2': ['c']})
     elif param_mode == 'param_no_targets':
         traj.add_parameter('c', val=1.5, units='DU/TU')
 
@@ -259,19 +256,6 @@ class TestTrajectoryParameters(unittest.TestCase):
                                          compressed=False, optimizer=optimizer,
                                          show_output=False,
                                          param_mode='param_sequence_missing_phase')
-
-        if p.model.orbit_transfer.phases.burn2 in p.model.orbit_transfer.phases._subsystems_myproc:
-            assert_near_equal(p.get_val('orbit_transfer.burn2.states:deltav')[-1], 0.3995,
-                              tolerance=2.0E-3)
-
-    def test_input_parameter_deprecated(self):
-        """
-        Make sure the old deprecated command works.
-        """
-        p = two_burn_orbit_raise_problem(transcription='gauss-lobatto', transcription_order=3,
-                                         compressed=False, optimizer=optimizer,
-                                         show_output=False,
-                                         param_mode='param_sequence_missing_phase_deprecated')
 
         if p.model.orbit_transfer.phases.burn2 in p.model.orbit_transfer.phases._subsystems_myproc:
             assert_near_equal(p.get_val('orbit_transfer.burn2.states:deltav')[-1], 0.3995,

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -177,43 +177,6 @@ class Trajectory(om.Group):
         if dynamic is not _unspecified:
             self.parameter_options[name]['dynamic'] = dynamic
 
-    def add_input_parameter(self, name, units, val=_unspecified, desc=_unspecified,
-                            targets=_unspecified, custom_targets=_unspecified,
-                            shape=_unspecified, dynamic=_unspecified):
-        """
-        Add an input parameter to the trajectory.
-
-        Parameters
-        ----------
-        name : str
-            Name of the input parameter.
-        units : str or None or 0
-            Units in which the input parameter is defined.  If 0, use the units declared
-            for the parameter in the ODE.
-        val : float or ndarray
-            Default value of the input parameter at all nodes.
-        desc : str
-            A description of the input parameter.
-        targets : dict or None
-            A dictionary mapping the name of each phase in the trajectory to a sequence of ODE
-            targets for this parameter in each phase.
-        custom_targets : dict or None
-            By default, the parameter will be connect to the parameter/targets of the given
-            name in each phase.  This argument can be used to override that behavior on a phase
-            by phase basis.
-        shape : Sequence of int
-            The shape of the input parameter.
-        dynamic : bool
-            True if the targets in the ODE may be dynamic (if the inputs are sized to the number
-            of nodes) else False.
-        """
-        msg = "DesignParameters and InputParameters are being replaced by Parameters in  " + \
-            "Dymos 1.0.0. Please use add_parameter or set_parameter_options to remove this " + \
-            "deprecation warning."
-        warn_deprecation(msg)
-        self.add_parameter(name, units, val=val, desc=desc, targets=targets, shape=shape,
-                           dynamic=dynamic)
-
     def add_design_parameter(self, name, units, val=_unspecified, desc=_unspecified, opt=_unspecified,
                              targets=_unspecified, custom_targets=_unspecified,
                              lower=_unspecified, upper=_unspecified, scaler=_unspecified,


### PR DESCRIPTION
### Summary

Removed the deprecated feature, the method add_input_parameter, in phase and trajectory

### Related Issues

- Resolves #551 

### Status

- [x] Ready for merge

### Backwards incompatibilities

add_input_parameter no longer allowed

### New Dependencies

None
