### PR TITLE
Fixed display of options tables in defining odes section of the docs.

### DIFF
--- a/docs/getting_started/defining_odes.ipynb
+++ b/docs/getting_started/defining_odes.ipynb
@@ -72,7 +72,10 @@
    },
    "outputs": [],
    "source": [
-    "om.show_options_table(\"dymos.phase.options.TimeOptionsDictionary\")"
+    "from IPython.display import display, HTML, IFrame, Code\n",
+    "from dymos.phase.options import TimeOptionsDictionary\n",
+    "obj = TimeOptionsDictionary()\n",
+    "display(HTML(obj.to_table(fmt='html')))"
    ]
   },
   {
@@ -94,7 +97,9 @@
    },
    "outputs": [],
    "source": [
-    "om.show_options_table(\"dymos.phase.options.StateOptionsDictionary\")"
+    "from dymos.phase.options import StateOptionsDictionary\n",
+    "obj = StateOptionsDictionary()\n",
+    "display(HTML(obj.to_table(fmt='html')))"
    ]
   },
   {
@@ -116,7 +121,9 @@
    },
    "outputs": [],
    "source": [
-    "om.show_options_table(\"dymos.phase.options.ControlOptionsDictionary\")"
+    "from dymos.phase.options import ControlOptionsDictionary\n",
+    "obj = ControlOptionsDictionary()\n",
+    "display(HTML(obj.to_table(fmt='html')))"
    ]
   },
   {
@@ -140,7 +147,9 @@
    },
    "outputs": [],
    "source": [
-    "om.show_options_table(\"dymos.phase.options.ParameterOptionsDictionary\")"
+    "from dymos.phase.options import ParameterOptionsDictionary\n",
+    "obj = ParameterOptionsDictionary()\n",
+    "display(HTML(obj.to_table(fmt='html')))"
    ]
   },
   {
@@ -460,7 +469,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -595,17 +595,3 @@ class SimulateOptionsDictionary(om.OptionsDictionary):
 
         self.declare(name='max_step', types=float, default=np.inf,
                      desc='Maximum allowable step size')
-
-
-class _ForDocs(object):  # pragma: no cover
-    """
-    This class is provided as a way to automatically display options dictionaries in the docs,
-    since these option dictionaries typically don't exist in instantiated form in the code base.
-    """
-
-    def __init__(self):
-
-        self.time_options = TimeOptionsDictionary()
-        self.state_options = StateOptionsDictionary()
-        self.control_options = ControlOptionsDictionary()
-        self.parameter_options = ParameterOptionsDictionary()


### PR DESCRIPTION
### Summary

Fixes display of options tables in defining_odes doc.
Removed the old `_ForDocs` instantiation of options dictionaries used in the mkdocs implementation.

### Related Issues

- Resolves #617 

### Status

- [ ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
