### PR TITLE
Updated tags and changed the name of option dynamic on parameters

### DIFF
--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -52,7 +52,7 @@ jobs:
             PYOPTSPARSE: 'v1.2'
             SNOPT: 7.2
             MBI: 1
-            OPENMDAO: 3.6.0
+            OPENMDAO: 3.9.0
             OPTIONAL: '[all]'
             DOCS: 0
 

--- a/benchmark/benchmark_balanced_field.py
+++ b/benchmark/benchmark_balanced_field.py
@@ -99,23 +99,23 @@ def _run_balanced_field_length_problem(tx=dm.GaussLobatto, timeseries=True, sim=
                        targets={'br_to_v1': ['m'], 'v1_to_vr': ['m'], 'rto': ['m'],
                                 'rotate': ['m'], 'climb': ['m']})
 
-    traj.add_parameter('T_nominal', val=27000 * 2, opt=False, units='lbf', dynamic=False,
+    traj.add_parameter('T_nominal', val=27000 * 2, opt=False, units='lbf', static_target=True,
                        desc='nominal aircraft thrust',
                        targets={'br_to_v1': ['T']})
 
-    traj.add_parameter('T_engine_out', val=27000, opt=False, units='lbf', dynamic=False,
+    traj.add_parameter('T_engine_out', val=27000, opt=False, units='lbf', static_target=True,
                        desc='thrust under a single engine',
                        targets={'v1_to_vr': ['T'], 'rotate': ['T'], 'climb': ['T']})
 
-    traj.add_parameter('T_shutdown', val=0.0, opt=False, units='lbf', dynamic=False,
+    traj.add_parameter('T_shutdown', val=0.0, opt=False, units='lbf', static_target=True,
                        desc='thrust when engines are shut down for rejected takeoff',
                        targets={'rto': ['T']})
 
-    traj.add_parameter('mu_r_nominal', val=0.03, opt=False, units=None, dynamic=False,
+    traj.add_parameter('mu_r_nominal', val=0.03, opt=False, units=None, static_target=True,
                        desc='nominal runway friction coefficient',
                        targets={'br_to_v1': ['mu_r'], 'v1_to_vr': ['mu_r'], 'rotate': ['mu_r']})
 
-    traj.add_parameter('mu_r_braking', val=0.3, opt=False, units=None, dynamic=False,
+    traj.add_parameter('mu_r_braking', val=0.3, opt=False, units=None, static_target=True,
                        desc='runway friction coefficient under braking',
                        targets={'rto': ['mu_r']})
 
@@ -124,52 +124,52 @@ def _run_balanced_field_length_problem(tx=dm.GaussLobatto, timeseries=True, sim=
                        targets={'br_to_v1': ['h'], 'v1_to_vr': ['h'], 'rto': ['h'],
                                 'rotate': ['h']})
 
-    traj.add_parameter('rho', val=1.225, opt=False, units='kg/m**3', dynamic=False,
+    traj.add_parameter('rho', val=1.225, opt=False, units='kg/m**3', static_target=True,
                        desc='atmospheric density',
                        targets={'br_to_v1': ['rho'], 'v1_to_vr': ['rho'], 'rto': ['rho'],
                                 'rotate': ['rho']})
 
-    traj.add_parameter('S', val=124.7, opt=False, units='m**2', dynamic=False,
+    traj.add_parameter('S', val=124.7, opt=False, units='m**2', static_target=True,
                        desc='aerodynamic reference area',
                        targets={'br_to_v1': ['S'], 'v1_to_vr': ['S'], 'rto': ['S'],
                                 'rotate': ['S'], 'climb': ['S']})
 
-    traj.add_parameter('CD0', val=0.03, opt=False, units=None, dynamic=False,
+    traj.add_parameter('CD0', val=0.03, opt=False, units=None, static_target=True,
                        desc='zero-lift drag coefficient',
                        targets={f'{phase}': ['CD0'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                   'rto', 'rotate' 'climb']})
 
-    traj.add_parameter('AR', val=9.45, opt=False, units=None, dynamic=False,
+    traj.add_parameter('AR', val=9.45, opt=False, units=None, static_target=True,
                        desc='wing aspect ratio',
                        targets={f'{phase}': ['AR'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                  'rto', 'rotate' 'climb']})
 
-    traj.add_parameter('e', val=801, opt=False, units=None, dynamic=False,
+    traj.add_parameter('e', val=801, opt=False, units=None, static_target=True,
                        desc='Oswald span efficiency factor',
                        targets={f'{phase}': ['e'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                 'rto', 'rotate' 'climb']})
 
-    traj.add_parameter('span', val=35.7, opt=False, units='m', dynamic=False,
+    traj.add_parameter('span', val=35.7, opt=False, units='m', static_target=True,
                        desc='wingspan',
                        targets={f'{phase}': ['span'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                    'rto', 'rotate' 'climb']})
 
-    traj.add_parameter('h_w', val=1.0, opt=False, units='m', dynamic=False,
+    traj.add_parameter('h_w', val=1.0, opt=False, units='m', static_target=True,
                        desc='height of wing above CG',
                        targets={f'{phase}': ['h_w'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                   'rto', 'rotate' 'climb']})
 
-    traj.add_parameter('CL0', val=0.5, opt=False, units=None, dynamic=False,
+    traj.add_parameter('CL0', val=0.5, opt=False, units=None, static_target=True,
                        desc='zero-alpha lift coefficient',
                        targets={f'{phase}': ['CL0'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                   'rto', 'rotate' 'climb']})
 
-    traj.add_parameter('CL_max', val=2.0, opt=False, units=None, dynamic=False,
+    traj.add_parameter('CL_max', val=2.0, opt=False, units=None, static_target=True,
                        desc='maximum lift coefficient for linear fit',
                        targets={f'{phase}': ['CL_max'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                      'rto', 'rotate' 'climb']})
 
-    traj.add_parameter('alpha_max', val=10.0, opt=False, units='deg', dynamic=False,
+    traj.add_parameter('alpha_max', val=10.0, opt=False, units='deg', static_target=True,
                        desc='angle of attack at maximum lift',
                        targets={f'{phase}': ['alpha_max'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                         'rto', 'rotate' 'climb']})

--- a/benchmark/benchmark_racecar.py
+++ b/benchmark/benchmark_racecar.py
@@ -92,19 +92,19 @@ def _run_racecar_problem(transcription, timeseries=False):
     # be found in their respective ODE files.
     phase.add_parameter('M', val=800.0, units='kg', opt=False,
                         targets=['car.M', 'tire.M', 'tireconstraint.M', 'normal.M'],
-                        dynamic=False)  # vehicle mass
+                        static_target=True)  # vehicle mass
     phase.add_parameter('beta', val=0.62, units=None, opt=False, targets=['tire.beta'],
-                        dynamic=False)  # brake bias
+                        static_target=True)  # brake bias
     phase.add_parameter('CoP', val=1.6, units='m', opt=False, targets=['normal.CoP'],
-                        dynamic=False)  # center of pressure location
+                        static_target=True)  # center of pressure location
     phase.add_parameter('h', val=0.3, units='m', opt=False, targets=['normal.h'],
-                        dynamic=False)  # center of gravity height
+                        static_target=True)  # center of gravity height
     phase.add_parameter('chi', val=0.5, units=None, opt=False, targets=['normal.chi'],
-                        dynamic=False)  # roll stiffness
+                        static_target=True)  # roll stiffness
     phase.add_parameter('ClA', val=4.0, units='m**2', opt=False, targets=['normal.ClA'],
-                        dynamic=False)  # downforce coefficient*area
+                        static_target=True)  # downforce coefficient*area
     phase.add_parameter('CdA', val=2.0, units='m**2', opt=False, targets=['car.CdA'],
-                        dynamic=False)  # drag coefficient*area
+                        static_target=True)  # drag coefficient*area
 
     # Minimize final time.
     # note that we use the 'state' time instead of Dymos 'time'

--- a/dymos/examples/balanced_field/balanced_field_ode.py
+++ b/dymos/examples/balanced_field/balanced_field_ode.py
@@ -48,9 +48,9 @@ class BalancedFieldODEComp(om.ExplicitComponent):
         self.add_output('K', val=np.ones(nn), desc='drag-due-to-lift factor', units=None)
         self.add_output('F_r', shape=(nn,), desc='runway normal force', units='N')
         self.add_output('v_dot', shape=(nn,), desc='rate of change of speed', units='m/s**2',
-                        tags=['state_rate_source:v'])
+                        tags=['dymos.state_rate_source:v'])
         self.add_output('r_dot', shape=(nn,), desc='rate of change of range', units='m/s',
-                        tags=['state_rate_source:r'])
+                        tags=['dymos.state_rate_source:r'])
         self.add_output('W', shape=(nn,), desc='aircraft weight', units='N')
         self.add_output('v_stall', shape=(nn,), desc='stall speed', units='m/s')
         self.add_output('v_over_v_stall', shape=(nn,), desc='stall speed ratio', units=None)
@@ -61,9 +61,9 @@ class BalancedFieldODEComp(om.ExplicitComponent):
         else:
             self.add_input('gam', shape=(nn,), desc='flight path angle', units='rad')
             self.add_output('gam_dot', shape=(nn,), desc='rate of change of flight path angle',
-                            units='rad/s', tags=['state_rate_source:gam'])
+                            units='rad/s', tags=['dymos.state_rate_source:gam'])
             self.add_output('h_dot', shape=(nn,), desc='rate of change of altitude', units='m/s',
-                            tags=['state_rate_source:h'])
+                            tags=['dymos.state_rate_source:h'])
 
         self.declare_coloring(wrt='*', method='cs')
 

--- a/dymos/examples/balanced_field/doc/test_doc_balanced_field_length.py
+++ b/dymos/examples/balanced_field/doc/test_doc_balanced_field_length.py
@@ -95,23 +95,23 @@ class TestBalancedFieldLengthForDocs(unittest.TestCase):
                            targets={'br_to_v1': ['m'], 'v1_to_vr': ['m'], 'rto': ['m'],
                                     'rotate': ['m'], 'climb': ['m']})
 
-        traj.add_parameter('T_nominal', val=27000 * 2, opt=False, units='lbf', dynamic=False,
+        traj.add_parameter('T_nominal', val=27000 * 2, opt=False, units='lbf', static_target=True,
                            desc='nominal aircraft thrust',
                            targets={'br_to_v1': ['T']})
 
-        traj.add_parameter('T_engine_out', val=27000, opt=False, units='lbf', dynamic=False,
+        traj.add_parameter('T_engine_out', val=27000, opt=False, units='lbf', static_target=True,
                            desc='thrust under a single engine',
                            targets={'v1_to_vr': ['T'], 'rotate': ['T'], 'climb': ['T']})
 
-        traj.add_parameter('T_shutdown', val=0.0, opt=False, units='lbf', dynamic=False,
+        traj.add_parameter('T_shutdown', val=0.0, opt=False, units='lbf', static_target=True,
                            desc='thrust when engines are shut down for rejected takeoff',
                            targets={'rto': ['T']})
 
-        traj.add_parameter('mu_r_nominal', val=0.03, opt=False, units=None, dynamic=False,
+        traj.add_parameter('mu_r_nominal', val=0.03, opt=False, units=None, static_target=True,
                            desc='nominal runway friction coefficient',
                            targets={'br_to_v1': ['mu_r'], 'v1_to_vr': ['mu_r'],  'rotate': ['mu_r']})
 
-        traj.add_parameter('mu_r_braking', val=0.3, opt=False, units=None, dynamic=False,
+        traj.add_parameter('mu_r_braking', val=0.3, opt=False, units=None, static_target=True,
                            desc='runway friction coefficient under braking',
                            targets={'rto': ['mu_r']})
 
@@ -120,52 +120,52 @@ class TestBalancedFieldLengthForDocs(unittest.TestCase):
                            targets={'br_to_v1': ['h'], 'v1_to_vr': ['h'], 'rto': ['h'],
                                     'rotate': ['h']})
 
-        traj.add_parameter('rho', val=1.225, opt=False, units='kg/m**3', dynamic=False,
+        traj.add_parameter('rho', val=1.225, opt=False, units='kg/m**3', static_target=True,
                            desc='atmospheric density',
                            targets={'br_to_v1': ['rho'], 'v1_to_vr': ['rho'], 'rto': ['rho'],
                                     'rotate': ['rho']})
 
-        traj.add_parameter('S', val=124.7, opt=False, units='m**2', dynamic=False,
+        traj.add_parameter('S', val=124.7, opt=False, units='m**2', static_target=True,
                            desc='aerodynamic reference area',
                            targets={'br_to_v1': ['S'], 'v1_to_vr': ['S'], 'rto': ['S'],
                                     'rotate': ['S'], 'climb': ['S']})
 
-        traj.add_parameter('CD0', val=0.03, opt=False, units=None, dynamic=False,
+        traj.add_parameter('CD0', val=0.03, opt=False, units=None, static_target=True,
                            desc='zero-lift drag coefficient',
                            targets={f'{phase}': ['CD0'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                       'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('AR', val=9.45, opt=False, units=None, dynamic=False,
+        traj.add_parameter('AR', val=9.45, opt=False, units=None, static_target=True,
                            desc='wing aspect ratio',
                            targets={f'{phase}': ['AR'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                      'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('e', val=801, opt=False, units=None, dynamic=False,
+        traj.add_parameter('e', val=801, opt=False, units=None, static_target=True,
                            desc='Oswald span efficiency factor',
                            targets={f'{phase}': ['e'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                     'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('span', val=35.7, opt=False, units='m', dynamic=False,
+        traj.add_parameter('span', val=35.7, opt=False, units='m', static_target=True,
                            desc='wingspan',
                            targets={f'{phase}': ['span'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                        'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('h_w', val=1.0, opt=False, units='m', dynamic=False,
+        traj.add_parameter('h_w', val=1.0, opt=False, units='m', static_target=True,
                            desc='height of wing above CG',
                            targets={f'{phase}': ['h_w'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                       'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('CL0', val=0.5, opt=False, units=None, dynamic=False,
+        traj.add_parameter('CL0', val=0.5, opt=False, units=None, static_target=True,
                            desc='zero-alpha lift coefficient',
                            targets={f'{phase}': ['CL0'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                       'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('CL_max', val=2.0, opt=False, units=None, dynamic=False,
+        traj.add_parameter('CL_max', val=2.0, opt=False, units=None, static_target=True,
                            desc='maximum lift coefficient for linear fit',
                            targets={f'{phase}': ['CL_max'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                          'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('alpha_max', val=10.0, opt=False, units='deg', dynamic=False,
+        traj.add_parameter('alpha_max', val=10.0, opt=False, units='deg', static_target=True,
                            desc='angle of attack at maximum lift',
                            targets={f'{phase}': ['alpha_max'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                             'rto', 'rotate' 'climb']})

--- a/dymos/examples/balanced_field/test/test_balanced_field_length.py
+++ b/dymos/examples/balanced_field/test/test_balanced_field_length.py
@@ -86,72 +86,72 @@ class TestBalancedFieldLengthRestart(unittest.TestCase):
                            targets={'br_to_v1': ['m'], 'v1_to_vr': ['m'], 'rto': ['m'],
                                     'rotate': ['m'], 'climb': ['m']})
 
-        traj.add_parameter('T_nominal', val=27000 * 2, opt=False, units='lbf', dynamic=False,
+        traj.add_parameter('T_nominal', val=27000 * 2, opt=False, units='lbf', static_target=True,
                            desc='nominal aircraft thrust',
                            targets={'br_to_v1': ['T']})
 
-        traj.add_parameter('T_engine_out', val=27000, opt=False, units='lbf', dynamic=False,
+        traj.add_parameter('T_engine_out', val=27000, opt=False, units='lbf', static_target=True,
                            desc='thrust under a single engine',
                            targets={'v1_to_vr': ['T'], 'rotate': ['T'], 'climb': ['T']})
 
-        traj.add_parameter('T_shutdown', val=0.0, opt=False, units='lbf', dynamic=False,
+        traj.add_parameter('T_shutdown', val=0.0, opt=False, units='lbf', static_target=True,
                            desc='thrust when engines are shut down for rejected takeoff',
                            targets={'rto': ['T']})
 
-        traj.add_parameter('mu_r_nominal', val=0.03, opt=False, units=None, dynamic=False,
+        traj.add_parameter('mu_r_nominal', val=0.03, opt=False, units=None, static_target=True,
                            desc='nominal runway friction coeffcient',
                            targets={'br_to_v1': ['mu_r'], 'v1_to_vr': ['mu_r'],  'rotate': ['mu_r']})
 
-        traj.add_parameter('mu_r_braking', val=0.3, opt=False, units=None, dynamic=False,
+        traj.add_parameter('mu_r_braking', val=0.3, opt=False, units=None, static_target=True,
                            desc='runway friction coefficient under braking',
                            targets={'rto': ['mu_r']})
 
-        traj.add_parameter('h_runway', val=0., opt=False, units='ft', dynamic=True,
+        traj.add_parameter('h_runway', val=0., opt=False, units='ft', static_target=False,
                            desc='runway altitude',
                            targets={'br_to_v1': ['h'], 'v1_to_vr': ['h'], 'rto': ['h'],
                                     'rotate': ['h']})
 
-        traj.add_parameter('rho', val=1.225, opt=False, units='kg/m**3', dynamic=False,
+        traj.add_parameter('rho', val=1.225, opt=False, units='kg/m**3', static_target=True,
                            desc='atmospheric density',
                            targets={'br_to_v1': ['rho'], 'v1_to_vr': ['rho'], 'rto': ['rho'],
                                     'rotate': ['rho']})
 
-        traj.add_parameter('S', val=124.7, opt=False, units='m**2', dynamic=False,
+        traj.add_parameter('S', val=124.7, opt=False, units='m**2', static_target=True,
                            desc='aerodynamic reference area',
                            targets={'br_to_v1': ['S'], 'v1_to_vr': ['S'], 'rto': ['S'],
                                     'rotate': ['S'], 'climb': ['S']})
 
-        traj.add_parameter('CD0', val=0.03, opt=False, units=None, dynamic=False,
+        traj.add_parameter('CD0', val=0.03, opt=False, units=None, static_target=True,
                            desc='zero-lift drag coefficient',
                            targets={f'{phase}': ['CD0'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                       'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('AR', val=9.45, opt=False, units=None, dynamic=False,
+        traj.add_parameter('AR', val=9.45, opt=False, units=None, static_target=True,
                            desc='wing aspect ratio',
                            targets={f'{phase}': ['AR'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                      'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('e', val=801, opt=False, units=None, dynamic=False,
+        traj.add_parameter('e', val=801, opt=False, units=None, static_target=True,
                            desc='Oswald span efficiency factor',
                            targets={f'{phase}': ['e'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                     'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('span', val=35.7, opt=False, units='m', dynamic=False,
+        traj.add_parameter('span', val=35.7, opt=False, units='m', static_target=True,
                            desc='wingspan',
                            targets={f'{phase}': ['span'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                        'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('h_w', val=1.0, opt=False, units='m', dynamic=False,
+        traj.add_parameter('h_w', val=1.0, opt=False, units='m', static_target=True,
                            desc='height of wing above CG',
                            targets={f'{phase}': ['h_w'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                       'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('CL0', val=0.5, opt=False, units=None, dynamic=False,
+        traj.add_parameter('CL0', val=0.5, opt=False, units=None, static_target=True,
                            desc='zero-alpha lift coefficient',
                            targets={f'{phase}': ['CL0'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                       'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('CL_max', val=2.0, opt=False, units=None, dynamic=False,
+        traj.add_parameter('CL_max', val=2.0, opt=False, units=None, static_target=True,
                            desc='maximum lift coefficient for linear fit',
                            targets={f'{phase}': ['CL_max'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                          'rto', 'rotate' 'climb']})
@@ -352,72 +352,71 @@ class TestBalancedFieldLengthDefaultValues(unittest.TestCase):
                            targets={'br_to_v1': ['m'], 'v1_to_vr': ['m'], 'rto': ['m'],
                                     'rotate': ['m'], 'climb': ['m']})
 
-        traj.add_parameter('T_nominal', val=27000 * 2, opt=False, units='lbf', dynamic=False,
-                           desc='nominal aircraft thrust',
-                           targets={'br_to_v1': ['T']})
+        traj.add_parameter('T_nominal', val=27000 * 2, opt=False, units='lbf', static_target=True,
+                           desc='nominal aircraft thrust', targets={'br_to_v1': ['T']})
 
-        traj.add_parameter('T_engine_out', val=27000, opt=False, units='lbf', dynamic=False,
+        traj.add_parameter('T_engine_out', val=27000, opt=False, units='lbf', static_target=True,
                            desc='thrust under a single engine',
                            targets={'v1_to_vr': ['T'], 'rotate': ['T'], 'climb': ['T']})
 
-        traj.add_parameter('T_shutdown', val=0.0, opt=False, units='lbf', dynamic=False,
+        traj.add_parameter('T_shutdown', val=0.0, opt=False, units='lbf', static_target=True,
                            desc='thrust when engines are shut down for rejected takeoff',
                            targets={'rto': ['T']})
 
-        traj.add_parameter('mu_r_nominal', val=0.03, opt=False, units=None, dynamic=False,
+        traj.add_parameter('mu_r_nominal', val=0.03, opt=False, units=None, static_target=True,
                            desc='nominal runway friction coeffcient',
                            targets={'br_to_v1': ['mu_r'], 'v1_to_vr': ['mu_r'],  'rotate': ['mu_r']})
 
-        traj.add_parameter('mu_r_braking', val=0.3, opt=False, units=None, dynamic=False,
+        traj.add_parameter('mu_r_braking', val=0.3, opt=False, units=None, static_target=True,
                            desc='runway friction coefficient under braking',
                            targets={'rto': ['mu_r']})
 
-        traj.add_parameter('h_runway', val=0., opt=False, units='ft', dynamic=True,
+        traj.add_parameter('h_runway', val=0., opt=False, units='ft', static_target=False,
                            desc='runway altitude',
                            targets={'br_to_v1': ['h'], 'v1_to_vr': ['h'], 'rto': ['h'],
                                     'rotate': ['h']})
 
-        traj.add_parameter('rho', val=1.225, opt=False, units='kg/m**3', dynamic=False,
+        traj.add_parameter('rho', val=1.225, opt=False, units='kg/m**3', static_target=True,
                            desc='atmospheric density',
                            targets={'br_to_v1': ['rho'], 'v1_to_vr': ['rho'], 'rto': ['rho'],
                                     'rotate': ['rho']})
 
-        traj.add_parameter('S', val=124.7, opt=False, units='m**2', dynamic=False,
+        traj.add_parameter('S', val=124.7, opt=False, units='m**2', static_target=True,
                            desc='aerodynamic reference area',
                            targets={'br_to_v1': ['S'], 'v1_to_vr': ['S'], 'rto': ['S'],
                                     'rotate': ['S'], 'climb': ['S']})
 
-        traj.add_parameter('CD0', val=0.03, opt=False, units=None, dynamic=False,
+        traj.add_parameter('CD0', val=0.03, opt=False, units=None, static_target=True,
                            desc='zero-lift drag coefficient',
                            targets={f'{phase}': ['CD0'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                       'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('AR', val=9.45, opt=False, units=None, dynamic=False,
+        traj.add_parameter('AR', val=9.45, opt=False, units=None, static_target=True,
                            desc='wing aspect ratio',
                            targets={f'{phase}': ['AR'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                      'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('e', val=801, opt=False, units=None, dynamic=False,
+        traj.add_parameter('e', val=801, opt=False, units=None, static_target=True,
                            desc='Oswald span efficiency factor',
                            targets={f'{phase}': ['e'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                     'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('span', val=35.7, opt=False, units='m', dynamic=False,
+        traj.add_parameter('span', val=35.7, opt=False, units='m', static_target=True,
                            desc='wingspan',
                            targets={f'{phase}': ['span'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                        'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('h_w', val=1.0, opt=False, units='m', dynamic=False,
+        traj.add_parameter('h_w', val=1.0, opt=False, units='m', static_target=True,
                            desc='height of wing above CG',
                            targets={f'{phase}': ['h_w'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                       'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('CL0', val=0.5, opt=False, units=None, dynamic=False,
+        traj.add_parameter('CL0', val=0.5, opt=False, units=None, static_target=True,
                            desc='zero-alpha lift coefficient',
                            targets={f'{phase}': ['CL0'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                       'rto', 'rotate' 'climb']})
 
-        traj.add_parameter('CL_max', val=2.0, opt=False, units=None, dynamic=False,
+        traj.add_parameter('CL_max', val=2.0, opt=False, units=None, static_target=True,
                            desc='maximum lift coefficient for linear fit',
                            targets={f'{phase}': ['CL_max'] for phase in ['br_to_v1', 'v1_to_vr',
                                                                          'rto', 'rotate' 'climb']})

--- a/dymos/examples/brachistochrone/brachistochrone_ode.py
+++ b/dymos/examples/brachistochrone/brachistochrone_ode.py
@@ -12,23 +12,26 @@ class BrachistochroneODE(om.ExplicitComponent):
 
     def setup(self):
         nn = self.options['num_nodes']
-        g_default_val = 9.80665 if self.options['static_gravity'] else 9.80665 * np.ones(nn)
 
         # Inputs
         self.add_input('v', val=np.zeros(nn), desc='velocity', units='m/s')
 
-        self.add_input('g', val=g_default_val, desc='grav. acceleration', units='m/s/s')
+        if self.options['static_gravity']:
+            self.add_input('g', val=9.80665, desc='grav. acceleration', units='m/s/s',
+                           tags=['dymos.static_target'])
+        else:
+            self.add_input('g', val=9.80665 * np.ones(nn), desc='grav. acceleration', units='m/s/s')
 
         self.add_input('theta', val=np.ones(nn), desc='angle of wire', units='rad')
 
         self.add_output('xdot', val=np.zeros(nn), desc='velocity component in x', units='m/s',
-                        tags=['state_rate_source:x', 'state_units:m'])
+                        tags=['dymos.state_rate_source:x', 'dymos.state_units:m'])
 
         self.add_output('ydot', val=np.zeros(nn), desc='velocity component in y', units='m/s',
-                        tags=['state_rate_source:y', 'state_units:m'])
+                        tags=['dymos.state_rate_source:y', 'dymos.state_units:m'])
 
         self.add_output('vdot', val=np.zeros(nn), desc='acceleration magnitude', units='m/s**2',
-                        tags=['state_rate_source:v', 'state_units:m/s'])
+                        tags=['dymos.state_rate_source:v', 'dymos.state_units:m/s'])
 
         self.add_output('check', val=np.zeros(nn), desc='check solution: v/sin(theta) = constant',
                         units='m/s')

--- a/dymos/examples/brachistochrone/brachistochrone_vector_states_ode.py
+++ b/dymos/examples/brachistochrone/brachistochrone_vector_states_ode.py
@@ -18,10 +18,10 @@ class BrachistochroneVectorStatesODE(om.ExplicitComponent):
         self.add_input('theta', val=np.zeros(nn), desc='angle of wire', units='rad')
 
         self.add_output('pos_dot', val=np.zeros((nn, 2)), desc='velocity components', units='m/s',
-                        tags=['state_rate_source:pos'])
+                        tags=['dymos.state_rate_source:pos'])
 
         self.add_output('vdot', val=np.zeros(nn), desc='acceleration magnitude', units='m/s**2',
-                        tags=['state_rate_source:v', 'state_units:m/s'])
+                        tags=['dymos.state_rate_source:v', 'dymos.state_units:m/s'])
 
         self.add_output('check', val=np.zeros(nn), desc='check solution: v/sin(theta) = constant',
                         units='m/s')

--- a/dymos/examples/brachistochrone/doc/brachistochrone_ode.py
+++ b/dymos/examples/brachistochrone/doc/brachistochrone_ode.py
@@ -17,13 +17,13 @@ class BrachistochroneODE(om.ExplicitComponent):
         self.add_input('theta', val=np.ones(nn), desc='angle of wire', units='rad')
 
         self.add_output('xdot', val=np.zeros(nn), desc='velocity component in x', units='m/s',
-                        tags=['state_rate_source:x', 'state_units:m'])
+                        tags=['dymos.state_rate_source:x', 'dymos.state_units:m'])
 
         self.add_output('ydot', val=np.zeros(nn), desc='velocity component in y', units='m/s',
-                        tags=['state_rate_source:y', 'state_units:m'])
+                        tags=['dymos.state_rate_source:y', 'dymos.state_units:m'])
 
         self.add_output('vdot', val=np.zeros(nn), desc='acceleration magnitude', units='m/s**2',
-                        tags=['state_rate_source:v', 'state_units:m/s'])
+                        tags=['dymos.state_rate_source:v', 'dymos.state_units:m/s'])
 
         self.add_output('check', val=np.zeros(nn), desc='check solution: v/sin(theta) = constant',
                         units='m/s')

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_static_gravity.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_static_gravity.py
@@ -95,7 +95,7 @@ class TestBrachistochroneStaticGravity(unittest.TestCase):
                           continuity=True, rate_continuity=True,
                           units='deg', lower=0.01, upper=179.9)
 
-        phase.add_parameter('g', targets=['g'], dynamic=False, opt=False)
+        phase.add_parameter('g', targets=['g'], static_target=True, opt=False)
 
         #
         # Minimize time at the end of the phase

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_callable_ode_class.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_callable_ode_class.py
@@ -65,7 +65,7 @@ class TestBrachExecCompODE(unittest.TestCase):
                           continuity=True, rate_continuity=True,
                           units='deg', lower=0.01, upper=179.9)
 
-        phase.add_parameter('g', units='m/s**2', dynamic=False)
+        phase.add_parameter('g', units='m/s**2', static_target=True)
 
         phase.add_boundary_constraint('x', loc='final', equals=10)
         phase.add_boundary_constraint('y', loc='final', equals=5)
@@ -168,7 +168,7 @@ class TestInvalidCallableODEClass(unittest.TestCase):
                           continuity=True, rate_continuity=True,
                           units='deg', lower=0.01, upper=179.9)
 
-        phase.add_parameter('g', units='m/s**2', dynamic=False)
+        phase.add_parameter('g', units='m/s**2', static_target=True)
 
         phase.add_boundary_constraint('x', loc='final', equals=10)
         phase.add_boundary_constraint('y', loc='final', equals=5)
@@ -273,7 +273,7 @@ class TestBrachCallableODE(unittest.TestCase):
                           continuity=True, rate_continuity=True,
                           units='deg', lower=0.01, upper=179.9)
 
-        phase.add_parameter('g', units='m/s**2', dynamic=False)
+        phase.add_parameter('g', units='m/s**2', static_target=True)
 
         phase.add_boundary_constraint('x', loc='final', equals=10)
         phase.add_boundary_constraint('y', loc='final', equals=5)

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_callable_ode_class.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_callable_ode_class.py
@@ -38,13 +38,13 @@ class TestBrachExecCompODE(unittest.TestCase):
                                             theta={'shape': (num_nodes,), 'units': 'rad'},
                                             vdot={'shape': (num_nodes,),
                                                   'units': 'm/s**2',
-                                                  'tags': ['state_rate_source:v']},
+                                                  'tags': ['dymos.state_rate_source:v']},
                                             xdot={'shape': (num_nodes,),
                                                   'units': 'm/s',
-                                                  'tags': ['state_rate_source:x']},
+                                                  'tags': ['dymos.state_rate_source:x']},
                                             ydot={'shape': (num_nodes,),
                                                   'units': 'm/s',
-                                                  'tags': ['state_rate_source:y']},
+                                                  'tags': ['dymos.state_rate_source:y']},
                                             has_diag_partials=True)
 
         traj = dm.Trajectory()
@@ -204,13 +204,13 @@ class CallableBrachistochroneODE(om.ExplicitComponent):
         self.add_input('theta', val=np.ones(nn), desc='angle of wire', units='rad')
 
         self.add_output('xdot', val=np.zeros(nn), desc='velocity component in x', units='m/s',
-                        tags=['state_rate_source:x', 'state_units:m'])
+                        tags=['dymos.state_rate_source:x', 'dymos.state_units:m'])
 
         self.add_output('ydot', val=np.zeros(nn), desc='velocity component in y', units='m/s',
-                        tags=['state_rate_source:y', 'state_units:m'])
+                        tags=['dymos.state_rate_source:y', 'dymos.state_units:m'])
 
         self.add_output('vdot', val=np.zeros(nn), desc='acceleration magnitude', units='m/s**2',
-                        tags=['state_rate_source:v', 'state_units:m/s'])
+                        tags=['dymos.state_rate_source:v', 'dymos.state_units:m/s'])
 
         self.declare_partials(of='*', wrt='*', method='cs')
 

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_static_gravity.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_static_gravity.py
@@ -1,0 +1,241 @@
+import os
+import unittest
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+plt.style.use('ggplot')
+
+from openmdao.utils.testing_utils import use_tempdirs
+
+import openmdao.api as om
+import dymos as dm
+from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
+
+
+@use_tempdirs
+class TestBrachistochroneStaticGravity(unittest.TestCase):
+
+    def _make_problem(self, tx):
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
+        p.driver.declare_coloring()
+
+        #
+        # Create a trajectory and add a phase to it
+        #
+        traj = p.model.add_subsystem('traj', dm.Trajectory())
+
+        phase = traj.add_phase('phase0',
+                               dm.Phase(ode_class=BrachistochroneODE,
+                                        ode_init_kwargs={'static_gravity': True},
+                                        transcription=tx))
+
+        #
+        # Set the variables
+        #
+        phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
+
+        phase.add_state('x', rate_source='xdot',
+                        targets=None,
+                        units='m',
+                        fix_initial=True, fix_final=True, solve_segments=False)
+
+        phase.add_state('y', rate_source='ydot',
+                        targets=None,
+                        units='m',
+                        fix_initial=True, fix_final=True, solve_segments=False)
+
+        phase.add_state('v', rate_source='vdot',
+                        targets=['v'],
+                        units='m/s',
+                        fix_initial=True, fix_final=False, solve_segments=False)
+
+        phase.add_control('theta', targets=['theta'],
+                          continuity=True, rate_continuity=True,
+                          units='deg', lower=0.01, upper=179.9)
+
+        phase.add_objective('time', loc='final', scaler=10)
+        return p, phase
+
+    def tearDown(self):
+        for filename in ['total_coloring.pkl', 'SLSQP.out', 'SNOPT_print.out', 'SNOPT_summary.out']:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    def test_conflicting_static_target(self):
+        """ Tests that control cannot be connected to target tagged as 'dymos.static_target'. """
+        p, phase = self._make_problem(dm.GaussLobatto(num_segments=10))
+
+        phase.add_parameter('g', targets=['g'], static_target=False, opt=False)
+        with self.assertRaises(ValueError) as e:
+            p.setup()
+
+        expected_msg = "User has specified 'static_target = False' for parameter g,but one or more " \
+                       "targets is tagged with 'dymos.static_target': g"
+
+        self.assertEqual(str(e.exception), expected_msg)
+
+    def test_control_to_static_target_fails_gl(self):
+        """ Tests that control cannot be connected to target tagged as 'dymos.static_target'. """
+        p, phase = self._make_problem(dm.GaussLobatto(num_segments=10))
+
+        phase.add_control('g', opt=False)
+        with self.assertRaises(ValueError) as e:
+            p.setup()
+
+        expected_msg = "Control 'g' cannot be connected to its targets because one or more " \
+                       "targets are tagged with 'dymos.static_target'."
+
+        self.assertEqual(expected_msg, str(e.exception))
+
+    def test_control_to_static_target_fails_radau(self):
+        """ Tests that control cannot be connected to target tagged as 'dymos.static_target'. """
+        p, phase = self._make_problem(dm.Radau(num_segments=10))
+
+        phase.add_control('g', opt=False)
+        with self.assertRaises(ValueError) as e:
+            p.setup()
+
+        expected_msg = "Control 'g' cannot be connected to its targets because one or more " \
+                       "targets are tagged with 'dymos.static_target'."
+
+        self.assertEqual(expected_msg, str(e.exception))
+
+    def test_control_rate_to_static_target_fails_gl(self):
+        """ Tests that control cannot be connected to target tagged as 'dymos.static_target'. """
+        p, phase = self._make_problem(dm.GaussLobatto(num_segments=10))
+
+        phase.add_control('foo', rate_targets=['g'], opt=False, shape=(1,), units='m/s')
+        with self.assertRaises(ValueError) as e:
+            p.setup()
+
+        expected_msg = "Control rate of 'foo' cannot be connected to its targets because one or " \
+                       "more targets are tagged with 'dymos.static_target'."
+
+        self.assertEqual(expected_msg, str(e.exception))
+
+    def test_control_rate_to_static_target_fails_radau(self):
+        """ Tests that control cannot be connected to target tagged as 'dymos.static_target'. """
+        p, phase = self._make_problem(dm.Radau(num_segments=10))
+
+        phase.add_control('foo', rate_targets=['g'], opt=False, shape=(1,), units='m/s')
+        with self.assertRaises(ValueError) as e:
+            p.setup()
+
+        expected_msg = "Control rate of 'foo' cannot be connected to its targets because one or " \
+                       "more targets are tagged with 'dymos.static_target'."
+
+        self.assertEqual(expected_msg, str(e.exception))
+
+    def test_control_rate2_to_static_target_fails_gl(self):
+        """ Tests that control cannot be connected to target tagged as 'dymos.static_target'. """
+        p, phase = self._make_problem(dm.GaussLobatto(num_segments=10))
+
+        phase.add_control('foo', rate2_targets=['g'], opt=False, shape=(1,), units='m/s')
+        with self.assertRaises(ValueError) as e:
+            p.setup()
+
+        expected_msg = "Control rate2 of 'foo' cannot be connected to its targets because one or " \
+                       "more targets are tagged with 'dymos.static_target'."
+
+        self.assertEqual(expected_msg, str(e.exception))
+
+    def test_control_rate2_to_static_target_fails_radau(self):
+        """ Tests that control cannot be connected to target tagged as 'dymos.static_target'. """
+        p, phase = self._make_problem(dm.Radau(num_segments=10))
+
+        phase.add_control('foo', rate2_targets=['g'], opt=False, shape=(1,), units='m/s')
+        with self.assertRaises(ValueError) as e:
+            p.setup()
+
+        expected_msg = "Control rate2 of 'foo' cannot be connected to its targets because one or " \
+                       "more targets are tagged with 'dymos.static_target'."
+
+        self.assertEqual(expected_msg, str(e.exception))
+
+    def test_polynomial_control_to_static_target_fails_gl(self):
+        """ Tests that control cannot be connected to target tagged as 'dymos.static_target'. """
+        p, phase = self._make_problem(dm.GaussLobatto(num_segments=10))
+
+        phase.add_polynomial_control('g', opt=False, order=5)
+        with self.assertRaises(ValueError) as e:
+            p.setup()
+
+        expected_msg = "Polynomial control 'g' cannot be connected to its targets because one or " \
+                       "more targets are tagged with 'dymos.static_target'."
+
+        self.assertEqual(expected_msg, str(e.exception))
+
+    def test_polynomial_control_to_static_target_fails_radau(self):
+        """ Tests that control cannot be connected to target tagged as 'dymos.static_target'. """
+        p, phase = self._make_problem(dm.Radau(num_segments=10))
+
+        phase.add_polynomial_control('g', opt=False, order=5)
+        with self.assertRaises(ValueError) as e:
+            p.setup()
+
+        expected_msg = "Polynomial control 'g' cannot be connected to its targets because one or " \
+                       "more targets are tagged with 'dymos.static_target'."
+
+        self.assertEqual(expected_msg, str(e.exception))
+
+    def test_polynomial_control_rate_to_static_target_fails_gl(self):
+        """ Tests that control cannot be connected to target tagged as 'dymos.static_target'. """
+        p, phase = self._make_problem(dm.GaussLobatto(num_segments=10))
+
+        phase.add_polynomial_control('foo', opt=False, order=5, shape=(1,), units='m/s',
+                                     rate_targets=['g'])
+        with self.assertRaises(ValueError) as e:
+            p.setup()
+
+        expected_msg = "Rate of polynomial control 'foo' cannot be connected to its targets " \
+                       "because one or more targets are tagged with 'dymos.static_target'."
+
+        self.assertEqual(expected_msg, str(e.exception))
+
+    def test_polynomial_control_rate_to_static_target_fails_radau(self):
+        """ Tests that control cannot be connected to target tagged as 'dymos.static_target'. """
+        p, phase = self._make_problem(dm.Radau(num_segments=10))
+
+        phase.add_polynomial_control('foo', opt=False, order=5, shape=(1,), units='m/s',
+                                     rate_targets=['g'])
+        with self.assertRaises(ValueError) as e:
+            p.setup()
+
+        expected_msg = "Rate of polynomial control 'foo' cannot be connected to its targets " \
+                       "because one or more targets are tagged with 'dymos.static_target'."
+
+        self.assertEqual(expected_msg, str(e.exception))
+
+    def test_polynomial_control_rate2_to_static_target_fails_gl(self):
+        """ Tests that control cannot be connected to target tagged as 'dymos.static_target'. """
+        p, phase = self._make_problem(dm.GaussLobatto(num_segments=10))
+
+        phase.add_polynomial_control('foo', opt=False, order=5, shape=(1,), units='m/s',
+                                     rate2_targets=['g'])
+        with self.assertRaises(ValueError) as e:
+            p.setup()
+
+        expected_msg = "Rate2 of polynomial control 'foo' cannot be connected to its targets " \
+                       "because one or more targets are tagged with 'dymos.static_target'."
+
+        self.assertEqual(expected_msg, str(e.exception))
+
+    def test_polynomial_control_rate2_to_static_target_fails_radau(self):
+        """ Tests that control cannot be connected to target tagged as 'dymos.static_target'. """
+        p, phase = self._make_problem(dm.Radau(num_segments=10))
+
+        phase.add_polynomial_control('foo', opt=False, order=5, shape=(1,), units='m/s',
+                                     rate2_targets=['g'])
+        with self.assertRaises(ValueError) as e:
+            p.setup()
+
+        expected_msg = "Rate2 of polynomial control 'foo' cannot be connected to its targets " \
+                       "because one or more targets are tagged with 'dymos.static_target'."
+
+        self.assertEqual(expected_msg, str(e.exception))
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()

--- a/dymos/examples/brachistochrone/test/test_static_outputs.py
+++ b/dymos/examples/brachistochrone/test/test_static_outputs.py
@@ -29,13 +29,13 @@ class BrachODEStaticOutput(om.ExplicitComponent):
         self.add_input('theta', val=np.ones(nn), desc='angle of wire', units='rad')
 
         self.add_output('xdot', val=np.zeros(nn), desc='velocity component in x', units='m/s',
-                        tags=['state_rate_source:x', 'state_units:m'])
+                        tags=['dymos.state_rate_source:x', 'dymos.state_units:m'])
 
         self.add_output('ydot', val=np.zeros(nn), desc='velocity component in y', units='m/s',
-                        tags=['state_rate_source:y', 'state_units:m'])
+                        tags=['dymos.state_rate_source:y', 'dymos.state_units:m'])
 
         self.add_output('vdot', val=np.zeros(nn), desc='acceleration magnitude', units='m/s**2',
-                        tags=['state_rate_source:v', 'state_units:m/s'])
+                        tags=['dymos.state_rate_source:v', 'dymos.state_units:m/s'])
 
         self.add_output('check', val=np.zeros(nn), desc='check solution: v/sin(theta) = constant',
                         units='m/s')

--- a/dymos/examples/brachistochrone/test/test_timeseries_units.py
+++ b/dymos/examples/brachistochrone/test/test_timeseries_units.py
@@ -63,7 +63,7 @@ class TestTimeseriesUnits(unittest.TestCase):
                           continuity=True, rate_continuity=True,
                           units='deg', lower=0.01, upper=179.9)
 
-        phase.add_parameter('g', units='m/s**2', dynamic=False)
+        phase.add_parameter('g', units='m/s**2', static_target=True)
 
         phase.add_boundary_constraint('x', loc='final', equals=10)
         phase.add_boundary_constraint('y', loc='final', equals=5)

--- a/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
+++ b/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
@@ -90,10 +90,10 @@ class TestTwoPhaseCannonballForDocs(unittest.TestCase):
                 self.add_input('gam', units='rad', shape=nn)
 
                 # state rates
-                self.add_output('v_dot', shape=nn, units='m/s**2', tags=['state_rate_source:v'])
-                self.add_output('gam_dot', shape=nn, units='rad/s', tags=['state_rate_source:gam'])
-                self.add_output('h_dot', shape=nn, units='m/s', tags=['state_rate_source:h'])
-                self.add_output('r_dot', shape=nn, units='m/s', tags=['state_rate_source:r'])
+                self.add_output('v_dot', shape=nn, units='m/s**2', tags=['dymos.state_rate_source:v'])
+                self.add_output('gam_dot', shape=nn, units='rad/s', tags=['dymos.state_rate_source:gam'])
+                self.add_output('h_dot', shape=nn, units='m/s', tags=['dymos.state_rate_source:h'])
+                self.add_output('r_dot', shape=nn, units='m/s', tags=['dymos.state_rate_source:r'])
                 self.add_output('ke', shape=nn, units='J')
 
                 # Ask OpenMDAO to compute the partial derivatives using complex-step

--- a/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
+++ b/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
@@ -172,8 +172,8 @@ class TestTwoPhaseCannonballForDocs(unittest.TestCase):
         ascent.set_state_options('gam', fix_initial=False, fix_final=True)
         ascent.set_state_options('v', fix_initial=False, fix_final=False)
 
-        ascent.add_parameter('S', units='m**2', dynamic=False)
-        ascent.add_parameter('m', units='kg', dynamic=False)
+        ascent.add_parameter('S', units='m**2', static_target=True)
+        ascent.add_parameter('m', units='kg', static_target=True)
 
         # Limit the muzzle energy
         ascent.add_boundary_constraint('ke', loc='initial',
@@ -196,25 +196,25 @@ class TestTwoPhaseCannonballForDocs(unittest.TestCase):
         descent.add_state('gam', fix_initial=False, fix_final=False)
         descent.add_state('v', fix_initial=False, fix_final=False)
 
-        descent.add_parameter('S', units='m**2', dynamic=False)
-        descent.add_parameter('m', units='kg', dynamic=False)
+        descent.add_parameter('S', units='m**2', static_target=True)
+        descent.add_parameter('m', units='kg', static_target=True)
 
         descent.add_objective('r', loc='final', scaler=-1.0)
 
         # Add internally-managed design parameters to the trajectory.
         traj.add_parameter('CD',
                            targets={'ascent': ['CD'], 'descent': ['CD']},
-                           val=0.5, units=None, opt=False, dynamic=False)
+                           val=0.5, units=None, opt=False, static_target=True)
 
         # Add externally-provided design parameters to the trajectory.
         # In this case, we connect 'm' to pre-existing input parameters
         # named 'mass' in each phase.
         traj.add_parameter('m', units='kg', val=1.0,
-                           targets={'ascent': 'mass', 'descent': 'mass'}, dynamic=False)
+                           targets={'ascent': 'mass', 'descent': 'mass'}, static_target=True)
 
         # In this case, by omitting targets, we're connecting these
         # parameters to parameters with the same name in each phase.
-        traj.add_parameter('S', units='m**2', val=0.005, dynamic=False)
+        traj.add_parameter('S', units='m**2', val=0.005, static_target=True)
 
         # Link Phases (link time and all state variables)
         traj.link_phases(phases=['ascent', 'descent'], vars=['*'])

--- a/dymos/examples/cannonball/test/test_connect_control_to_parameter.py
+++ b/dymos/examples/cannonball/test/test_connect_control_to_parameter.py
@@ -122,8 +122,8 @@ class TestConnectControlToParameter(unittest.TestCase):
         ascent.add_state('gam', fix_initial=False, fix_final=True, units='rad', rate_source='gam_dot')
         ascent.add_state('v', fix_initial=False, fix_final=False, units='m/s', rate_source='v_dot')
 
-        ascent.add_parameter('S', targets=['S'], units='m**2', dynamic=False)
-        ascent.add_parameter('mass', targets=['m'], units='kg', dynamic=False)
+        ascent.add_parameter('S', targets=['S'], units='m**2', static_target=True)
+        ascent.add_parameter('mass', targets=['m'], units='kg', static_target=True)
 
         ascent.add_control('CD', targets=['CD'], opt=False, val=0.05)
 
@@ -146,8 +146,8 @@ class TestConnectControlToParameter(unittest.TestCase):
         descent.add_state('gam', units='rad', rate_source='gam_dot', fix_initial=False, fix_final=False)
         descent.add_state('v', units='m/s', rate_source='v_dot', fix_initial=False, fix_final=False)
 
-        descent.add_parameter('S', targets=['S'], units='m**2', dynamic=False)
-        descent.add_parameter('mass', targets=['m'], units='kg', dynamic=False)
+        descent.add_parameter('S', targets=['S'], units='m**2', static_target=True)
+        descent.add_parameter('mass', targets=['m'], units='kg', static_target=True)
         descent.add_parameter('CD', targets=['CD'], val=0.01)
 
         descent.add_objective('r', loc='final', scaler=-1.0)
@@ -155,11 +155,11 @@ class TestConnectControlToParameter(unittest.TestCase):
         # Add externally-provided design parameters to the trajectory.
         # In this case, we connect 'm' to pre-existing input parameters named 'mass' in each phase.
         traj.add_parameter('m', units='kg', val=1.0,
-                           targets={'ascent': 'mass', 'descent': 'mass'}, dynamic=False)
+                           targets={'ascent': 'mass', 'descent': 'mass'}, static_target=True)
 
         # In this case, by omitting targets, we're connecting these parameters to parameters
         # with the same name in each phase.
-        traj.add_parameter('S', units='m**2', val=0.005, dynamic=False)
+        traj.add_parameter('S', units='m**2', val=0.005, static_target=True)
 
         # Link Phases (link time and all state variables)
         traj.link_phases(phases=['ascent', 'descent'], vars=['*'])

--- a/dymos/examples/cannonball/test/test_two_phase_cannonball_ode_output_linkage.py
+++ b/dymos/examples/cannonball/test/test_two_phase_cannonball_ode_output_linkage.py
@@ -41,8 +41,8 @@ class TestTwoPhaseCannonballODEOutputLinkage(unittest.TestCase):
         ascent.add_state('gam', fix_initial=False, fix_final=True, units='rad', rate_source='gam_dot')
         ascent.add_state('v', fix_initial=False, fix_final=False, units='m/s', rate_source='v_dot')
 
-        ascent.add_parameter('S', targets=['S'], units='m**2', dynamic=False)
-        ascent.add_parameter('mass', targets=['m'], units='kg', dynamic=False)
+        ascent.add_parameter('S', targets=['S'], units='m**2', static_target=True)
+        ascent.add_parameter('mass', targets=['m'], units='kg', static_target=True)
 
         # Limit the muzzle energy
         ascent.add_boundary_constraint('ke', loc='initial',
@@ -63,15 +63,15 @@ class TestTwoPhaseCannonballODEOutputLinkage(unittest.TestCase):
         descent.add_state('gam', fix_initial=False, fix_final=False, units='rad', rate_source='gam_dot')
         descent.add_state('v', fix_initial=False, fix_final=False, units='m/s', rate_source='v_dot')
 
-        descent.add_parameter('S', targets=['S'], units='m**2', dynamic=False)
-        descent.add_parameter('mass', targets=['m'], units='kg', dynamic=False)
+        descent.add_parameter('S', targets=['S'], units='m**2', static_target=True)
+        descent.add_parameter('mass', targets=['m'], units='kg', static_target=True)
 
         descent.add_objective('r', loc='final', scaler=-1.0)
 
         # Add internally-managed design parameters to the trajectory.
         traj.add_parameter('CD',
                            targets={'ascent': ['CD'], 'descent': ['CD']},
-                           val=0.5, units=None, opt=False, dynamic=False)
+                           val=0.5, units=None, opt=False, static_target=True)
 
         # Add externally-provided design parameters to the trajectory.
         # In this case, we connect 'm' to pre-existing input parameters named 'mass' in each phase.
@@ -242,8 +242,8 @@ class TestTwoPhaseCannonballODEOutputLinkage(unittest.TestCase):
         ascent.add_state('gam', fix_initial=False, fix_final=True, units='rad', rate_source='gam_dot')
         ascent.add_state('v', fix_initial=False, fix_final=False, units='m/s', rate_source='v_dot')
 
-        ascent.add_parameter('S', targets=['S'], units='m**2', dynamic=False)
-        ascent.add_parameter('mass', targets=['m'], units='kg', dynamic=False)
+        ascent.add_parameter('S', targets=['S'], units='m**2', static_target=True)
+        ascent.add_parameter('mass', targets=['m'], units='kg', static_target=True)
 
         # Limit the muzzle energy
         ascent.add_boundary_constraint('ke', loc='initial', units='J',
@@ -264,24 +264,24 @@ class TestTwoPhaseCannonballODEOutputLinkage(unittest.TestCase):
         descent.add_state('gam', fix_initial=False, fix_final=False, units='rad', rate_source='gam_dot')
         descent.add_state('v', fix_initial=False, fix_final=False, units='m/s', rate_source='v_dot')
 
-        descent.add_parameter('S', targets=['S'], units='m**2', dynamic=False)
-        descent.add_parameter('mass', targets=['m'], units='kg', dynamic=False)
+        descent.add_parameter('S', targets=['S'], units='m**2', static_target=True)
+        descent.add_parameter('mass', targets=['m'], units='kg', static_target=True)
 
         descent.add_objective('r', loc='final', scaler=-1.0)
 
         # Add internally-managed design parameters to the trajectory.
         traj.add_parameter('CD',
                            targets={'ascent': ['CD'], 'descent': ['CD']},
-                           val=0.5, units=None, opt=False, dynamic=False)
+                           val=0.5, units=None, opt=False, static_target=True)
 
         # Add externally-provided design parameters to the trajectory.
         # In this case, we connect 'm' to pre-existing input parameters named 'mass' in each phase.
         traj.add_parameter('m', units='kg', val=1.0,
-                           targets={'ascent': 'mass', 'descent': 'mass'}, dynamic=False)
+                           targets={'ascent': 'mass', 'descent': 'mass'}, static_target=True)
 
         # In this case, by omitting targets, we're connecting these parameters to parameters
         # with the same name in each phase.
-        traj.add_parameter('S', units='m**2', val=0.005, dynamic=False)
+        traj.add_parameter('S', units='m**2', val=0.005, static_target=True)
 
         # Link Phases (link time and all state variables)
         # Note velocity is not included here.  Doing so is equivalent to linking kinetic energy,

--- a/dymos/examples/min_time_climb/test/test_refine_with_shaped_parameter.py
+++ b/dymos/examples/min_time_climb/test/test_refine_with_shaped_parameter.py
@@ -105,7 +105,7 @@ def min_time_climb(optimizer='SLSQP', num_seg=3, transcription='gauss-lobatto',
     phase.add_parameter('S', val=49.2386, units='m**2', opt=False, targets=['S'])
     phase.add_parameter('Isp', val=1600.0, units='s', opt=False, targets=['Isp'])
     phase.add_parameter('throttle', val=1.0, opt=False, targets=['throttle'])
-    phase.add_parameter('test', val=40 * [1], opt=False, dynamic=False, targets=['test'])
+    phase.add_parameter('test', val=40 * [1], opt=False, static_target=True, targets=['test'])
 
     phase.add_boundary_constraint('h', loc='final', equals=20000, scaler=1.0E-3)
     phase.add_boundary_constraint('aero.mach', loc='final', equals=1.0)

--- a/dymos/examples/racecar/doc/test_doc_racecar.py
+++ b/dymos/examples/racecar/doc/test_doc_racecar.py
@@ -106,19 +106,19 @@ class TestRaceCarForDocs(unittest.TestCase):
         # be found in their respective ODE files.
         phase.add_parameter('M', val=800.0, units='kg', opt=False,
                             targets=['car.M', 'tire.M', 'tireconstraint.M', 'normal.M'],
-                            dynamic=False)  # vehicle mass
+                            static_target=True)  # vehicle mass
         phase.add_parameter('beta', val=0.62, units=None, opt=False, targets=['tire.beta'],
-                            dynamic=False)  # brake bias
+                            static_target=True)  # brake bias
         phase.add_parameter('CoP', val=1.6, units='m', opt=False, targets=['normal.CoP'],
-                            dynamic=False)  # center of pressure location
+                            static_target=True)  # center of pressure location
         phase.add_parameter('h', val=0.3, units='m', opt=False, targets=['normal.h'],
-                            dynamic=False)  # center of gravity height
+                            static_target=True)  # center of gravity height
         phase.add_parameter('chi', val=0.5, units=None, opt=False, targets=['normal.chi'],
-                            dynamic=False)  # roll stiffness
+                            static_target=True)  # roll stiffness
         phase.add_parameter('ClA', val=4.0, units='m**2', opt=False, targets=['normal.ClA'],
-                            dynamic=False)  # downforce coefficient*area
+                            static_target=True)  # downforce coefficient*area
         phase.add_parameter('CdA', val=2.0, units='m**2', opt=False, targets=['car.CdA'],
-                            dynamic=False)  # drag coefficient*area
+                            static_target=True)  # drag coefficient*area
 
         # Minimize final time.
         # note that we use the 'state' time instead of Dymos 'time'

--- a/dymos/grid_refinement/grid_refinement_ode_system.py
+++ b/dymos/grid_refinement/grid_refinement_ode_system.py
@@ -189,12 +189,12 @@ class GridRefinementODESystem(om.Group):
 
         # Configure the parameters
         for name, options in self.options['parameters'].items():
-            dynamic = options['dynamic']
+            static_target = options['static_target']
             shape = options['shape']
             prom_name = f'parameters:{name}'
             targets = get_targets(self.ode, name, options['targets'])
             for tgt in targets:
-                if dynamic:
+                if not static_target:
                     self.promotes('ode', inputs=[(tgt, prom_name)],
                                   src_indices=om.slicer[np.zeros(num_nodes, dtype=int), ...])
                 else:

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -256,8 +256,9 @@ class ParameterOptionsDictionary(om.OptionsDictionary):
                           'for the optimization problem.  If False, allow the '
                           'control to be connected externally.')
 
-        self.declare(name='dynamic', types=bool, default=True,
-                     desc='True if this parameter can be used as a dynamic control, else False')
+        self.declare(name='dynamic', values=[True, False, _unspecified], default=_unspecified,
+                     desc='True if this parameter can be used as a dynamic control, else False.'
+                          'If _unspecified, attempt to determine through introspection.')
 
         self.declare(name='targets', allow_none=True, default=_unspecified,
                      desc='Targets in the ODE to which the state is connected')

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -110,14 +110,6 @@ class ControlOptionsDictionary(om.OptionsDictionary):
                           'segment boundaries. '
                           'This option is invalid if opt=False.')
 
-        self.declare('dynamic', default=True, types=bool,
-                     desc='If True, the value of the shape of the parameter will '
-                          'be (num_nodes, ...), allowing the variable to be used as either a '
-                          'static or dynamic control.  This impacts the shape of the partial '
-                          'derivatives matrix.  Unless a parameter is large and broadcasting a '
-                          'value to each individual node would be inefficient, users should stick '
-                          'to the default value of True.')
-
 
 class PolynomialControlOptionsDictionary(om.OptionsDictionary):
     """
@@ -204,14 +196,6 @@ class PolynomialControlOptionsDictionary(om.OptionsDictionary):
                      desc='A integer that provides the interpolation order when the control is '
                           'to assume a single polynomial basis across the entire phase, or None '
                           'to use the default control behavior.')
-
-        self.declare('dynamic', default=True, types=bool,
-                     desc='If True, the value of the shape of the parameter will '
-                          'be (num_nodes, ...), allowing the variable to be used as either a '
-                          'static or dynamic control.  This impacts the shape of the partial '
-                          'derivatives matrix.  Unless a parameter is large and broadcasting a '
-                          'value to each individual node would be inefficient, users should stick '
-                          'to the default value of True.')
 
 
 def check_valid_shape(name, value):

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -258,6 +258,16 @@ class ParameterOptionsDictionary(om.OptionsDictionary):
 
         self.declare(name='dynamic', values=[True, False, _unspecified], default=_unspecified,
                      desc='True if this parameter can be used as a dynamic control, else False.'
+                          'If _unspecified, attempt to determine through introspection.',
+                     deprecation="Option dynamic has been replaced by option 'static_target' and "
+                                 "will be removed in Dymos 2.0.0.\nNote that 'static_target' has "
+                                 "the opposite meaning of option 'dynamic', so parameters with "
+                                 "option 'dynamic' set to False should now use 'static_target' set "
+                                 "to True.")
+
+        self.declare(name='static_target', values=[True, False, _unspecified], default=_unspecified,
+                     desc='True if the target of this parameter does NOT have a unique value at '
+                          'each node in the ODE.'
                           'If _unspecified, attempt to determine through introspection.')
 
         self.declare(name='targets', allow_none=True, default=_unspecified,

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -930,9 +930,9 @@ class Phase(om.Group):
 
         if dynamic is not _unspecified and static_target is not _unspecified:
             raise ValueError("Both the deprecated 'dynamic' option and option 'static_target' were "
-                             "specified for parameter '{name}. Going forward, please use only "
+                             f"specified for parameter '{name}'. Going forward, please use only "
                              "option static_target.  Option 'dynamic' will be removed in "
-                             "Dymos 2.0.0")
+                             "Dymos 2.0.0.")
 
         if lower is not _unspecified:
             self.parameter_options[name]['lower'] = lower

--- a/dymos/phase/test/test_add_parameter_types.py
+++ b/dymos/phase/test/test_add_parameter_types.py
@@ -37,9 +37,9 @@ def add_parameter_test(testShape=None):
     phase = dm.Phase(ode_class=ODEComp, transcription=tx)
 
     if testShape is None:
-        phase.add_parameter('param', dynamic=False)
+        phase.add_parameter('param', static_target=True)
     else:
-        phase.add_parameter('param', shape=testShape, dynamic=False)
+        phase.add_parameter('param', shape=testShape, static_target=True)
 
     traj.add_phase('phase', phase)
 

--- a/dymos/phase/test/test_input_parameter_connections.py
+++ b/dymos/phase/test/test_input_parameter_connections.py
@@ -93,6 +93,38 @@ class TestStaticParameters(unittest.TestCase):
         except Exception as e:
             self.fail('Exception encountered in setup:\n' + str(e))
 
+    def test_static_and_dynamic_error(self):
+
+        phase = dm.Phase(ode_class=MyODE,
+                         ode_init_kwargs={'n_traj': n_traj},
+                         transcription=dm.Radau(num_segments=25,
+                                                order=3,
+                                                compressed=True))
+
+        with self.assertRaises(ValueError) as e:
+            phase.add_parameter('alpha', val=np.ones((n_traj, 2)), units='m',
+                                targets='comp.alpha', dynamic=False, static_target=True)
+
+        expected_msg = "Both the deprecated 'dynamic' option and option 'static_target' were " \
+                       "specified for parameter 'alpha'. Going forward, please use only option " \
+                       "static_target.  Option 'dynamic' will be removed in Dymos 2.0.0."
+
+        self.assertEqual(str(e.exception), expected_msg)
+
+    def test_static_and_dynamic_error_in_traj(self):
+
+        t = dm.Trajectory()
+
+        with self.assertRaises(ValueError) as e:
+            t.add_parameter('alpha', val=np.ones((n_traj, 2)), units='m',
+                            targets={'p': ['comp.alpha']}, dynamic=False, static_target=True)
+
+        expected_msg = "Both the deprecated 'dynamic' option and option 'static_target' were " \
+                       "specified for parameter 'alpha'. Going forward, please use only option " \
+                       "static_target.  Option 'dynamic' will be removed in Dymos 2.0.0."
+
+        self.assertEqual(str(e.exception), expected_msg)
+
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()

--- a/dymos/phase/test/test_input_parameter_connections.py
+++ b/dymos/phase/test/test_input_parameter_connections.py
@@ -62,7 +62,7 @@ class TestStaticParameters(unittest.TestCase):
         phase.set_time_options(units='s', targets=['comp.time'])
         phase.add_state(name='F', rate_source='comp.y')
         phase.add_parameter('alpha', val=np.ones((n_traj, 2)), units='m',
-                            targets='comp.alpha', dynamic=False)
+                            targets='comp.alpha', static_target=True)
 
         p.model.add_subsystem('phase0', phase)
 
@@ -84,7 +84,7 @@ class TestStaticParameters(unittest.TestCase):
         phase.set_time_options(units='s', targets=['comp.time'])
         phase.add_state(name='F', rate_source='comp.y')
         phase.add_parameter('alpha', val=np.ones((n_traj, 2)), units='m',
-                            targets='comp.alpha', dynamic=False)
+                            targets='comp.alpha', static_target=True)
 
         p.model.add_subsystem('phase0', phase)
 

--- a/dymos/phase/test/test_simulate.py
+++ b/dymos/phase/test/test_simulate.py
@@ -59,7 +59,7 @@ class TestSimulateShapedParams(unittest.TestCase):
         main_phase.set_time_options(fix_initial=True, fix_duration=True, units='s')
 
         main_phase.add_parameter('chord', targets='chord', shape=(4,), units='inch',
-                                 dynamic=False)
+                                 static_target=True)
         p.model.connect('chord', 'hop0.main_phase.parameters:chord')
 
         main_phase.add_state('impulse', fix_initial=True, fix_final=False, units='N*s',

--- a/dymos/phase/test/test_sized_input_parameters.py
+++ b/dymos/phase/test/test_sized_input_parameters.py
@@ -122,7 +122,7 @@ class TestParameterConnections(unittest.TestCase):
         phase.add_state('h', fix_initial=True, fix_final=True, lower=0.0, units='m', rate_source='eom.h_dot')
         phase.add_state('v', fix_initial=True, fix_final=False, units='m/s', rate_source='eom.v_dot')
 
-        phase.add_parameter('m', val=[[1, 2], [3, 4]], units='kg', targets='sum.m', dynamic=False)
+        phase.add_parameter('m', val=[[1, 2], [3, 4]], units='kg', targets='sum.m', static_target=True)
 
         p.model.linear_solver = om.DirectSolver()
 
@@ -249,7 +249,7 @@ class TestParameterConnections(unittest.TestCase):
         phase.add_state('h', fix_initial=True, fix_final=True, lower=0.0, units='m', rate_source='eom.h_dot')
         phase.add_state('v', fix_initial=True, fix_final=False, units='m/s', rate_source='eom.v_dot')
 
-        phase.add_parameter('m', val=[[1, 2], [3, 4]], units='kg', targets='sum.m', dynamic=False)
+        phase.add_parameter('m', val=[[1, 2], [3, 4]], units='kg', targets='sum.m', static_target=True)
 
         p.model.linear_solver = om.DirectSolver()
 

--- a/dymos/test/test_run_problem.py
+++ b/dymos/test/test_run_problem.py
@@ -472,7 +472,7 @@ class TestSimulateArrayParam(unittest.TestCase):
                           units='deg', lower=0.01, upper=179.9)
 
         phase.add_parameter('g', units='m/s**2', val=9.80665)
-        phase.add_parameter('array', units=None, shape=(10,), dynamic=False)
+        phase.add_parameter('array', units=None, shape=(10,), static_target=True)
 
         # dummy array of data
         indeps = p.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])

--- a/dymos/test/test_upgrade_guide.py
+++ b/dymos/test/test_upgrade_guide.py
@@ -708,7 +708,7 @@ class TestUpgrade_0_19_0(unittest.TestCase):
                           continuity=True, rate_continuity=True,
                           units='deg', lower=0.01, upper=179.9)
 
-        phase.add_parameter('g', units='m/s**2', dynamic=False)
+        phase.add_parameter('g', units='m/s**2', static_target=True)
 
         phase.add_boundary_constraint('x', loc='final', equals=10)
         phase.add_boundary_constraint('y', loc='final', equals=5)

--- a/dymos/test/test_upgrade_guide.py
+++ b/dymos/test/test_upgrade_guide.py
@@ -516,13 +516,13 @@ class TestUpgrade_0_17_0(unittest.TestCase):
 
                 # upgrade_doc: begin tag_rate_source
                 self.add_output('xdot', val=np.zeros(nn), desc='velocity component in x', units='m/s',
-                                tags=['state_rate_source:x', 'state_units:m'])
+                                tags=['dymos.state_rate_source:x', 'dymos.state_units:m'])
 
                 self.add_output('ydot', val=np.zeros(nn), desc='velocity component in y', units='m/s',
-                                tags=['state_rate_source:y', 'state_units:m'])
+                                tags=['dymos.state_rate_source:y', 'dymos.state_units:m'])
 
                 self.add_output('vdot', val=np.zeros(nn), desc='acceleration magnitude', units='m/s**2',
-                                tags=['state_rate_source:v', 'state_units:m/s'])
+                                tags=['dymos.state_rate_source:v', 'dymos.state_units:m/s'])
                 # upgrade_doc: end tag_rate_source
 
                 self.add_output('check', val=np.zeros(nn), desc='check solution: v/sin(theta) = constant',

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -75,7 +75,7 @@ class Trajectory(om.Group):
     def add_parameter(self, name, units, val=_unspecified, desc=_unspecified, opt=False,
                       targets=_unspecified, lower=_unspecified, upper=_unspecified,
                       scaler=_unspecified, adder=_unspecified, ref0=_unspecified, ref=_unspecified,
-                      shape=_unspecified, dynamic=_unspecified):
+                      shape=_unspecified, dynamic=_unspecified, static_target=_unspecified):
         """
         Add a parameter (static control) to the trajectory.
 
@@ -116,6 +116,9 @@ class Trajectory(om.Group):
         dynamic : bool
             True if the targets in the ODE may be dynamic (if the inputs are sized to the number
             of nodes) else False.
+        static_target : bool or _unspecified
+            True if the targets in the ODE are not shaped with num_nodes as the first dimension
+            (meaning they cannot have a unique value at each node).  Otherwise False.
         """
         if name not in self.parameter_options:
             self.parameter_options[name] = TrajParameterOptionsDictionary()
@@ -160,7 +163,16 @@ class Trajectory(om.Group):
             self.parameter_options[name]['shape'] = shape
 
         if dynamic is not _unspecified:
-            self.parameter_options[name]['dynamic'] = dynamic
+            self.parameter_options[name]['static_target'] = not dynamic
+
+        if static_target is not _unspecified:
+            self.parameter_options[name]['static_target'] = static_target
+
+        if dynamic is not _unspecified and static_target is not _unspecified:
+            raise ValueError("Both the deprecated 'dynamic' option and option 'static_target' were "
+                             "specified for parameter '{name}. Going forward, please use only "
+                             "option static_target.  Option 'dynamic' will be removed in "
+                             "Dymos 2.0.0")
 
     def _setup_parameters(self):
         """
@@ -206,7 +218,7 @@ class Trajectory(om.Group):
                         # We need to add an input parameter to this phase.
 
                         # The default target in the phase is name unless otherwise specified.
-                        kwargs = {'dynamic': options['dynamic'],
+                        kwargs = {'static_target': options['static_target'],
                                   'units': options['units'],
                                   'val': options['val'],
                                   'targets': tgts[phase_name]}

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -170,9 +170,9 @@ class Trajectory(om.Group):
 
         if dynamic is not _unspecified and static_target is not _unspecified:
             raise ValueError("Both the deprecated 'dynamic' option and option 'static_target' were "
-                             "specified for parameter '{name}. Going forward, please use only "
-                             "option static_target.  Option 'dynamic' will be removed in "
-                             "Dymos 2.0.0")
+                             f"specified for parameter '{name}'. "
+                             f"Going forward, please use only option static_target.  Option "
+                             f"'dynamic' will be removed in Dymos 2.0.0.")
 
     def _setup_parameters(self):
         """

--- a/dymos/transcriptions/pseudospectral/components/control_endpoint_defect_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/control_endpoint_defect_comp.py
@@ -55,14 +55,14 @@ class ControlEndpointDefectComp(om.ExplicitComponent):
         self._output_str = {}
 
         for control_name, options in control_options.items():
-            if not (options['dynamic'] and options['opt']):
+            if not options['opt']:
                 continue
 
             shape = options['shape']
             size = np.prod(shape)
             units = options['units']
-            self._input_str[control_name] = 'controls:{0}'.format(control_name)
-            self._output_str[control_name] = 'control_endpoint_defects:{0}'.format(control_name)
+            self._input_str[control_name] = f'controls:{control_name}'
+            self._output_str[control_name] = f'control_endpoint_defects:{control_name}'
 
             self.add_input(name=self._input_str[control_name],
                            shape=(num_nodes,) + shape,

--- a/dymos/transcriptions/pseudospectral/gauss_lobatto.py
+++ b/dymos/transcriptions/pseudospectral/gauss_lobatto.py
@@ -817,10 +817,10 @@ class GaussLobatto(PseudospectralBase):
             options = phase.parameter_options[name]
             targets = get_targets(ode=phase.rhs_disc, name=name, user_targets=options['targets'])
 
-            dynamic = options['dynamic']
+            static = options['static_target']
             shape = options['shape']
 
-            if dynamic:
+            if not static:
                 disc_rows = np.zeros(self.grid_data.subset_num_nodes['state_disc'], dtype=int)
                 col_rows = np.zeros(self.grid_data.subset_num_nodes['col'], dtype=int)
                 disc_src_idxs = get_src_indices_by_row(disc_rows, shape)

--- a/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
+++ b/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
@@ -682,10 +682,10 @@ class Radau(PseudospectralBase):
             options = phase.parameter_options[name]
             targets = get_targets(ode=phase.rhs_all, name=name, user_targets=options['targets'])
 
-            dynamic = options['dynamic']
+            static = options['static_target']
             shape = options['shape']
 
-            if dynamic:
+            if not static:
                 src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
                 src_idxs = get_src_indices_by_row(src_idxs_raw, shape)
                 if shape == (1,):

--- a/dymos/transcriptions/solve_ivp/components/ode_integration_interface_system.py
+++ b/dymos/transcriptions/solve_ivp/components/ode_integration_interface_system.py
@@ -106,7 +106,7 @@ class ODEIntegrationInterfaceSystem(om.Group):
             targets = get_targets(ode=ode, name=name, user_targets=options['targets'])
             if targets:
                 for tgt in targets:
-                    tgt_shape, _ = get_target_metadata(ode=ode, name=name, user_targets=tgt)
+                    tgt_shape, _, _ = get_target_metadata(ode=ode, name=name, user_targets=tgt)
                     if len(tgt_shape) == 1 and tgt_shape[0] == 1:
                         src_idxs = np.arange(size, dtype=int).reshape(tgt_shape)
                     else:
@@ -156,10 +156,10 @@ class ODEIntegrationInterfaceSystem(om.Group):
         if self.options['parameter_options']:
             for name, options in self.options['parameter_options'].items():
                 targets = get_targets(ode=ode, name=name, user_targets=options['targets'])
-                shape, units = get_target_metadata(ode=ode, name=name,
-                                                   user_targets=options['targets'],
-                                                   user_shape=options['shape'],
-                                                   user_units=options['units'])
+                shape, units, _ = get_target_metadata(ode=ode, name=name,
+                                                      user_targets=options['targets'],
+                                                      user_shape=options['shape'],
+                                                      user_units=options['units'])
                 ivc.add_output(f'parameters:{name}', shape=shape, units=units)
                 if targets:
                     self.connect(f'parameters:{name}',
@@ -168,7 +168,7 @@ class ODEIntegrationInterfaceSystem(om.Group):
     def _get_rate_source_path(self, state_var):
         var = self.options['state_options'][state_var]['rate_source']
 
-        rate_path = 'ode.{0}'.format(var)
+        rate_path = f'ode.{var}'
 
         if var == 'time':
             rate_path = 'time'

--- a/dymos/transcriptions/solve_ivp/components/segment_simulation_comp.py
+++ b/dymos/transcriptions/solve_ivp/components/segment_simulation_comp.py
@@ -46,7 +46,7 @@ class SegmentSimulationComp(om.ExplicitComponent):
         self.options.declare('rtol', default=1.0E-6, types=(float,),
                              desc='Relative tolerance passed to scipy.integrate.solve_ivp.')
 
-        self.options.declare('ode_class',
+        self.options.declare('ode_class', recordable=False,
                              desc='System defining the ODE')
 
         self.options.declare('ode_init_kwargs', types=dict, default={},

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -321,8 +321,28 @@ class SolveIVP(TranscriptionBase):
             options['shape'] = shape
 
             if static_target:
-                raise ValueError(f"Control '{name} cannot be connected to its targets because one"
+                raise ValueError(f"Control '{name}' cannot be connected to its targets because one"
                                  f"or more targets are tagged with 'dymos.static_target'.")
+
+            # Now check rate targets
+            _, _, static_target = get_target_metadata(ode, name=name,
+                                                      user_targets=options['rate_targets'],
+                                                      user_units=options['units'],
+                                                      user_shape=options['shape'],
+                                                      control_rate=True)
+            if static_target:
+                raise ValueError(f"Control rate of '{name}' cannot be connected to its targets "
+                                 f"because one or more targets are tagged with 'dymos.static_target'.")
+
+            # Now check rate2 targets
+            _, _, static_target = get_target_metadata(ode, name=name,
+                                                      user_targets=options['rate2_targets'],
+                                                      user_units=options['units'],
+                                                      user_shape=options['shape'],
+                                                      control_rate=True)
+            if static_target:
+                raise ValueError(f"Control rate2 of '{name}' cannot be connected to its targets "
+                                 f"because one or more targets are tagged with 'dymos.static_target'.")
 
         grid_data = self.grid_data
 

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -292,8 +292,28 @@ class TranscriptionBase(object):
             options['shape'] = shape
 
             if static_target:
-                raise ValueError(f"Control '{name} cannot be connected to its targets because one"
+                raise ValueError(f"Control '{name}' cannot be connected to its targets because one "
                                  f"or more targets are tagged with 'dymos.static_target'.")
+
+            # Now check rate targets
+            _, _, static_target = get_target_metadata(ode, name=name,
+                                                      user_targets=options['rate_targets'],
+                                                      user_units=options['units'],
+                                                      user_shape=options['shape'],
+                                                      control_rate=True)
+            if static_target:
+                raise ValueError(f"Control rate of '{name}' cannot be connected to its targets "
+                                 f"because one or more targets are tagged with 'dymos.static_target'.")
+
+            # Now check rate2 targets
+            _, _, static_target = get_target_metadata(ode, name=name,
+                                                      user_targets=options['rate2_targets'],
+                                                      user_units=options['units'],
+                                                      user_shape=options['shape'],
+                                                      control_rate=True)
+            if static_target:
+                raise ValueError(f"Control rate2 of '{name}' cannot be connected to its targets "
+                                 f"because one or more targets are tagged with 'dymos.static_target'.")
 
         if phase.control_options:
             phase.control_group.configure_io()
@@ -342,8 +362,30 @@ class TranscriptionBase(object):
             options['shape'] = shape
 
             if static_target:
-                raise ValueError(f"Control '{name} cannot be connected to its targets because one"
-                                 f"or more targets are tagged with 'dymos.static_target'.")
+                raise ValueError(f"Polynomial control '{name}' cannot be connected to its targets "
+                                 f"because one or more targets are tagged with 'dymos.static_target'.")
+
+            # Now check rate targets
+            _, _, static_target = get_target_metadata(ode, name=name,
+                                                      user_targets=options['rate_targets'],
+                                                      user_units=options['units'],
+                                                      user_shape=options['shape'],
+                                                      control_rate=True)
+            if static_target:
+                raise ValueError(f"Rate of polynomial control '{name}' cannot be connected to its "
+                                 f"targets because one or more targets are tagged with "
+                                 f"'dymos.static_target'.")
+
+            # Now check rate2 targets
+            _, _, static_target = get_target_metadata(ode, name=name,
+                                                      user_targets=options['rate2_targets'],
+                                                      user_units=options['units'],
+                                                      user_shape=options['shape'],
+                                                      control_rate=True)
+            if static_target:
+                raise ValueError(f"Rate2 of polynomial control '{name}' cannot be connected to its "
+                                 f"targets because one or more targets are tagged with "
+                                 f"'dymos.static_target'.")
 
         if phase.polynomial_control_options:
             phase.polynomial_control_group.configure_io()

--- a/dymos/utils/misc.py
+++ b/dymos/utils/misc.py
@@ -156,10 +156,13 @@ def get_target_metadata(ode, name, user_targets=_unspecified, user_units=_unspec
         units = user_units
 
     # Resolve whether the targets is static or dynamic
-    static_target_tags = ['dymos.static_target' in ode_inputs[tgt]['tags']
-                          for tgt in targets]
-    if any(static_target_tags):
+    static_target_tags = [tgt for tgt in targets if 'dymos.static_target' in ode_inputs[tgt]['tags']]
+    if static_target_tags:
         static_target = True
+        if not user_static_target:
+            raise ValueError(f"User has specified 'static_target = False' for parameter {name},"
+                             f"but one or more targets is tagged with "
+                             f"'dymos.static_target': {' '.join(static_target_tags)}")
     else:
         if user_static_target is _unspecified:
             static_target = False

--- a/joss/test/test_cannonball_for_joss.py
+++ b/joss/test/test_cannonball_for_joss.py
@@ -127,8 +127,8 @@ class TestCannonballForJOSS(unittest.TestCase):
         traj = p.model.add_subsystem('traj', dm.Trajectory())
         # Declare parameters that will be constant across
         # the two phases of the trajectory, so we can connect to it only once
-        traj.add_parameter('mass', units='kg', val=0.01, dynamic=False)
-        traj.add_parameter('area', units='m**2', dynamic=False)
+        traj.add_parameter('mass', units='kg', val=0.01, static_target=True)
+        traj.add_parameter('area', units='m**2', static_target=True)
 
         tx = dm.Radau(num_segments=5, order=3, compressed=True)
         ascent = dm.Phase(transcription=tx, ode_class=CannonballODE)
@@ -151,8 +151,8 @@ class TestCannonballForJOSS(unittest.TestCase):
         ascent.set_time_options(fix_initial=True, duration_bounds=(1, 100),
                                 duration_ref=100, units='s')
 
-        ascent.add_parameter('mass', units='kg', val=0.01, dynamic=False)
-        ascent.add_parameter('area', units='m**2', dynamic=False)
+        ascent.add_parameter('mass', units='kg', val=0.01, static_target=True)
+        ascent.add_parameter('area', units='m**2', static_target=True)
 
         # Limit the initial muzzle energy to create a well posed problem
         # with respect to cannonball size and initial velocity
@@ -180,8 +180,8 @@ class TestCannonballForJOSS(unittest.TestCase):
         descent.set_time_options(initial_bounds=(.5, 100), duration_bounds=(.5, 100),
                                  duration_ref=100, units='s')
 
-        descent.add_parameter('mass', units='kg', val=0.01, dynamic=False)
-        descent.add_parameter('area', units='m**2', dynamic=False)
+        descent.add_parameter('mass', units='kg', val=0.01, static_target=True)
+        descent.add_parameter('area', units='m**2', static_target=True)
 
         # Link Phases (link time and all state variables)
         traj.link_phases(phases=['ascent', 'descent'], vars=['*'])

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ The software has two primary objectives:
     packages=find_packages(),
     python_requires=">=3.6",
     install_requires=[
-        'openmdao>=3.3.0',
+        'openmdao>=3.9.0',
         'numpy>=1.14.1',
         'scipy>=1.0.0'
     ],


### PR DESCRIPTION
### Summary

Updated tags to new format so that dymos related tags begin with 'dymos.' 
Added 'dymos.static_target' tag. 

Deprecated parameter option 'dynamic' which is now replaced by 'static_target' which has the opposite meaning.

### Related Issues

- Resolves #542

### Status

- [x] Ready for merge

### Backwards incompatibilities

- Parameter option 'dynamic' is now deprecated.  Replaced by option 'static_target' which has the opposite meaning.
- Dymos is starting to use the OpenMDAO warning system, so 3.9.0 is the minimum required version for this release.

### New Dependencies

None
