### PR TITLE
New decorator 'require_pyoptsparse' that can be used to skip tests or test objects that require specific optimizers.

### DIFF
--- a/dymos/examples/aircraft_steady_flight/test/test_ex_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_ex_aircraft_steady_flight.py
@@ -2,7 +2,6 @@ import os
 import unittest
 
 import openmdao.api as om
-from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
 
@@ -15,7 +14,6 @@ def ex_aircraft_steady_flight(optimizer='SLSQP', solve_segments=False,
                               use_boundary_constraints=False, compressed=False):
     p = om.Problem(model=om.Group())
     p.driver = om.pyOptSparseDriver()
-    _, optimizer = set_pyoptsparse_opt(optimizer, fallback=False)
     p.driver.options['optimizer'] = optimizer
     p.driver.declare_coloring()
     if optimizer == 'SNOPT':

--- a/dymos/examples/balanced_field/doc/test_doc_balanced_field_length.py
+++ b/dymos/examples/balanced_field/doc/test_doc_balanced_field_length.py
@@ -1,16 +1,15 @@
 import unittest
 
 from openmdao.utils.testing_utils import use_tempdirs
-from openmdao.utils.general_utils import set_pyoptsparse_opt
-_, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
 
 from dymos.utils.doc_utils import save_for_docs
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 @use_tempdirs
 class TestBalancedFieldLengthForDocs(unittest.TestCase):
 
-    @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
+    @require_pyoptsparse(optimizer='IPOPT')
     @save_for_docs
     def test_balanced_field_length_for_docs(self):
         import matplotlib.pyplot as plt

--- a/dymos/examples/balanced_field/doc/test_doc_balanced_field_length.py
+++ b/dymos/examples/balanced_field/doc/test_doc_balanced_field_length.py
@@ -1,11 +1,16 @@
 import unittest
+
 from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.general_utils import set_pyoptsparse_opt
+_, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
+
 from dymos.utils.doc_utils import save_for_docs
 
 
 @use_tempdirs
 class TestBalancedFieldLengthForDocs(unittest.TestCase):
 
+    @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
     @save_for_docs
     def test_balanced_field_length_for_docs(self):
         import matplotlib.pyplot as plt

--- a/dymos/examples/balanced_field/test/test_balanced_field_length.py
+++ b/dymos/examples/balanced_field/test/test_balanced_field_length.py
@@ -1,14 +1,14 @@
 import unittest
 
 import numpy as np
+
 import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.assert_utils import assert_near_equal
+
 import dymos as dm
 from dymos.examples.balanced_field.balanced_field_ode import BalancedFieldODEComp
-
-from openmdao.utils.general_utils import set_pyoptsparse_opt
-_, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 @use_tempdirs
@@ -218,6 +218,7 @@ class TestBalancedFieldLengthRestart(unittest.TestCase):
 
         return p
 
+    @require_pyoptsparse(optimizer='IPOPT')
     def test_restart_from_sol(self):
         p = self._make_problem()
         dm.run_problem(p, run_driver=True, simulate=False)
@@ -237,6 +238,7 @@ class TestBalancedFieldLengthRestart(unittest.TestCase):
         assert_near_equal(sol_results.get_val('traj.rto.timeseries.states:r')[-1], 2016, tolerance=0.01)
         assert_near_equal(sim_results.get_val('traj.rto.timeseries.states:r')[-1], 2016, tolerance=0.01)
 
+    @require_pyoptsparse(optimizer='IPOPT')
     def test_restart_from_sim(self):
         p = self._make_problem()
         dm.run_problem(p, run_driver=True, simulate=True)

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
@@ -6,7 +6,6 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
-from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.utils.testing_utils import use_tempdirs
 
 from dymos.utils.doc_utils import save_for_docs
@@ -224,7 +223,6 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         import dymos as dm
         from dymos.examples.plotting import plot_results
         from dymos.examples.brachistochrone import BrachistochroneODE
-        from openmdao.utils.general_utils import set_pyoptsparse_opt
 
         #
         # Initialize the Problem and the optimization driver
@@ -312,7 +310,6 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         import dymos as dm
         from dymos.examples.plotting import plot_results
         from dymos.examples.brachistochrone import BrachistochroneODE
-        from openmdao.utils.general_utils import set_pyoptsparse_opt
 
         #
         # Initialize the Problem and the optimization driver

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
@@ -7,10 +7,10 @@ import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
 from openmdao.utils.general_utils import set_pyoptsparse_opt
-_, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
-
 from openmdao.utils.testing_utils import use_tempdirs
+
 from dymos.utils.doc_utils import save_for_docs
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 @use_tempdirs
@@ -217,7 +217,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
 
         plt.show()
 
-    @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
+    @require_pyoptsparse(optimizer='IPOPT')
     def test_brachistochrone_for_docs_coloring_demo(self):
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal
@@ -230,8 +230,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         # Initialize the Problem and the optimization driver
         #
         p = om.Problem(model=om.Group())
-        _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
-        p.driver = om.pyOptSparseDriver(optimizer=optimizer)
+        p.driver = om.pyOptSparseDriver(optimizer='IPOPT')
         p.driver.declare_coloring(tol=1.0E-12)
 
         #
@@ -306,7 +305,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
 
         plt.show()
 
-    @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
+    @require_pyoptsparse(optimizer='IPOPT')
     def test_brachistochrone_for_docs_coloring_demo_solve_segments(self):
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal
@@ -319,8 +318,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         # Initialize the Problem and the optimization driver
         #
         p = om.Problem(model=om.Group())
-        _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
-        p.driver = om.pyOptSparseDriver(optimizer=optimizer)
+        p.driver = om.pyOptSparseDriver(optimizer='IPOPT')
         p.driver.opt_settings['print_level'] = 4
         # p.driver.declare_coloring()
 

--- a/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
@@ -4,18 +4,16 @@ import matplotlib.pyplot as plt
 plt.switch_backend('Agg')
 plt.style.use('ggplot')
 
-from openmdao.utils.general_utils import set_pyoptsparse_opt
-from dymos.utils.doc_utils import save_for_docs
 from openmdao.utils.testing_utils import use_tempdirs
 
-
-_, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
+from dymos.utils.doc_utils import save_for_docs
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 @use_tempdirs
 class TestFiniteBurnOrbitRaise(unittest.TestCase):
 
-    @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
+    @require_pyoptsparse(optimizer='IPOPT')
     @save_for_docs
     def test_finite_burn_orbit_raise(self):
         import numpy as np

--- a/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise.py
@@ -4,13 +4,12 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.utils.mpi import MPI
-_, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
+from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
-from openmdao.utils.testing_utils import use_tempdirs
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 def make_traj(transcription='gauss-lobatto', transcription_order=3, compressed=False,
@@ -266,10 +265,10 @@ def two_burn_orbit_raise_problem(transcription='gauss-lobatto', optimizer='SLSQP
     return p
 
 
+@require_pyoptsparse(optimizer='IPOPT')
 @use_tempdirs
 class TestExampleTwoBurnOrbitRaise(unittest.TestCase):
 
-    @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
     def test_ex_two_burn_orbit_raise(self):
         optimizer = 'IPOPT'
 
@@ -283,10 +282,10 @@ class TestExampleTwoBurnOrbitRaise(unittest.TestCase):
 
 
 # This test is separate because connected phases aren't directly parallelizable.
+@require_pyoptsparse(optimizer='IPOPT')
 @use_tempdirs
 class TestExampleTwoBurnOrbitRaiseConnected(unittest.TestCase):
 
-    @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
     def test_ex_two_burn_orbit_raise_connected(self):
         optimizer = 'IPOPT'
 
@@ -299,12 +298,12 @@ class TestExampleTwoBurnOrbitRaiseConnected(unittest.TestCase):
                               tolerance=4.0E-3)
 
 
+@require_pyoptsparse(optimizer='IPOPT')
 @unittest.skipUnless(MPI, "MPI is required.")
 @use_tempdirs
 class TestExampleTwoBurnOrbitRaiseMPI(unittest.TestCase):
     N_PROCS = 3
 
-    @unittest.skipIf(optimizer is not 'IPOPT', 'IPOPT not available')
     def test_ex_two_burn_orbit_raise(self):
         optimizer = 'IPOPT'
 

--- a/dymos/examples/finite_burn_orbit_raise/test/test_multi_phase_restart.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_multi_phase_restart.py
@@ -4,13 +4,11 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.general_utils import set_pyoptsparse_opt
-_, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
+from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
-from openmdao.utils.testing_utils import use_tempdirs
-from dymos.utils.testing_utils import assert_cases_equal
+from dymos.utils.testing_utils import assert_cases_equal, require_pyoptsparse
 
 
 def make_traj(transcription='gauss-lobatto', transcription_order=3, compressed=False,
@@ -269,10 +267,10 @@ def two_burn_orbit_raise_problem(transcription='gauss-lobatto', optimizer='SLSQP
     return p
 
 
+@require_pyoptsparse(optimizer='IPOPT')
 @use_tempdirs
 class TestExampleTwoBurnOrbitRaiseRestart(unittest.TestCase):
 
-    @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
     def test_restart_from_solution_gl(self):
         optimizer = 'IPOPT'
 
@@ -299,7 +297,6 @@ class TestExampleTwoBurnOrbitRaiseRestart(unittest.TestCase):
         assert_cases_equal(case1, case2)
         assert_cases_equal(sim_case1, sim_case2)
 
-    @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
     def test_restart_from_solution_radau(self):
         optimizer = 'IPOPT'
 
@@ -327,10 +324,10 @@ class TestExampleTwoBurnOrbitRaiseRestart(unittest.TestCase):
 
 
 # This test is separate because connected phases aren't directly parallelizable.
+@require_pyoptsparse(optimizer='IPOPT')
 @use_tempdirs
 class TestExampleTwoBurnOrbitRaiseConnected(unittest.TestCase):
 
-    @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
     def test_ex_two_burn_orbit_raise_connected(self):
         optimizer = 'IPOPT'
 
@@ -358,7 +355,6 @@ class TestExampleTwoBurnOrbitRaiseConnected(unittest.TestCase):
         assert_cases_equal(case1, case2)
         assert_cases_equal(sim_case1, sim_case2)
 
-    @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
     def test_restart_from_solution_radau_to_connected(self):
         optimizer = 'IPOPT'
 

--- a/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
@@ -2,20 +2,20 @@ import unittest
 import warnings
 
 from openmdao.utils.testing_utils import use_tempdirs
-from openmdao.utils.general_utils import set_pyoptsparse_opt
-_, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
+
+from dymos.utils.testing_utils import require_pyoptsparse
 
 import matplotlib.pyplot as plt
 plt.switch_backend('Agg')
 
 
-@unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
+#@unittest.skipIf('optimizer' != 'IPOPT', 'IPOPT not available')
+@require_pyoptsparse(optimizer='IPOPT')
 @use_tempdirs
 class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
     def test_two_burn_orbit_raise_gl_radau_gl_changing_units_error(self):
         import openmdao.api as om
-        from openmdao.utils.general_utils import set_pyoptsparse_opt
 
         import dymos as dm
         from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
@@ -25,8 +25,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
         p.model.add_subsystem('traj', traj)
 
         p.driver = om.pyOptSparseDriver()
-        _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
-        p.driver.options['optimizer'] = optimizer
+        p.driver.options['optimizer'] = 'IPOPT'
 
         p.driver.declare_coloring()
 
@@ -138,7 +137,6 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal
-        from openmdao.utils.general_utils import set_pyoptsparse_opt
 
         import dymos as dm
         from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
@@ -148,8 +146,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
         p.model.add_subsystem('traj', traj)
 
         p.driver = om.pyOptSparseDriver()
-        _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
-        p.driver.options['optimizer'] = optimizer
+        p.driver.options['optimizer'] = 'IPOPT'
 
         p.driver.declare_coloring()
 
@@ -377,7 +374,6 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal
-        from openmdao.utils.general_utils import set_pyoptsparse_opt
 
         import dymos as dm
         from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
@@ -387,8 +383,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
         p.model.add_subsystem('traj', traj)
 
         p.driver = om.pyOptSparseDriver()
-        _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=False)
-        p.driver.options['optimizer'] = optimizer
+        p.driver.options['optimizer'] = 'IPOPT'
         p.driver.opt_settings['max_iter'] = 500
         p.driver.opt_settings['print_level'] = 4
 
@@ -631,7 +626,6 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal
-        from openmdao.utils.general_utils import set_pyoptsparse_opt
 
         import dymos as dm
         from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
@@ -641,8 +635,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
         p.model.add_subsystem('traj', traj)
 
         p.driver = om.pyOptSparseDriver()
-        _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
-        p.driver.options['optimizer'] = optimizer
+        p.driver.options['optimizer'] = 'IPOPT'
 
         p.driver.declare_coloring()
 
@@ -810,7 +803,6 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal
-        from openmdao.utils.general_utils import set_pyoptsparse_opt
 
         import dymos as dm
         from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
@@ -820,8 +812,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
         p.model.add_subsystem('traj', traj)
 
         p.driver = om.pyOptSparseDriver()
-        _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
-        p.driver.options['optimizer'] = optimizer
+        p.driver.options['optimizer'] = 'IPOPT'
 
         p.driver.declare_coloring()
 
@@ -995,7 +986,6 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal
-        from openmdao.utils.general_utils import set_pyoptsparse_opt
 
         import dymos as dm
         from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
@@ -1005,8 +995,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
         p.model.add_subsystem('traj', traj)
 
         p.driver = om.pyOptSparseDriver()
-        _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
-        p.driver.options['optimizer'] = optimizer
+        p.driver.options['optimizer'] = 'IPOPT'
 
         p.driver.declare_coloring()
 

--- a/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
@@ -9,7 +9,6 @@ import matplotlib.pyplot as plt
 plt.switch_backend('Agg')
 
 
-#@unittest.skipIf('optimizer' != 'IPOPT', 'IPOPT not available')
 @require_pyoptsparse(optimizer='IPOPT')
 @use_tempdirs
 class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):

--- a/dymos/examples/hyper_sensitive/test/test_hyper_sensitive.py
+++ b/dymos/examples/hyper_sensitive/test/test_hyper_sensitive.py
@@ -3,17 +3,19 @@ from __future__ import print_function, division, absolute_import
 import os
 import unittest
 import warnings
+
+import numpy as np
+
 from openmdao.api import Problem, Group, pyOptSparseDriver
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import printoptions
 from openmdao.utils.testing_utils import use_tempdirs
+
+import dymos as dm
 from dymos import Trajectory, GaussLobatto, Phase, Radau
 from dymos.examples.hyper_sensitive.hyper_sensitive_ode import HyperSensitiveODE
-import numpy as np
-import dymos as dm
+from dymos.utils.testing_utils import require_pyoptsparse
 
-from openmdao.utils.general_utils import set_pyoptsparse_opt
-_, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
 
 tf = np.float128(10)
 
@@ -89,7 +91,7 @@ class TestHyperSensitive(unittest.TestCase):
         with printoptions(linewidth=1024, edgeitems=100):
             cpd = p.check_partials(method='fd', compact_print=True, out_stream=None)
 
-    @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
+    @require_pyoptsparse(optimizer='IPOPT')
     def test_hyper_sensitive_radau(self):
         p = self.make_problem(transcription=Radau, optimizer='IPOPT')
         dm.run_problem(p, refine_iteration_limit=5)
@@ -107,7 +109,7 @@ class TestHyperSensitive(unittest.TestCase):
                           J,
                           tolerance=1e-6)
 
-    @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
+    @require_pyoptsparse(optimizer='IPOPT')
     def test_hyper_sensitive_gauss_lobatto(self):
         p = self.make_problem(transcription=GaussLobatto, optimizer='IPOPT')
         dm.run_problem(p, refine_iteration_limit=5)
@@ -126,7 +128,7 @@ class TestHyperSensitive(unittest.TestCase):
                           J,
                           tolerance=1e-4)
 
-    @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
+    @require_pyoptsparse(optimizer='IPOPT')
     def test_refinement_warning(self):
         p = self.make_problem(transcription=Radau, optimizer='IPOPT')
 

--- a/dymos/examples/min_time_climb/doc/test_doc_min_time_climb_fd.py
+++ b/dymos/examples/min_time_climb/doc/test_doc_min_time_climb_fd.py
@@ -8,9 +8,11 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
-from dymos.utils.doc_utils import save_for_docs
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.coloring import Coloring
+
+from dymos.utils.doc_utils import save_for_docs
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 def _view_coloring(coloring_file, show_sparsity_text=False, show_sparsity=True,
@@ -45,6 +47,7 @@ def _view_coloring(coloring_file, show_sparsity_text=False, show_sparsity=True,
 @use_tempdirs
 class TestMinTimeClimbForDocs(unittest.TestCase):
 
+    @require_pyoptsparse(optimizer='IPOPT')
     @save_for_docs
     def test_min_time_climb_for_docs_partial_coloring(self):
         import openmdao.api as om

--- a/dymos/examples/racecar/doc/test_doc_racecar.py
+++ b/dymos/examples/racecar/doc/test_doc_racecar.py
@@ -1,12 +1,15 @@
 import unittest
 
-from dymos.utils.doc_utils import save_for_docs
 from openmdao.utils.testing_utils import use_tempdirs
+
+from dymos.utils.doc_utils import save_for_docs
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 @use_tempdirs
 class TestRaceCarForDocs(unittest.TestCase):
 
+    @require_pyoptsparse(optimizer='IPOPT')
     @save_for_docs
     def test_racecar_for_docs(self):
         import numpy as np

--- a/dymos/examples/shuttle_reentry/test/test_reentry.py
+++ b/dymos/examples/shuttle_reentry/test/test_reentry.py
@@ -1,13 +1,14 @@
 import unittest
-import openmdao.api as om
 
+import numpy as np
+
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 from openmdao.utils.testing_utils import use_tempdirs
 
-from openmdao.utils.general_utils import set_pyoptsparse_opt
 from dymos import Trajectory, GaussLobatto, Phase, Radau
 from dymos.examples.shuttle_reentry.shuttle_ode import ShuttleODE
-import numpy as np
+from dymos.utils.testing_utils import require_pyoptsparse
 
 # Expected results from Betts
 expected_results = {'constrained': {'time': 2198.67, 'theta': 30.6255},
@@ -22,8 +23,7 @@ class TestReentry(unittest.TestCase):
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()
         p.driver.declare_coloring()
-        OPT, OPTIMIZER = set_pyoptsparse_opt(optimizer, fallback=False)
-        p.driver.options['optimizer'] = OPTIMIZER
+        p.driver.options['optimizer'] = optimizer
 
         traj = p.model.add_subsystem('traj', Trajectory())
         phase0 = traj.add_phase('phase0',
@@ -88,6 +88,7 @@ class TestReentry(unittest.TestCase):
         cpd = p.check_partials(method='cs', compact_print=True, out_stream=None)
         assert_check_partials(cpd, atol=1.0E-4, rtol=1.1)
 
+    @require_pyoptsparse(optimizer='IPOPT')
     def test_reentry_constrained_radau(self):
         p = self.make_problem(constrained=True, transcription=Radau, optimizer='IPOPT')
         p.run_driver()
@@ -99,6 +100,7 @@ class TestReentry(unittest.TestCase):
                           expected_results['constrained']['theta'],
                           tolerance=1e-2)
 
+    @require_pyoptsparse(optimizer='IPOPT')
     def test_reentry_constrained_gauss_lobatto(self):
         p = self.make_problem(constrained=True, transcription=GaussLobatto, optimizer='IPOPT')
         p.run_driver()
@@ -110,6 +112,7 @@ class TestReentry(unittest.TestCase):
                           expected_results['constrained']['theta'],
                           tolerance=1e-2)
 
+    @require_pyoptsparse(optimizer='IPOPT')
     def test_reentry_unconstrained_radau(self):
         p = self.make_problem(constrained=False, transcription=Radau, optimizer='IPOPT')
         p.run_driver()
@@ -121,6 +124,7 @@ class TestReentry(unittest.TestCase):
                           expected_results['unconstrained']['theta'],
                           tolerance=1e-2)
 
+    @require_pyoptsparse(optimizer='IPOPT')
     def test_reentry_unconstrained_gauss_lobatto(self):
         p = self.make_problem(constrained=False, transcription=GaussLobatto, optimizer='IPOPT')
         p.run_driver()
@@ -132,13 +136,13 @@ class TestReentry(unittest.TestCase):
                           expected_results['unconstrained']['theta'],
                           tolerance=1e-2)
 
+    @require_pyoptsparse(optimizer='IPOPT')
     def test_reentry_mixed_controls(self):
 
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()
         p.driver.declare_coloring()
-        OPT, OPTIMIZER = set_pyoptsparse_opt('IPOPT', fallback=False)
-        p.driver.options['optimizer'] = OPTIMIZER
+        p.driver.options['optimizer'] = 'IPOPT'
 
         traj = p.model.add_subsystem('traj', Trajectory())
         phase0 = traj.add_phase('phase0',

--- a/dymos/examples/vanderpol/test/test_vanderpol.py
+++ b/dymos/examples/vanderpol/test/test_vanderpol.py
@@ -4,11 +4,10 @@ import numpy as np
 
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.mpi import MPI
-from openmdao.utils.general_utils import set_pyoptsparse_opt
-_, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
 
 import dymos as dm
 from dymos.examples.vanderpol.vanderpol_dymos import vanderpol
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 @use_tempdirs
@@ -47,7 +46,8 @@ class TestVanderpolExampleMPI(unittest.TestCase):
 
     N_PROCS = 4
 
-    @unittest.skipUnless(MPI and optimizer == 'IPOPT', 'this test requires MPI and IPOPT')
+    @require_pyoptsparse(optimizer='IPOPT')
+    @unittest.skipUnless(MPI, 'this test requires MPI')
     def test_vanderpol_optimal_mpi(self):
         """to test with MPI:
            OPENMDAO_REQUIRE_MPI=1 mpirun -n 4 python

--- a/dymos/examples/water_rocket/doc/test_doc_water_rocket.py
+++ b/dymos/examples/water_rocket/doc/test_doc_water_rocket.py
@@ -1,21 +1,22 @@
 import unittest
 from collections import namedtuple
 
+import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 
-import numpy as np
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.utils.testing_utils import use_tempdirs
 
 from dymos.examples.water_rocket.phases import (new_water_rocket_trajectory,
                                                 set_sane_initial_guesses)
 
 from dymos.utils.doc_utils import save_for_docs
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
+@require_pyoptsparse(optimizer='IPOPT')
 @use_tempdirs
 class TestWaterRocketForDocs(unittest.TestCase):
 
@@ -26,7 +27,6 @@ class TestWaterRocketForDocs(unittest.TestCase):
         traj, phases = new_water_rocket_trajectory(objective='height')
         traj = p.model.add_subsystem('traj', traj)
 
-        _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=False)
         p.driver = om.pyOptSparseDriver(optimizer='IPOPT')
         p.driver.opt_settings['print_level'] = 4
         p.driver.opt_settings['max_iter'] = 1000
@@ -69,7 +69,6 @@ class TestWaterRocketForDocs(unittest.TestCase):
         traj, phases = new_water_rocket_trajectory(objective='range')
         traj = p.model.add_subsystem('traj', traj)
 
-        _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=False)
         p.driver = om.pyOptSparseDriver(optimizer='IPOPT')
         p.driver.opt_settings['print_level'] = 4
         p.driver.opt_settings['max_iter'] = 1000

--- a/dymos/trajectory/test/test_parameter_promotion.py
+++ b/dymos/trajectory/test/test_parameter_promotion.py
@@ -7,11 +7,13 @@ from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 @use_tempdirs
 class TestPhaseParameterPromotion(unittest.TestCase):
 
+    @require_pyoptsparse(optimizer='SNOPT')
     def test_promotes_parameter(self):
         transcription = 'radau-ps'
         optimizer = 'SNOPT'

--- a/dymos/utils/testing_utils.py
+++ b/dymos/utils/testing_utils.py
@@ -1,4 +1,7 @@
+import functools
+
 import numpy as np
+
 from scipy.interpolate import interp1d
 
 import openmdao.utils.assert_utils as _om_assert_utils
@@ -179,3 +182,52 @@ def assert_timeseries_near_equal(t1, x1, t2, x2, tolerance=1.0E-6):
     y_interp = np.reshape(interp(t_check), newshape=(num_points,) + shape1)
 
     _om_assert_utils.assert_near_equal(y_interp, x_check, tolerance=tolerance)
+
+
+def require_pyoptsparse(optimizer=None):
+    """
+    Decorate test to raise a skiptest if a required pyoptsparse optimizer cannot be imported.
+
+    Parameters
+    ----------
+    optimizer : String
+        Pyoptsparse optimizer string. Default is None, which just checks for pyoptsparse.
+
+    Returns
+    -------
+    TestCase or TestCase.method
+        The decorated TestCase class or method.
+    """
+    def decorator(obj):
+
+        import unittest
+        try:
+            from pyoptsparse import OPT
+
+        except Exception:
+            msg = "pyoptsparse is not installed."
+
+            if not isinstance(obj, type):
+                @functools.wraps(obj)
+                def skip_wrapper(*args, **kwargs):
+                    raise unittest.SkipTest(msg)
+                obj = skip_wrapper
+            obj.__unittest_skip__ = True
+            obj.__unittest_skip_why__ = msg
+            return obj
+
+        try:
+            OPT(optimizer)
+        except Exception:
+            msg = "pyoptsparse is not providing %s" % optimizer
+
+            if not isinstance(obj, type):
+                @functools.wraps(obj)
+                def skip_wrapper(*args, **kwargs):
+                    raise unittest.SkipTest(msg)
+                obj = skip_wrapper
+            obj.__unittest_skip__ = True
+            obj.__unittest_skip_why__ = msg
+
+        return obj
+    return decorator

--- a/dymos/visualization/test/test_timeseries_plots.py
+++ b/dymos/visualization/test/test_timeseries_plots.py
@@ -12,9 +12,7 @@ from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneOD
 from dymos.examples.battery_multibranch.battery_multibranch_ode import BatteryODE
 from dymos.utils.lgl import lgl
 from dymos.visualization.timeseries_plots import timeseries_plots
-
-from openmdao.utils.general_utils import set_pyoptsparse_opt
-_, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 @use_tempdirs
@@ -125,7 +123,7 @@ class TestTimeSeriesPlotsBasics(unittest.TestCase):
 @use_tempdirs
 class TestTimeSeriesPlotsMultiPhase(unittest.TestCase):
 
-    @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
+    @require_pyoptsparse(optimizer='IPOPT')
     def test_trajectory_linked_phases_make_plot(self):
 
         self.traj = dm.Trajectory()
@@ -357,7 +355,7 @@ class TestTimeSeriesPlotsMultiPhase(unittest.TestCase):
         self.assertTrue(os.path.exists('plots/states_state_of_charge.png'))
         self.assertTrue(os.path.exists('plots/state_rates_state_of_charge.png'))
 
-    @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
+    @require_pyoptsparse(optimizer='IPOPT')
     def test_trajectory_linked_phases_make_plot_missing_data(self):
         """
         Test that plots are still generated even if the phases don't share the exact same


### PR DESCRIPTION
### Summary

New decorator 'require_pyoptsparse' that can be used to skip tests or test objects that require specific optimizers.
(e.g. require_pyoptsparse(optimizer='IPOPT')

### Related Issues

- Resolves #569

### Status

- [x ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
