### PR TITLE
Phases now have simulate_options

### DIFF
--- a/dymos/examples/brachistochrone/test/ex_brachistochrone.py
+++ b/dymos/examples/brachistochrone/test/ex_brachistochrone.py
@@ -62,6 +62,8 @@ def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, tran
 
     p.setup(check=['unconnected_inputs'], force_alloc_complex=force_alloc_complex)
 
+    phase.set_simulate_options(method='DOP853')
+
     p['traj0.phase0.t_initial'] = 0.0
     p['traj0.phase0.t_duration'] = 2.0
 
@@ -71,47 +73,7 @@ def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, tran
     p['traj0.phase0.controls:theta'] = phase.interp('theta', [5, 100])
     p['traj0.phase0.parameters:g'] = 9.80665
 
-    dm.run_problem(p, run_driver=run_driver)
-
-    # Plot results
-    if SHOW_PLOTS:
-        exp_out = traj.simulate()
-
-        fig, ax = plt.subplots()
-        fig.suptitle('Brachistochrone Solution')
-
-        x_imp = p.get_val('traj0.phase0.timeseries.states:x')
-        y_imp = p.get_val('traj0.phase0.timeseries.states:y')
-
-        x_exp = exp_out.get_val('traj0.phase0.timeseries.states:x')
-        y_exp = exp_out.get_val('traj0.phase0.timeseries.states:y')
-
-        ax.plot(x_imp, y_imp, 'ro', label='implicit')
-        ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-        ax.set_xlabel('x (m)')
-        ax.set_ylabel('y (m)')
-        ax.grid(True)
-        ax.legend(loc='upper right')
-
-        fig, ax = plt.subplots()
-        fig.suptitle('Brachistochrone Solution')
-
-        x_imp = p.get_val('traj0.phase0.timeseries.time_phase')
-        y_imp = p.get_val('traj0.phase0.timeseries.controls:theta')
-
-        x_exp = exp_out.get_val('traj0.phase0.timeseries.time_phase')
-        y_exp = exp_out.get_val('traj0.phase0.timeseries.controls:theta')
-
-        ax.plot(x_imp, y_imp, 'ro', label='implicit')
-        ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-        ax.set_xlabel('time (s)')
-        ax.set_ylabel('theta (rad)')
-        ax.grid(True)
-        ax.legend(loc='lower right')
-
-        plt.show()
+    dm.run_problem(p, run_driver=run_driver, simulate=True, make_plots=True)
 
     return p
 

--- a/dymos/examples/brachistochrone/test/ex_brachistochrone.py
+++ b/dymos/examples/brachistochrone/test/ex_brachistochrone.py
@@ -62,7 +62,7 @@ def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, tran
 
     p.setup(check=['unconnected_inputs'], force_alloc_complex=force_alloc_complex)
 
-    phase.set_simulate_options(method='DOP853')
+    phase.set_simulate_options(method='RK23')
 
     p['traj0.phase0.t_initial'] = 0.0
     p['traj0.phase0.t_duration'] = 2.0

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_control.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_control.py
@@ -136,7 +136,7 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         # Test the results
         assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
-        sim_out = phase.simulate(times_per_seg=20)
+        sim_out = phase.simulate(times_per_seg=20, rtol=1.0E-5)
 
         x_sol = p.get_val('phase0.timeseries.states:x')
         y_sol = p.get_val('phase0.timeseries.states:y')
@@ -158,11 +158,11 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         theta_interp = interp1d(time_sim[:, 0], theta_sim[:, 0])
         theta_dot_interp = interp1d(time_sim[:, 0], theta_dot_sim[:, 0])
 
-        assert_near_equal(x_interp(time_sol), x_sol, tolerance=1.0E-5)
-        assert_near_equal(y_interp(time_sol), y_sol, tolerance=1.0E-5)
-        assert_near_equal(v_interp(time_sol), v_sol, tolerance=1.0E-5)
-        assert_near_equal(theta_interp(time_sol), theta_sol, tolerance=1.0E-5)
-        assert_near_equal(theta_dot_interp(time_sol), theta_dot_sol, tolerance=1.0E-5)
+        assert_near_equal(x_interp(time_sol), x_sol, tolerance=1.0E-4)
+        assert_near_equal(y_interp(time_sol), y_sol, tolerance=1.0E-4)
+        assert_near_equal(v_interp(time_sol), v_sol, tolerance=1.0E-4)
+        assert_near_equal(theta_interp(time_sol), theta_sol, tolerance=1.0E-4)
+        assert_near_equal(theta_dot_interp(time_sol), theta_dot_sol, tolerance=1.0E-4)
 
     def test_brachistochrone_integrated_control_radau_ps(self):
         import numpy as np
@@ -190,6 +190,8 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         phase.add_control('theta_dot', units='deg/s', rate_continuity=True, shape=(1, ), lower=0, upper=60)
 
         phase.add_parameter('g', units='m/s**2', opt=False, val=9.80665, targets=['g'])
+
+        phase.set_simulate_options(rtol=1.0E-8, atol=1.0E-8)
 
         # Minimize time at the end of the phase
         phase.add_objective('time', loc='final', scaler=10)

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_simulate_options.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_simulate_options.py
@@ -71,7 +71,7 @@ class TestBrachistochroneSimulate(unittest.TestCase):
         import openmdao.api as om
         import dymos as dm
 
-        for method, atol, first_step in itertools.product(('RK23', 'RK45', 'DOP853'), (0.01, 0.001),
+        for method, atol, first_step in itertools.product(('RK23', 'RK45'), (0.01, 0.001),
                                                           (None, 0.01, .1)):
             with self.subTest():
 

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_simulate_options.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_simulate_options.py
@@ -1,0 +1,147 @@
+import unittest
+
+import numpy as np
+
+import openmdao.api as om
+from openmdao.utils.testing_utils import use_tempdirs
+
+
+class BrachistochroneODE(om.ExplicitComponent):
+
+    def initialize(self):
+        self.options.declare('num_nodes', types=int)
+
+    def setup(self):
+        nn = self.options['num_nodes']
+
+        # Inputs
+        self.add_input('v', val=np.zeros(nn), desc='velocity', units='m/s')
+        self.add_input('g', val=9.80665, desc='acceleration of gravity', units='m/s**2')
+        self.add_input('theta', val=np.zeros(nn), desc='angle of wire', units='rad')
+        self.add_output('xdot', val=np.zeros(nn), desc='horizontal velocity', units='m/s')
+        self.add_output('ydot', val=np.zeros(nn), desc='vertical velocity', units='m/s')
+        self.add_output('vdot', val=np.zeros(nn), desc='acceleration mag.', units='m/s**2')
+
+        # Setup partials
+        arange = np.arange(self.options['num_nodes'], dtype=int)
+
+        self.declare_partials(of='vdot', wrt='g', rows=arange, cols=np.zeros(nn, dtype=int))
+        self.declare_partials(of='vdot', wrt='theta', rows=arange, cols=arange)
+
+        self.declare_partials(of='xdot', wrt='v', rows=arange, cols=arange)
+        self.declare_partials(of='xdot', wrt='theta', rows=arange, cols=arange)
+
+        self.declare_partials(of='ydot', wrt='v', rows=arange, cols=arange)
+        self.declare_partials(of='ydot', wrt='theta', rows=arange, cols=arange)
+
+    def compute(self, inputs, outputs):
+        theta = inputs['theta']
+        cos_theta = np.cos(theta)
+        sin_theta = np.sin(theta)
+        g = inputs['g']
+        v = inputs['v']
+
+        outputs['vdot'] = g * cos_theta
+        outputs['xdot'] = v * sin_theta
+        outputs['ydot'] = -v * cos_theta
+
+    def compute_partials(self, inputs, jacobian):
+        theta = inputs['theta']
+        cos_theta = np.cos(theta)
+        sin_theta = np.sin(theta)
+        g = inputs['g']
+        v = inputs['v']
+
+        jacobian['vdot', 'g'] = cos_theta
+        jacobian['vdot', 'theta'] = -g * sin_theta
+
+        jacobian['xdot', 'v'] = sin_theta
+        jacobian['xdot', 'theta'] = v * cos_theta
+
+        jacobian['ydot', 'v'] = -cos_theta
+        jacobian['ydot', 'theta'] = v * sin_theta
+
+
+@use_tempdirs
+class TestBrachistochroneSimulate(unittest.TestCase):
+
+    def test_simulate_options(self):
+        import itertools
+        import numpy as np
+        import openmdao.api as om
+        import dymos as dm
+
+        for method, atol, first_step in itertools.product(('RK23', 'RK45', 'DOP853'), (0.01, 0.001),
+                                                          (None, 0.01, .1)):
+            with self.subTest():
+
+                #
+                # Define the OpenMDAO problem
+                #
+                p = om.Problem(model=om.Group())
+
+                #
+                # Define a Trajectory object
+                #
+                traj = dm.Trajectory()
+
+                p.model.add_subsystem('traj', subsys=traj)
+
+                #
+                # Define a Dymos Phase object with GaussLobatto Transcription
+                #
+                phase = dm.Phase(ode_class=BrachistochroneODE,
+                                 transcription=dm.GaussLobatto(num_segments=10, order=3))
+
+                traj.add_phase(name='phase0', phase=phase)
+
+                #
+                # Set the time options
+                # Time has no targets in our ODE.
+                # We fix the initial time so that the it is not a design variable in the optimization.
+                # The duration of the phase is allowed to be optimized, but is bounded on [0.5, 10].
+                #
+                phase.set_time_options(fix_initial=True, duration_bounds=(0.5, 10.0), units='s')
+
+                #
+                # Set the time options
+                # Initial values of positions and velocity are all fixed.
+                # The final value of position are fixed, but the final velocity is a free variable.
+                # The equations of motion are not functions of position, so 'x' and 'y' have no targets.
+                # The rate source points to the output in the ODE which provides the time derivative of the
+                # given state.
+                phase.add_state('x', fix_initial=True, fix_final=True, rate_source='xdot')
+                phase.add_state('y', fix_initial=True, fix_final=True, rate_source='ydot')
+                phase.add_state('v', fix_initial=True, fix_final=False, rate_source='vdot')
+
+                # Define theta as a control.
+                phase.add_control(name='theta', units='rad', lower=0, upper=np.pi)
+
+                # Minimize final time.
+                phase.add_objective('time', loc='final')
+
+                # Set the simulate options
+                phase.set_simulate_options(method=method, atol=atol, first_step=first_step)
+
+                # Set the driver.
+                p.driver = om.ScipyOptimizeDriver()
+
+                # Allow OpenMDAO to automatically determine our sparsity pattern.
+                # Doing so can significant speed up the execution of Dymos.
+                p.driver.declare_coloring()
+
+                # Setup the problem
+                p.setup(check=True)
+
+                # Now that the OpenMDAO problem is setup, we can set the values of the states.
+                p.set_val('traj.phase0.states:x', phase.interp('x', [0, 10]), units='m')
+
+                p.set_val('traj.phase0.states:y', phase.interp('y', [10, 5]), units='m')
+
+                p.set_val('traj.phase0.states:v', phase.interp('v', [0, 5]), units='m/s')
+
+                p.set_val('traj.phase0.controls:theta', phase.interp('theta', [90, 90]), units='deg')
+
+                # Run the driver to solve the problem
+                dm.run_problem(p, run_driver=True, simulate=True)
+

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_simulate_options.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_simulate_options.py
@@ -144,4 +144,3 @@ class TestBrachistochroneSimulate(unittest.TestCase):
 
                 # Run the driver to solve the problem
                 dm.run_problem(p, run_driver=True, simulate=True)
-

--- a/dymos/examples/cannonball/test/test_cannonball_matrix_state.py
+++ b/dymos/examples/cannonball/test/test_cannonball_matrix_state.py
@@ -45,6 +45,8 @@ class TestCannonballMatrixState(unittest.TestCase):
         phase.add_boundary_constraint('z', loc='final', lower=0, upper=0, indices=[1])
         phase.add_objective('time', loc='final')
 
+        phase.set_simulate_options(rtol=1.0E-9, atol=1.0E-9)
+
         p.driver = om.pyOptSparseDriver()
         p.driver.declare_coloring(tol=1.0E-12)
 
@@ -144,6 +146,8 @@ class TestCannonballMatrixStateExplicitShape(unittest.TestCase):
 
         phase.add_boundary_constraint('z', loc='final', lower=0, upper=0, indices=[1])
         phase.add_objective('time', loc='final')
+
+        phase.set_simulate_options(rtol=1.0E-9, atol=1.0E-9)
 
         p.driver = om.pyOptSparseDriver()
         p.driver.declare_coloring(tol=1.0E-12)

--- a/dymos/examples/double_integrator/test/test_double_integrator_timeseries_units.py
+++ b/dymos/examples/double_integrator/test/test_double_integrator_timeseries_units.py
@@ -31,6 +31,8 @@ def double_integrator_direct_collocation(transcription=dm.GaussLobatto, compress
     phase.add_control('u', units='m/s**2', scaler=0.01, continuity=False, rate_continuity=False,
                       rate2_continuity=False, shape=(1, ), lower=-1.0, upper=1.0)
 
+    phase.set_simulate_options(rtol=1.0E-9, atol=1.0E-9)
+
     # Maximize distance travelled in one second.
     phase.add_objective('x', loc='final', scaler=-1)
 

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -569,6 +569,34 @@ class GridRefinementOptionsDictionary(om.OptionsDictionary):
                      desc='Maximum allowed ratio of state second derivatives across refinement iterations')
 
 
+class SimulateOptionsDictionary(om.OptionsDictionary):
+    """
+    An OptionsDictionary for simulate options in a Phase.
+
+    Parameters
+    ----------
+    read_only : bool
+        If True, setting (via __setitem__ or update) is not permitted.
+    """
+    def __init__(self, read_only=False):
+        super(SimulateOptionsDictionary, self).__init__(read_only)
+
+        self.declare('method', values=('RK23', 'RK45', 'DOP853'), default='RK45',
+                     desc='The method used by simulate to propagate the ODE.')
+
+        self.declare(name='atol', types=(float, np.array), default=1.0E-6,
+                     desc='Absolute error tolerance for variable step integration.')
+
+        self.declare(name='rtol', types=(float, np.array), default=1.0E-3,
+                     desc='Relative error tolerance for variable step integration.')
+
+        self.declare(name='first_step', types=float, allow_none=True, default=None,
+                     desc='Initial step size, or None if the algorithm should choose.')
+
+        self.declare(name='max_step', types=float, default=np.inf,
+                     desc='Maximum allowable step size')
+
+
 class _ForDocs(object):  # pragma: no cover
     """
     This class is provided as a way to automatically display options dictionaries in the docs,

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -1793,13 +1793,13 @@ class Phase(om.Group):
             None, output to all nodes provided by this phases GridData.
         method : str
             The scipy.integrate.solve_ivp integration method.
-        atol : float or _unspecified
+        atol : float
             Absolute convergence tolerance for the scipy.integrate.solve_ivp method.
-        rtol : float or _unspecified
+        rtol : float
             Relative convergence tolerance for the scipy.integrate.solve_ivp method.
-        first_step: float or _unspecified
-            Initital step size for the integration.
-        max_step: float or _unspecified
+        first_step : float
+            Initial step size for the integration.
+        max_step : float or _unspecified
             Maximum step size for the integration.
 
         Returns
@@ -1921,9 +1921,9 @@ class Phase(om.Group):
             Absolute convergence tolerance for scipy.integrate.solve_ivp.
         rtol : float
             Relative convergence tolerance for scipy.integrate.solve_ivp.
-        first_step: float or _unspecified
-            Initital step size for the integration.
-        max_step: float or _unspecified
+        first_step : float
+            Initial step size for the integration.
+        max_step : float
             Maximum step size for the integration.
         record_file : str or None
             If a string, the file to which the result of the simulation will be saved.
@@ -2001,13 +2001,13 @@ class Phase(om.Group):
         ----------
         method : str
             The scipy.integrate.solve_ivp integration method.
-        atol : float or _unspecified
+        atol : float
             Absolute convergence tolerance for the scipy.integrate.solve_ivp method.
-        rtol : float or _unspecified
+        rtol : float
             Relative convergence tolerance for the scipy.integrate.solve_ivp method.
-        first_step: float or _unspecified
-            Initital step size for the integration.
-        max_step: float or _unspecified
+        first_step : float
+            Initial step size for the integration.
+        max_step : float
             Maximum step size for the integration.
         """
         if method is not _unspecified:

--- a/dymos/test/test_run_problem.py
+++ b/dymos/test/test_run_problem.py
@@ -305,7 +305,7 @@ class TestRunProblem(unittest.TestCase):
         # # Run the model
         run_problem(q, restart='vanderpol_simulation.sql')
 
-        s = q.model.traj.simulate()
+        s = q.model.traj.simulate(rtol=1.0E-9, atol=1.0E-9)
 
         # get_val returns data for duplicate time points; remove them before interpolating
         tq = q.get_val('traj.phase0.timeseries.time')[:, 0]

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -902,7 +902,8 @@ class Trajectory(om.Group):
                                             var_a=var, var_b=var, loc_a=loc_a, loc_b=loc_b,
                                             connected=connected)
 
-    def simulate(self, times_per_seg=10, method='RK45', atol=1.0E-9, rtol=1.0E-9, record_file=None):
+    def simulate(self, times_per_seg=10, method=_unspecified, atol=_unspecified, rtol=_unspecified,
+                 first_step=_unspecified, max_step=_unspecified, record_file=None):
         """
         Simulate the Trajectory using scipy.integrate.solve_ivp.
 
@@ -917,6 +918,10 @@ class Trajectory(om.Group):
             Absolute convergence tolerance for scipy.integrate.solve_ivp.
         rtol : float
             Relative convergence tolerance for scipy.integrate.solve_ivp.
+        first_step: float or _unspecified
+            Initital step size for the integration.
+        max_step: float or _unspecified
+            Maximum step size for the integration.
         record_file : str or None
             If a string, the file to which the result of the simulation will be saved.
             If None, no record of the simulation will be saved.
@@ -932,7 +937,8 @@ class Trajectory(om.Group):
 
         for name, phs in self._phases.items():
             sim_phs = phs.get_simulation_phase(times_per_seg=times_per_seg, method=method,
-                                               atol=atol, rtol=rtol)
+                                               atol=atol, rtol=rtol, first_step=first_step,
+                                               max_step=max_step)
             sim_traj.add_phase(name, sim_phs)
 
         sim_traj.parameter_options.update(self.parameter_options)

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -918,9 +918,9 @@ class Trajectory(om.Group):
             Absolute convergence tolerance for scipy.integrate.solve_ivp.
         rtol : float
             Relative convergence tolerance for scipy.integrate.solve_ivp.
-        first_step: float or _unspecified
-            Initital step size for the integration.
-        max_step: float or _unspecified
+        first_step : float
+            Initial step size for the integration.
+        max_step : float
             Maximum step size for the integration.
         record_file : str or None
             If a string, the file to which the result of the simulation will be saved.

--- a/dymos/transcriptions/solve_ivp/components/segment_simulation_comp.py
+++ b/dymos/transcriptions/solve_ivp/components/segment_simulation_comp.py
@@ -242,6 +242,8 @@ class SegmentSimulationComp(om.ExplicitComponent):
         # Perform the integration using solve_ivp
         sim_options = {key: val for key, val in self.options['simulate_options'].items()}
 
+        print(sim_options)
+
         sol = solve_ivp(fun=self.options['ode_integration_interface'],
                         t_span=(inputs['time'][0], inputs['time'][-1]),
                         y0=self.initial_state_vec,

--- a/dymos/transcriptions/solve_ivp/components/segment_simulation_comp.py
+++ b/dymos/transcriptions/solve_ivp/components/segment_simulation_comp.py
@@ -242,9 +242,6 @@ class SegmentSimulationComp(om.ExplicitComponent):
         # Perform the integration using solve_ivp
         sim_options = {key: val for key, val in self.options['simulate_options'].items()}
 
-        for key, val in sim_options.items():
-            print(key, val)
-
         sol = solve_ivp(fun=self.options['ode_integration_interface'],
                         t_span=(inputs['time'][0], inputs['time'][-1]),
                         y0=self.initial_state_vec,

--- a/dymos/transcriptions/solve_ivp/components/segment_simulation_comp.py
+++ b/dymos/transcriptions/solve_ivp/components/segment_simulation_comp.py
@@ -2,7 +2,6 @@
 SimulationPhase is an instance that resembles a Phase in structure but is intended for
 use with scipy.solve_ivp to verify the accuracy of the implicit solutions of Dymos.
 """
-import inspect
 import numpy as np
 
 from scipy.integrate import solve_ivp
@@ -11,7 +10,7 @@ import openmdao.api as om
 from ....utils.interpolate import LagrangeBarycentricInterpolant
 from ....utils.lgl import lgl
 from .ode_integration_interface import ODEIntegrationInterface
-from ....phase.options import TimeOptionsDictionary
+from ....phase.options import TimeOptionsDictionary, SimulateOptionsDictionary
 
 
 class SegmentSimulationComp(om.ExplicitComponent):
@@ -36,15 +35,8 @@ class SegmentSimulationComp(om.ExplicitComponent):
 
         self.options.declare('grid_data', desc='the grid data of the corresponding phase.')
 
-        self.options.declare('method', default='RK45', values=('RK45', 'RK23', 'BDF', 'Radau'),
-                             desc='The integrator used within scipy.integrate.solve_ivp. Currently '
-                                  'supports \'RK45\', \'RK23\', and \'BDF\'.')
-
-        self.options.declare('atol', default=1.0E-6, types=(float,),
-                             desc='Absolute tolerance passed to scipy.integrate.solve_ivp.')
-
-        self.options.declare('rtol', default=1.0E-6, types=(float,),
-                             desc='Relative tolerance passed to scipy.integrate.solve_ivp.')
+        self.options.declare('simulate_options', types=SimulateOptionsDictionary,
+                             desc='The simulation options of the parent phase.')
 
         self.options.declare('ode_class', recordable=False,
                              desc='System defining the ODE')
@@ -248,13 +240,13 @@ class SegmentSimulationComp(om.ExplicitComponent):
                                  self.options['output_nodes_per_seg'])
 
         # Perform the integration using solve_ivp
+        sim_options = {key: val for key, val in self.options['simulate_options'].items()}
+
         sol = solve_ivp(fun=self.options['ode_integration_interface'],
                         t_span=(inputs['time'][0], inputs['time'][-1]),
                         y0=self.initial_state_vec,
-                        method=self.options['method'],
-                        atol=self.options['atol'],
-                        rtol=self.options['rtol'],
-                        t_eval=t_eval)
+                        t_eval=t_eval,
+                        **sim_options)
 
         if not sol.success:
             raise om.AnalysisError(f'solve_ivp failed: {sol.message}')

--- a/dymos/transcriptions/solve_ivp/components/segment_simulation_comp.py
+++ b/dymos/transcriptions/solve_ivp/components/segment_simulation_comp.py
@@ -242,7 +242,8 @@ class SegmentSimulationComp(om.ExplicitComponent):
         # Perform the integration using solve_ivp
         sim_options = {key: val for key, val in self.options['simulate_options'].items()}
 
-        print(sim_options)
+        for key, val in sim_options.items():
+            print(key, val)
 
         sol = solve_ivp(fun=self.options['ode_integration_interface'],
                         t_span=(inputs['time'][0], inputs['time'][-1]),

--- a/dymos/transcriptions/solve_ivp/components/test/test_segment_simulation_comp.py
+++ b/dymos/transcriptions/solve_ivp/components/test/test_segment_simulation_comp.py
@@ -6,7 +6,8 @@ from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
 
 from dymos.transcriptions.solve_ivp.components.segment_simulation_comp import SegmentSimulationComp
-from dymos.phase.options import TimeOptionsDictionary, StateOptionsDictionary
+from dymos.phase.options import TimeOptionsDictionary, StateOptionsDictionary, \
+    SimulateOptionsDictionary
 from dymos.transcriptions.grid_data import GridData
 
 # Modify class so we can run it standalone.
@@ -53,8 +54,11 @@ class TestSegmentSimulationComp(unittest.TestCase):
 
         gd = GridData(num_segments=4, transcription='gauss-lobatto', transcription_order=3)
 
-        seg0_comp = SegmentSimulationComp(index=0, grid_data=gd, method='RK45',
-                                          atol=1.0E-9, rtol=1.0E-9,
+        sim_options = SimulateOptionsDictionary()
+        sim_options['rtol'] = 1.0E-9
+        sim_options['atol'] = 1.0E-9
+
+        seg0_comp = SegmentSimulationComp(index=0, grid_data=gd, simulate_options=sim_options,
                                           ode_class=TestODE, time_options=time_options,
                                           state_options=state_options)
 

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -43,16 +43,6 @@ class SolveIVP(TranscriptionBase):
         """
         super(SolveIVP, self).initialize()
 
-        self.options.declare('method', default='RK45', values=('RK45', 'RK23', 'BDF'),
-                             desc='The integrator used within scipy.integrate.solve_ivp. Currently '
-                                  'supports \'RK45\', \'RK23\', and \'BDF\'.')
-
-        self.options.declare('atol', default=1.0E-6, types=(float,),
-                             desc='Absolute tolerance passed to scipy.integrate.solve_ivp.')
-
-        self.options.declare('rtol', default=1.0E-6, types=(float,),
-                             desc='Relative tolerance passed to scipy.integrate.solve_ivp.')
-
         self.options.declare('output_nodes_per_seg', default=None, types=(int,), allow_none=True,
                              desc='If None, results are provided at the all nodes within each'
                                   'segment.  If an int (n) then results are provided at n '
@@ -226,9 +216,7 @@ class SolveIVP(TranscriptionBase):
         for i in range(num_seg):
             seg_i_comp = SegmentSimulationComp(
                 index=i,
-                method=self.options['method'],
-                atol=self.options['atol'],
-                rtol=self.options['rtol'],
+                simulate_options=phase.simulate_options,
                 grid_data=self.grid_data,
                 ode_class=phase.options['ode_class'],
                 ode_init_kwargs=phase.options['ode_init_kwargs'],

--- a/dymos/utils/misc.py
+++ b/dymos/utils/misc.py
@@ -12,7 +12,7 @@ class _ReprClass(object):
 
     def __init__(self, repr_string):
         """
-        Inititialize the __repr__ string.
+        Initialize the __repr__ string.
 
         Parameters
         ----------


### PR DESCRIPTION
### Summary

Phases now have `simulate_options`, which currently consists of the `method`, `atol`, `rtol`, `first_step`, and `max_step` options used by scipy.integrate.solve_ivp.

The user may set these options through the options dictionary interface:

```
phase.simulate_options['method'] = 'RK23'
phase.simulate_options['atol'] = 1.0E-4
```

or through the new `set_simulate_options` method that allows setting multiple values at once:

```
phase.set_simulate_options(method='RK23', atol=1.0E-4)
```

This allows phases to each have their own appropriate solve_ivp settings when using simulate from the trajectory level, or when using the `dymos.run_problem` interface with `simulate=True`.

Once the new documentation is up, this capability will be added to the new documentation.

### Related Issues

- Resolves #609 

### Status

- [ ] Ready for merge

### Backwards incompatibilities

- Some users reported problems with the default tolerances.  The scipy.integrate.solve_ivp default values for atol and rtol are now the defaults for simulate.
- There are some changes to the arguments some methods within phase, notably `get_simulation_phase`.  Most users should not see any difference since these methods are internal (and should probably be underscored in the future to convey that fact).

### New Dependencies

None
