### PR TITLE
Revert "removed require_pyoptsparse decorator"

### DIFF
--- a/dymos/examples/balanced_field/doc/test_doc_balanced_field_length.py
+++ b/dymos/examples/balanced_field/doc/test_doc_balanced_field_length.py
@@ -1,8 +1,9 @@
 import unittest
 
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs
 
 from dymos.utils.doc_utils import save_for_docs
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 @use_tempdirs

--- a/dymos/examples/balanced_field/test/test_balanced_field_length.py
+++ b/dymos/examples/balanced_field/test/test_balanced_field_length.py
@@ -3,11 +3,12 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.assert_utils import assert_near_equal
 
 import dymos as dm
 from dymos.examples.balanced_field.balanced_field_ode import BalancedFieldODEComp
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 @use_tempdirs

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
@@ -6,9 +6,10 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs
 
 from dymos.utils.doc_utils import save_for_docs
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 @use_tempdirs

--- a/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
@@ -4,9 +4,10 @@ import matplotlib.pyplot as plt
 plt.switch_backend('Agg')
 plt.style.use('ggplot')
 
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs
 
 from dymos.utils.doc_utils import save_for_docs
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 @use_tempdirs

--- a/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise.py
@@ -5,10 +5,11 @@ import numpy as np
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.mpi import MPI
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 def make_traj(transcription='gauss-lobatto', transcription_order=3, compressed=False,

--- a/dymos/examples/finite_burn_orbit_raise/test/test_multi_phase_restart.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_multi_phase_restart.py
@@ -4,11 +4,11 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
-from dymos.utils.testing_utils import assert_cases_equal
+from dymos.utils.testing_utils import assert_cases_equal, require_pyoptsparse
 
 
 def make_traj(transcription='gauss-lobatto', transcription_order=3, compressed=False,

--- a/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
@@ -1,7 +1,9 @@
 import unittest
 import warnings
 
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs
+
+from dymos.utils.testing_utils import require_pyoptsparse
 
 import matplotlib.pyplot as plt
 plt.switch_backend('Agg')

--- a/dymos/examples/hyper_sensitive/test/test_hyper_sensitive.py
+++ b/dymos/examples/hyper_sensitive/test/test_hyper_sensitive.py
@@ -9,11 +9,12 @@ import numpy as np
 from openmdao.api import Problem, Group, pyOptSparseDriver
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import printoptions
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos import Trajectory, GaussLobatto, Phase, Radau
 from dymos.examples.hyper_sensitive.hyper_sensitive_ode import HyperSensitiveODE
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 tf = np.float128(10)

--- a/dymos/examples/min_time_climb/doc/test_doc_min_time_climb_fd.py
+++ b/dymos/examples/min_time_climb/doc/test_doc_min_time_climb_fd.py
@@ -8,10 +8,11 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.coloring import Coloring
 
 from dymos.utils.doc_utils import save_for_docs
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 def _view_coloring(coloring_file, show_sparsity_text=False, show_sparsity=True,

--- a/dymos/examples/racecar/doc/test_doc_racecar.py
+++ b/dymos/examples/racecar/doc/test_doc_racecar.py
@@ -1,8 +1,9 @@
 import unittest
 
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs
 
 from dymos.utils.doc_utils import save_for_docs
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 @use_tempdirs

--- a/dymos/examples/robot_arm/doc/test_doc_robot_arm.py
+++ b/dymos/examples/robot_arm/doc/test_doc_robot_arm.py
@@ -8,11 +8,12 @@ import numpy as np
 from openmdao.api import Problem, Group, pyOptSparseDriver
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import printoptions
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos import Trajectory, GaussLobatto, Phase, Radau
 from dymos.examples.robot_arm.robot_arm_ode import RobotArmODE
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 @use_tempdirs

--- a/dymos/examples/robot_arm/test/test_robot_arm.py
+++ b/dymos/examples/robot_arm/test/test_robot_arm.py
@@ -7,11 +7,12 @@ import matplotlib.pyplot as plt
 from openmdao.api import Problem, Group, pyOptSparseDriver
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import printoptions
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos import Trajectory, GaussLobatto, Phase, Radau
 from dymos.examples.robot_arm.robot_arm_ode import RobotArmODE
+from dymos.utils.testing_utils import require_pyoptsparse
 
 plt.switch_backend('Agg')
 show_plots = True

--- a/dymos/examples/shuttle_reentry/test/test_reentry.py
+++ b/dymos/examples/shuttle_reentry/test/test_reentry.py
@@ -4,10 +4,11 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs
 
 from dymos import Trajectory, GaussLobatto, Phase, Radau
 from dymos.examples.shuttle_reentry.shuttle_ode import ShuttleODE
+from dymos.utils.testing_utils import require_pyoptsparse
 
 # Expected results from Betts
 expected_results = {'constrained': {'time': 2198.67, 'theta': 30.6255},

--- a/dymos/examples/vanderpol/test/test_vanderpol.py
+++ b/dymos/examples/vanderpol/test/test_vanderpol.py
@@ -2,11 +2,12 @@ import unittest
 from numpy.testing import assert_almost_equal
 import numpy as np
 
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.mpi import MPI
 
 import dymos as dm
 from dymos.examples.vanderpol.vanderpol_dymos import vanderpol
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 @use_tempdirs

--- a/dymos/examples/water_rocket/doc/test_doc_water_rocket.py
+++ b/dymos/examples/water_rocket/doc/test_doc_water_rocket.py
@@ -7,12 +7,13 @@ import matplotlib.pyplot as plt
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs
 
 from dymos.examples.water_rocket.phases import (new_water_rocket_trajectory,
                                                 set_sane_initial_guesses)
 
 from dymos.utils.doc_utils import save_for_docs
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 @require_pyoptsparse(optimizer='IPOPT')

--- a/dymos/trajectory/test/test_parameter_promotion.py
+++ b/dymos/trajectory/test/test_parameter_promotion.py
@@ -3,10 +3,11 @@ import unittest
 import openmdao.api as om
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 @use_tempdirs

--- a/dymos/utils/testing_utils.py
+++ b/dymos/utils/testing_utils.py
@@ -182,3 +182,52 @@ def assert_timeseries_near_equal(t1, x1, t2, x2, tolerance=1.0E-6):
     y_interp = np.reshape(interp(t_check), newshape=(num_points,) + shape1)
 
     _om_assert_utils.assert_near_equal(y_interp, x_check, tolerance=tolerance)
+
+
+def require_pyoptsparse(optimizer=None):
+    """
+    Decorate test to raise a skiptest if a required pyoptsparse optimizer cannot be imported.
+
+    Parameters
+    ----------
+    optimizer : String
+        Pyoptsparse optimizer string. Default is None, which just checks for pyoptsparse.
+
+    Returns
+    -------
+    TestCase or TestCase.method
+        The decorated TestCase class or method.
+    """
+    def decorator(obj):
+
+        import unittest
+        try:
+            from pyoptsparse import OPT
+
+        except Exception:
+            msg = "pyoptsparse is not installed."
+
+            if not isinstance(obj, type):
+                @functools.wraps(obj)
+                def skip_wrapper(*args, **kwargs):
+                    raise unittest.SkipTest(msg)
+                obj = skip_wrapper
+            obj.__unittest_skip__ = True
+            obj.__unittest_skip_why__ = msg
+            return obj
+
+        try:
+            OPT(optimizer)
+        except Exception:
+            msg = "pyoptsparse is not providing %s" % optimizer
+
+            if not isinstance(obj, type):
+                @functools.wraps(obj)
+                def skip_wrapper(*args, **kwargs):
+                    raise unittest.SkipTest(msg)
+                obj = skip_wrapper
+            obj.__unittest_skip__ = True
+            obj.__unittest_skip_why__ = msg
+
+        return obj
+    return decorator

--- a/dymos/visualization/test/test_timeseries_plots.py
+++ b/dymos/visualization/test/test_timeseries_plots.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
 from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
@@ -12,6 +12,7 @@ from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneOD
 from dymos.examples.battery_multibranch.battery_multibranch_ode import BatteryODE
 from dymos.utils.lgl import lgl
 from dymos.visualization.timeseries_plots import timeseries_plots
+from dymos.utils.testing_utils import require_pyoptsparse
 
 
 @use_tempdirs


### PR DESCRIPTION
This reverts commit 1cc5320d7b0471365fcca8ba4b4c06341e7bb1a3.

### Summary

Summary of PR.

### Related Issues

- Resolves #

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
