### PR TITLE
Cleanup of a few remaining deprecation issues.

### DIFF
--- a/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_parameter.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_parameter.py
@@ -221,10 +221,10 @@ class TestBrachistochroneIntegratedParameter(unittest.TestCase):
         v_sim = sim_out.get_val('phase0.timeseries.states:v')
         theta_sim = sim_out.get_val('phase0.timeseries.states:theta')
 
-        assert_timeseries_near_equal(t_sol, x_sol, t_sim, x_sim, tolerance=1.0E-3, num_points=10)
-        assert_timeseries_near_equal(t_sol, y_sol, t_sim, y_sim, tolerance=1.0E-3, num_points=10)
-        assert_timeseries_near_equal(t_sol, v_sol, t_sim, v_sim, tolerance=1.0E-3, num_points=10)
-        assert_timeseries_near_equal(t_sol, theta_sol, t_sim, theta_sim, tolerance=1.0E-3, num_points=10)
+        assert_timeseries_near_equal(t_sol, x_sol, t_sim, x_sim, tolerance=1.0E-3)
+        assert_timeseries_near_equal(t_sol, y_sol, t_sim, y_sim, tolerance=1.0E-3)
+        assert_timeseries_near_equal(t_sol, v_sol, t_sim, v_sim, tolerance=1.0E-3)
+        assert_timeseries_near_equal(t_sol, theta_sol, t_sim, theta_sim, tolerance=1.0E-3)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_solve_segments.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_solve_segments.py
@@ -232,7 +232,7 @@ class TestBrachistochroneSolveSegments(unittest.TestCase):
     def test_brachistochrone_solve_segments(self):
 
         for tx in ('radau-ps', 'gauss-lobatto'):
-            for solve_segs in (True, False, 'forward', 'backward', None):
+            for solve_segs in (False, 'forward', 'backward', None):
                 for compressed in (True, False):
                     print(f'transcription: {tx}  solve_segments: {solve_segs}  compressed: {compressed}')
                     with self.subTest(f'transcription: {tx}  solve_segments: {solve_segs}  '

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -446,8 +446,8 @@ class StateOptionsDictionary(om.OptionsDictionary):
                           'option is invalid if opt=False.')
 
         self.declare(name='solve_segments', default=None, allow_none=True,
-                     values=(True, False, 'forward', 'backward'),
-                     desc='If True (deprecated) or \'forward\', collocation defects within each'
+                     values=(False, 'forward', 'backward'),
+                     desc='If \'forward\', collocation defects within each'
                           'segment are solved with a Newton solver by fixing the initial value in the'
                           'phase (if using compressed transcription) or segment (if not using '
                           'compressed transcription). This provides a forward shooting (or multiple shooting)'

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -9,7 +9,6 @@ from scipy import interpolate
 import openmdao
 import openmdao.api as om
 from openmdao.core.system import System
-from openmdao.utils.general_utils import warn_deprecation
 import dymos as dm
 
 from .options import ControlOptionsDictionary, ParameterOptionsDictionary, \
@@ -132,8 +131,7 @@ class Phase(om.Group):
             The path to the targets of the state variable in the ODE system.  If given
             this will override the value given by the @declare_state decorator on the ODE.
             In the future, if left _unspecified (the default), the phase variable will try to connect to an ODE input
-            of the same name. Currently _unspecified is the same as None, but a deprecation warning is issued.
-            Set targets to None to prevent this (the old default behavior).
+            of the same name. Set targets to None to prevent this.
         val :  ndarray
             The default value of the state at the state discretization nodes of the phase.
         fix_initial : bool(False)
@@ -206,8 +204,7 @@ class Phase(om.Group):
             The path to the targets of the state variable in the ODE system.  If given
             this will override the value given by the @declare_state decorator on the ODE.
             In the future, if left _unspecified (the default), the phase variable will try to connect to an ODE input
-            of the same name. Currently _unspecified is the same as None, but a deprecation warning is issued.
-            Set targets to None to prevent this (the old default behavior).
+            of the same name. Set targets to None to prevent this.
         val :  ndarray
             The default value of the state at the state discretization nodes of the phase.
         fix_initial : bool(False)
@@ -366,8 +363,7 @@ class Phase(om.Group):
         targets : Sequence of str or None
             Targets in the ODE to which this control is connected.
             In the future, if left _unspecified (the default), the phase control will try to connect to an ODE input
-            of the same name. Currently _unspecified is the same as None, but a deprecation warning is issued.
-            Set targets to None to prevent this (the old default behavior).
+            of the same name. Set targets to None to prevent this.
         rate_targets : Sequence of str or None
             The targets in the ODE to which the control rate is connected.
         rate2_targets : Sequence of str or None
@@ -463,8 +459,7 @@ class Phase(om.Group):
         targets : Sequence of str or None
             Targets in the ODE to which this control is connected.
             In the future, if left _unspecified (the default), the phase control will try to connect to an ODE input
-            of the same name. Currently _unspecified is the same as None, but a deprecation warning is issued.
-            Set targets to None to prevent this (the old default behavior).
+            of the same name. Set targets to None to prevent this.
         rate_targets : Sequence of str or None
             The targets in the ODE to which the control rate is connected.
         rate2_targets : Sequence of str or None
@@ -822,8 +817,7 @@ class Phase(om.Group):
         targets : Sequence of str or None
             Targets in the ODE to which this parameter is connected.
             In the future, if left _unspecified (the default), the phase parameter will try to connect to an ODE input
-            of the same name. Currently _unspecified is the same as None, but a deprecation warning is issued.
-            Set targets to None to prevent this (the old default behavior).
+            of the same name. Set targets to None to prevent this.
         shape : Sequence of int
             The shape of the parameter.
         dynamic : bool
@@ -880,8 +874,7 @@ class Phase(om.Group):
         targets : Sequence of str or None
             Targets in the ODE to which this parameter is connected.
             In the future, if left _unspecified (the default), the phase parameter will try to connect to an ODE input
-            of the same name. Currently _unspecified is the same as None, but a deprecation warning is issued.
-            Set targets to None to prevent this (the old default behavior).
+            of the same name. Set targets to None to prevent this.
         shape : Sequence of int
             The shape of the parameter.
         dynamic : bool
@@ -1644,7 +1637,7 @@ class Phase(om.Group):
         """
         if not isinstance(ys, Iterable):
             raise ValueError('ys must be provided as an Iterable of length at least 2.')
-        if nodes not in ('col', 'disc', 'all', 'state_disc', 'state_input', 'control_disc',
+        if nodes not in ('col', 'all', 'state_disc', 'state_input', 'control_disc',
                          'control_input', 'segment_ends'):
             raise ValueError("nodes must be one of 'col', 'all', 'state_disc', "
                              "'state_input', 'control_disc', 'control_input', or 'segment_ends'")

--- a/dymos/phase/test/test_time_targets.py
+++ b/dymos/phase/test/test_time_targets.py
@@ -151,13 +151,13 @@ class TestPhaseTimeTargets(unittest.TestCase):
 
         time_all = p['phase0.time']
         time_col = time_all[gd.subset_node_indices['col']]
-        time_disc = time_all[gd.subset_node_indices['disc']]
+        time_disc = time_all[gd.subset_node_indices['state_disc']]
         time_segends = np.reshape(time_all[gd.subset_node_indices['segment_ends']],
                                   newshape=(gd.num_segments, 2))
 
         time_phase_all = p['phase0.time_phase']
         time_phase_col = time_phase_all[gd.subset_node_indices['col']]
-        time_phase_disc = time_phase_all[gd.subset_node_indices['disc']]
+        time_phase_disc = time_phase_all[gd.subset_node_indices['state_disc']]
         time_phase_segends = np.reshape(time_phase_all[gd.subset_node_indices['segment_ends']],
                                         newshape=(gd.num_segments, 2))
 

--- a/dymos/trajectory/phase_linkage_comp.py
+++ b/dymos/trajectory/phase_linkage_comp.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.general_utils import warn_deprecation
 
 from ..options import options as dymos_options
 

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -11,7 +11,6 @@ except ImportError:
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.general_utils import warn_deprecation
 from openmdao.utils.mpi import MPI
 
 from ..utils.constants import INF_BOUND
@@ -74,9 +73,8 @@ class Trajectory(om.Group):
         return phase
 
     def add_parameter(self, name, units, val=_unspecified, desc=_unspecified, opt=False,
-                      targets=_unspecified, custom_targets=_unspecified,
-                      lower=_unspecified, upper=_unspecified, scaler=_unspecified,
-                      adder=_unspecified, ref0=_unspecified, ref=_unspecified,
+                      targets=_unspecified, lower=_unspecified, upper=_unspecified,
+                      scaler=_unspecified, adder=_unspecified, ref0=_unspecified, ref=_unspecified,
                       shape=_unspecified, dynamic=_unspecified):
         """
         Add a parameter (static control) to the trajectory.
@@ -101,10 +99,6 @@ class Trajectory(om.Group):
             a warning will be issued.  If targets is given as a dict, the dict should provide
             the relevant phase names as keys, each associated with the respective controllable
             parameter as a value.
-        custom_targets : dict or None
-            By default, the parameter will be connect to the parameter/targets of the given
-            name in each phase.  This argument can be used to override that behavior on a phase
-            by phase basis.
         lower : float or ndarray
             The lower bound of the parameter value.
         upper : float or ndarray
@@ -161,15 +155,6 @@ class Trajectory(om.Group):
                 self.parameter_options[name]['targets'] = (targets,)
             else:
                 self.parameter_options[name]['targets'] = targets
-
-        if custom_targets is not _unspecified:
-            warnings.warn('Option custom_targets is now targets, and should provide the ode '
-                          'targets for the parameter in each phase', DeprecationWarning)
-
-            if isinstance(custom_targets, str):
-                self.parameter_options[name]['targets'] = (custom_targets,)
-            else:
-                self.parameter_options[name]['targets'] = custom_targets
 
         if shape is not _unspecified:
             self.parameter_options[name]['shape'] = shape

--- a/dymos/transcriptions/grid_data.py
+++ b/dymos/transcriptions/grid_data.py
@@ -27,7 +27,6 @@ def gauss_lobatto_subsets_and_nodes(n, seg_idx, compressed=False):
     -------
     dict
         A dictionary with the following keys:
-        'disc' gives the indices of the state discretization nodes (deprecated)
         'state_disc' gives the indices of the state discretization nodes
         'state_input' gives the indices of the state input nodes
         'control_disc' gives the indices of the control discretization nodes
@@ -45,7 +44,6 @@ def gauss_lobatto_subsets_and_nodes(n, seg_idx, compressed=False):
         raise ValueError('A Gauss-Lobatto scheme must use an odd number of points')
 
     subsets = {
-        'disc': np.arange(0, n, 2, dtype=int),
         'state_disc': np.arange(0, n, 2, dtype=int),
         'state_input': np.arange(0, n, 2, dtype=int) if not compressed or seg_idx == 0
         else np.arange(2, n, 2, dtype=int),
@@ -78,7 +76,6 @@ def radau_pseudospectral_subsets_and_nodes(n, seg_idx, compressed=False):
     -------
     dict
         A dictionary with the following keys:
-        'disc' gives the indices of the state discretization nodes (deprecated)
         'state_disc' gives the indices of the state discretization nodes
         'state_input' gives the indices of the state input nodes
         'control_disc' gives the indices of the control discretization nodes
@@ -94,7 +91,6 @@ def radau_pseudospectral_subsets_and_nodes(n, seg_idx, compressed=False):
     the same as subset 'control_disc'.
     """
     subsets = {
-        'disc': np.arange(n + 1, dtype=int),
         'state_disc': np.arange(n + 1, dtype=int),
         'state_input': np.arange(n + 1, dtype=int) if not compressed or seg_idx == 0
         else np.arange(1, n + 1, dtype=int),

--- a/dymos/transcriptions/pseudospectral/components/state_interp_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/state_interp_comp.py
@@ -175,7 +175,7 @@ class StateInterpComp(om.ExplicitComponent):
                                   rows=Ad_rows, cols=Ad_cols)
 
     def _compute_radau(self, inputs, outputs):
-        num_disc_nodes = self.options['grid_data'].subset_num_nodes['disc']
+        num_disc_nodes = self.options['grid_data'].subset_num_nodes['state_disc']
         num_col_nodes = self.options['grid_data'].subset_num_nodes['col']
         state_options = self.options['state_options']
         dt_dstau = inputs['dt_dstau'][:, np.newaxis]
@@ -197,7 +197,7 @@ class StateInterpComp(om.ExplicitComponent):
 
         dt_dstau = inputs['dt_dstau'][:, np.newaxis]
 
-        num_disc_nodes = self.options['grid_data'].subset_num_nodes['disc']
+        num_disc_nodes = self.options['grid_data'].subset_num_nodes['state_disc']
         num_col_nodes = self.options['grid_data'].subset_num_nodes['col']
 
         Ai = self.matrices['Ai']
@@ -227,7 +227,7 @@ class StateInterpComp(om.ExplicitComponent):
     def _compute_partials_radau(self, inputs, partials):
         state_options = self.options['state_options']
 
-        ndn = self.options['grid_data'].subset_num_nodes['disc']
+        ndn = self.options['grid_data'].subset_num_nodes['state_disc']
 
         Ad = self.matrices['Ad']
 
@@ -250,7 +250,7 @@ class StateInterpComp(om.ExplicitComponent):
             partials[xdotc_name, xd_name] = self.jacs['Ad'][name].multiply(dstau_dt_x_size).data
 
     def _compute_partials_gauss_lobatto(self, inputs, partials):
-        ndn = self.options['grid_data'].subset_num_nodes['disc']
+        ndn = self.options['grid_data'].subset_num_nodes['state_disc']
 
         Ad = self.matrices['Ad']
         Bi = self.matrices['Bi']

--- a/dymos/transcriptions/pseudospectral/gauss_lobatto.py
+++ b/dymos/transcriptions/pseudospectral/gauss_lobatto.py
@@ -245,7 +245,7 @@ class GaussLobatto(PseudospectralBase):
                 # f_computed to the parameter name instead of connecting to it.
                 shape = phase.parameter_options[rate_src]['shape']
                 param_size = np.prod(shape)
-                ndn = self.grid_data.subset_num_nodes['disc']
+                ndn = self.grid_data.subset_num_nodes['state_disc']
                 ncn = self.grid_data.subset_num_nodes['col']
                 src_idxs = np.tile(np.arange(0, param_size, dtype=int), ndn)
                 src_idxs = np.reshape(src_idxs, (ndn,) + shape)
@@ -314,7 +314,7 @@ class GaussLobatto(PseudospectralBase):
                     # f_computed to the parameter name instead of connecting to it.
                     shape = phase.parameter_options[rate_src]['shape']
                     param_size = np.prod(shape)
-                    ndn = self.grid_data.subset_num_nodes['disc']
+                    ndn = self.grid_data.subset_num_nodes['state_disc']
                     ncn = self.grid_data.subset_num_nodes['col']
                     src_idxs = np.tile(np.arange(0, param_size, dtype=int), ndn)
                     src_idxs = np.reshape(src_idxs, (ndn,) + shape)

--- a/dymos/transcriptions/pseudospectral/pseudospectral_base.py
+++ b/dymos/transcriptions/pseudospectral/pseudospectral_base.py
@@ -3,7 +3,6 @@ from collections.abc import Iterable
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.general_utils import warn_deprecation
 from ..transcription_base import TranscriptionBase
 from ..common import TimeComp, PseudospectralTimeseriesOutputComp
 from .components import StateIndependentsComp, StateInterpComp, CollocationComp
@@ -308,14 +307,6 @@ class PseudospectralBase(TranscriptionBase):
         # Transcription solve_segments overrides state solve_segments if its not set
         if options['solve_segments'] is None:
             options['solve_segments'] = self.options['solve_segments']
-
-        # Flag deprecated solve_segments options:
-        if options['solve_segments'] is True:
-            ss = options['solve_segments']
-            warn_deprecation(f'State {state_name} in phase {phase.name} has option '
-                             f'\'solve_segments=forward\'. Setting \'solve_segments=forward\' now gives '
-                             f'forward propagation. In Dymos 1.0 and later, only options '
-                             f'\'forward\' and \'backward\' will be valid.')
 
         # Sanity-checks for solve segments
         # If solve_segments is used at all, we cannot fix the state at both ends of the phase.

--- a/dymos/utils/testing_utils.py
+++ b/dymos/utils/testing_utils.py
@@ -2,7 +2,6 @@ import numpy as np
 from scipy.interpolate import interp1d
 
 import openmdao.utils.assert_utils as _om_assert_utils
-from openmdao.utils.general_utils import warn_deprecation
 
 
 def assert_check_partials(data, atol=1.0E-6, rtol=1.0E-6):
@@ -110,7 +109,7 @@ def assert_cases_equal(case1, case2, tol=1.0E-12, require_same_vars=True):
         raise AssertionError(err_msg)
 
 
-def assert_timeseries_near_equal(t1, x1, t2, x2, tolerance=1.0E-6, num_points=None):
+def assert_timeseries_near_equal(t1, x1, t2, x2, tolerance=1.0E-6):
     """
     Assert that two timeseries of data are approximately equal.
 
@@ -129,8 +128,6 @@ def assert_timeseries_near_equal(t1, x1, t2, x2, tolerance=1.0E-6, num_points=No
         Data values for the second timeseries.
     tolerance : float
         The tolerance for any errors along at each point checked.
-    num_points : int
-        The number of points along the timeseries to be compared.
 
     Raises
     ------
@@ -138,9 +135,6 @@ def assert_timeseries_near_equal(t1, x1, t2, x2, tolerance=1.0E-6, num_points=No
         When one or more elements of the interpolated timeseries are not within the
         desired tolerance.
     """
-    if num_points is not None:
-        warn_deprecation('Argument num_points is deprecated and will be removed in dymos 1.0.0')
-
     shape1 = x1.shape[1:]
     shape2 = x2.shape[1:]
 


### PR DESCRIPTION
### Summary

A few comments mentioned (no longer) deprecated options.  These have been removed.
Removed the "disc" node subset, which has been long-deprecated by "state_disc".

### Related Issues

- None

### Status

- [x] Ready for merge

### Backwards incompatibilities

- Requesting node subset "disc" will no longer work. The correct subset name is "state_disc".  This removes ambiguity since controls are not discretized at the same nodes as the states.

### New Dependencies

None
