### PR TITLE
install coveralls from pypi in github workflow

### DIFF
--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -221,7 +221,7 @@ jobs:
           echo "Submit coverage"
           echo "============================================================="
           cp $HOME/.coverage .
-          pip install git+https://github.com/swryan/coveralls-python
+          pip install coveralls
           SITE_DIR=`python -c 'import site; print(site.getsitepackages()[-1])'`
           coveralls --basedir $SITE_DIR
 


### PR DESCRIPTION
### Summary

the --basedir arg is now available on the pypi release of coveralls

### Related Issues

- Resolves #

### Status

- [ ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
