### PR TITLE
Added warnings to the transcriptions if ODE has multiple timeseries variables with the same name

### DIFF
--- a/dymos/phase/test/test_timeseries.py
+++ b/dymos/phase/test/test_timeseries.py
@@ -1,13 +1,20 @@
 import unittest
 
+import numpy as np
+
 from scipy.interpolate import interp1d
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
+
+from dymos.models.atmosphere import USatm1976Comp
+from dymos.examples.min_time_climb.aero import AeroGroup
+from dymos.examples.min_time_climb.prop import PropGroup
+from dymos.models.eom import FlightPathEOM2D
 
 
 @use_tempdirs
@@ -199,6 +206,142 @@ class TestTimeseriesOutput(unittest.TestCase):
 
     def test_timeseries_radau_smaller_timeseries(self):
         self.test_timeseries_radau(test_smaller_timeseries=True)
+
+
+class MinTimeClimbODEDuplicateOutput(om.Group):
+
+    def initialize(self):
+        self.options.declare('num_nodes', types=int)
+
+    def setup(self):
+        nn = self.options['num_nodes']
+
+        self.add_subsystem(name='atmos',
+                           subsys=USatm1976Comp(num_nodes=nn),
+                           promotes_inputs=['h'])
+
+        self.add_subsystem(name='aero',
+                           subsys=AeroGroup(num_nodes=nn),
+                           promotes_inputs=['v', 'alpha', 'S'])
+
+        self.connect('atmos.sos', 'aero.sos')
+        self.connect('atmos.rho', 'aero.rho')
+
+        self.add_subsystem(name='prop',
+                           subsys=PropGroup(num_nodes=nn),
+                           promotes_inputs=['h', 'Isp', 'throttle'])
+
+        self.connect('aero.mach', 'prop.mach')
+
+        self.add_subsystem(name='flight_dynamics',
+                           subsys=FlightPathEOM2D(num_nodes=nn),
+                           promotes_inputs=['m', 'v', 'gam', 'alpha'])
+
+        foo = self.add_subsystem('foo', om.IndepVarComp())
+        foo.add_output('rho', val=100 * np.ones(nn), units='g/cm**3')
+
+        self.connect('aero.f_drag', 'flight_dynamics.D')
+        self.connect('aero.f_lift', 'flight_dynamics.L')
+        self.connect('prop.thrust', 'flight_dynamics.T')
+
+
+def min_time_climb(num_seg=3, transcription_class=dm.Radau, transcription_order=3,
+                   force_alloc_complex=False):
+
+    p = om.Problem(model=om.Group())
+
+    p.driver = om.pyOptSparseDriver()
+
+    tx = transcription_class(num_segments=num_seg, order=transcription_order)
+
+    traj = dm.Trajectory()
+
+    phase = dm.Phase(ode_class=MinTimeClimbODEDuplicateOutput, transcription=tx)
+    traj.add_phase('phase0', phase)
+
+    p.model.add_subsystem('traj', traj)
+
+    phase.set_time_options(fix_initial=True, duration_bounds=(50, 400),
+                           duration_ref=100.0)
+
+    phase.add_state('r', fix_initial=True, lower=0, upper=1.0E6,
+                    ref=1.0E3, defect_ref=1.0E3, units='m',
+                    rate_source='flight_dynamics.r_dot')
+
+    phase.add_state('h', fix_initial=True, lower=0, upper=20000.0,
+                    ref=1.0E2, defect_ref=1.0E2, units='m',
+                    rate_source='flight_dynamics.h_dot', targets=['h'])
+
+    phase.add_state('v', fix_initial=True, lower=10.0,
+                    ref=1.0E2, defect_ref=1.0E2, units='m/s',
+                    rate_source='flight_dynamics.v_dot', targets=['v'])
+
+    phase.add_state('gam', fix_initial=True, lower=-1.5, upper=1.5,
+                    ref=1.0, defect_ref=1.0, units='rad',
+                    rate_source='flight_dynamics.gam_dot', targets=['gam'])
+
+    phase.add_state('m', fix_initial=True, lower=10.0, upper=1.0E5,
+                    ref=1.0E3, defect_ref=1.0E3, units='kg',
+                    rate_source='prop.m_dot', targets=['m'])
+
+    phase.add_control('alpha', units='deg', lower=-8.0, upper=8.0, scaler=1.0,
+                      rate_continuity=True, rate_continuity_scaler=100.0,
+                      rate2_continuity=False, targets=['alpha'])
+
+    phase.add_parameter('S', val=49.2386, units='m**2', opt=False, targets=['S'])
+    phase.add_parameter('Isp', val=1600.0, units='s', opt=False, targets=['Isp'])
+    phase.add_parameter('throttle', val=1.0, opt=False, targets=['throttle'])
+
+    phase.add_boundary_constraint('h', loc='final', equals=20000, scaler=1.0E-3)
+    phase.add_boundary_constraint('aero.mach', loc='final', equals=1.0)
+    phase.add_boundary_constraint('gam', loc='final', equals=0.0)
+
+    phase.add_path_constraint(name='h', lower=100.0, upper=20000, ref=20000)
+    phase.add_path_constraint(name='aero.mach', lower=0.1, upper=1.8)
+
+    # Unnecessary but included to test capability
+    phase.add_path_constraint(name='alpha', lower=-8, upper=8)
+    phase.add_path_constraint(name='time', lower=0, upper=400)
+    phase.add_path_constraint(name='time_phase', lower=0, upper=400)
+
+    # Minimize time at the end of the phase
+    phase.add_objective('time', loc='final', ref=1.0)
+
+    # Add all ODE outputs to the timeseries
+    phase.add_timeseries_output('*')
+
+    p.model.linear_solver = om.DirectSolver()
+
+    p.setup(check=True, force_alloc_complex=force_alloc_complex)
+
+    p['traj.phase0.t_initial'] = 0.0
+    p['traj.phase0.t_duration'] = 300.0
+
+    p['traj.phase0.states:r'] = phase.interpolate(ys=[0.0, 111319.54], nodes='state_input')
+    p['traj.phase0.states:h'] = phase.interpolate(ys=[100.0, 20000.0], nodes='state_input')
+    p['traj.phase0.states:v'] = phase.interpolate(ys=[135.964, 283.159], nodes='state_input')
+    p['traj.phase0.states:gam'] = phase.interpolate(ys=[0.0, 0.0], nodes='state_input')
+    p['traj.phase0.states:m'] = phase.interpolate(ys=[19030.468, 16841.431], nodes='state_input')
+    p['traj.phase0.controls:alpha'] = phase.interpolate(ys=[0.0, 0.0], nodes='control_input')
+
+    return p
+
+
+class TestDuplicateTimeseriesGlobName(unittest.TestCase):
+
+    def test_duplicate_timeseries_glob_name(self):
+        """
+        Test that the user gets a warning about multiple timeseries with the same name.
+        """
+
+        msg = "The timeseries variable name rho is duplicated in these variables: atmos.rho, " \
+              "foo.rho. Disambiguate by using the add_timeseries_output output_name option."
+        with assert_warning(UserWarning, msg):
+            p = min_time_climb(num_seg=12, transcription_class=dm.Radau, transcription_order=3)
+
+        with assert_warning(UserWarning, msg):
+            p = min_time_climb(num_seg=12, transcription_class=dm.GaussLobatto,
+                               transcription_order=3)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/transcriptions/pseudospectral/gauss_lobatto.py
+++ b/dymos/transcriptions/pseudospectral/gauss_lobatto.py
@@ -647,8 +647,9 @@ class GaussLobatto(PseudospectralBase):
                         if len(var_list) > 1:
                             var_list_as_string = ', '.join(var_list)
                             simple_warning(f"The timeseries variable name {output_name} is "
-                            f"duplicated in these variables: {var_list_as_string}. "
-                            "Disambiguate by using the add_timeseries_output output_name option.")
+                                           f"duplicated in these variables: {var_list_as_string}. "
+                                           "Disambiguate by using the add_timeseries_output "
+                                           "output_name option.")
                 else:
                     matches = [var]
 

--- a/dymos/transcriptions/pseudospectral/gauss_lobatto.py
+++ b/dymos/transcriptions/pseudospectral/gauss_lobatto.py
@@ -1,7 +1,9 @@
+from collections import defaultdict
 import warnings
 
 import numpy as np
 import openmdao.api as om
+from openmdao.utils.general_utils import simple_warning
 
 from .pseudospectral_base import PseudospectralBase
 from .components import GaussLobattoInterleaveComp
@@ -628,6 +630,25 @@ class GaussLobatto(PseudospectralBase):
                     ode_outputs = {opts['prom_name']: opts for (k, opts) in
                                    phase.rhs_disc.get_io_metadata(iotypes=('output',)).items()}
                     matches = filter(list(ode_outputs.keys()), var)
+
+                    # A nested ODE can have multiple outputs at different levels that share
+                    #   the same name.
+                    # If the user does not use the output_name option to add_timeseries_output
+                    #   to disambiguate the variables with the same name, only one of the
+                    #   variables will be added. This code warns the user if that is happening.
+                    # Find the duplicate timeseries names by looking at the last part of the names.
+                    output_name_groups = defaultdict(list)
+                    for v in matches:
+                        output_name = v.split('.')[-1]
+                        output_name_groups[output_name].append(v)
+
+                    # If there are duplicates, warn the user
+                    for output_name, var_list in output_name_groups.items():
+                        if len(var_list) > 1:
+                            var_list_as_string = ', '.join(var_list)
+                            simple_warning(f"The timeseries variable name {output_name} is "
+                            f"duplicated in these variables: {var_list_as_string}. "
+                            "Disambiguate by using the add_timeseries_output output_name option.")
                 else:
                     matches = [var]
 

--- a/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
+++ b/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
@@ -1,8 +1,10 @@
+from collections import defaultdict
 from fnmatch import filter
 import warnings
 
 import numpy as np
 import openmdao.api as om
+from openmdao.utils.general_utils import simple_warning
 
 from .pseudospectral_base import PseudospectralBase
 from ..common import RadauPSContinuityComp
@@ -494,6 +496,25 @@ class Radau(PseudospectralBase):
                     ode_outputs = {opts['prom_name']: opts for (k, opts) in
                                    phase.rhs_all.get_io_metadata(iotypes=('output',)).items()}
                     matches = filter(list(ode_outputs.keys()), var)
+
+                    # A nested ODE can have multiple outputs at different levels that share
+                    #   the same name.
+                    # If the user does not use the output_name option to add_timeseries_output
+                    #   to disambiguate the variables with the same name, only one of the
+                    #   variables will be added. This code warns the user if that is happening.
+                    # Find the duplicate timeseries names by looking at the last part of the names.
+                    output_name_groups = defaultdict(list)
+                    for v in matches:
+                        output_name = v.split('.')[-1]
+                        output_name_groups[output_name].append(v)
+
+                    # If there are duplicates, warn the user
+                    for output_name, var_list in output_name_groups.items():
+                        if len(var_list) > 1:
+                            var_list_as_string = ', '.join(var_list)
+                            simple_warning(f"The timeseries variable name {output_name} is "
+                            f"duplicated in these variables: {var_list_as_string}. "
+                            "Disambiguate by using the add_timeseries_output output_name option.")
                 else:
                     matches = [var]
 

--- a/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
+++ b/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
@@ -513,8 +513,9 @@ class Radau(PseudospectralBase):
                         if len(var_list) > 1:
                             var_list_as_string = ', '.join(var_list)
                             simple_warning(f"The timeseries variable name {output_name} is "
-                            f"duplicated in these variables: {var_list_as_string}. "
-                            "Disambiguate by using the add_timeseries_output output_name option.")
+                                           f"duplicated in these variables: {var_list_as_string}. "
+                                           "Disambiguate by using the add_timeseries_output "
+                                           "output_name option.")
                 else:
                     matches = [var]
 


### PR DESCRIPTION
Variables with the same name would prevent all but one from being added to the timeseries unless the user explicitly gave them unique names using the output_name argument to add_timeseries_output

### Summary

When there is a glob pattern used with add_timeseries_output, check to see if there are any variables with the same name and warn the user. Also give them a list of the variables in conflict and provide a suggestion for how to deal with the problem.

### Related Issues

- Resolves #538 

### Status

- [X] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
