### PR TITLE
Added require_pyoptsparse to all tests that use pyOptSparseDriver

### DIFF
--- a/dymos/examples/aircraft_steady_flight/doc/test_doc_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/doc/test_doc_aircraft_steady_flight.py
@@ -5,13 +5,14 @@ import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
 from dymos.utils.doc_utils import save_for_docs
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
 @use_tempdirs
 class TestSteadyAircraftFlightForDocs(unittest.TestCase):
 
     @save_for_docs
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_steady_aircraft_for_docs(self):
         import matplotlib.pyplot as plt
 

--- a/dymos/examples/aircraft_steady_flight/test/test_ex_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_ex_aircraft_steady_flight.py
@@ -3,13 +3,14 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 import dymos as dm
 from dymos.utils.lgl import lgl
 from dymos.examples.aircraft_steady_flight.aircraft_ode import AircraftODE
 
 
+@require_pyoptsparse(optimizer='SLSQP')
 def ex_aircraft_steady_flight(optimizer='SLSQP', solve_segments=False,
                               use_boundary_constraints=False, compressed=False):
     p = om.Problem(model=om.Group())

--- a/dymos/examples/battery_multibranch/test/test_multibranch_trajectory.py
+++ b/dymos/examples/battery_multibranch/test/test_multibranch_trajectory.py
@@ -6,7 +6,7 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 import dymos as dm
 from dymos.examples.battery_multibranch.battery_multibranch_ode import BatteryODE
@@ -23,6 +23,7 @@ class TestBatteryBranchingPhases(unittest.TestCase):
     def tearDown(self):
         dm.options['include_check_partials'] = False
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_optimizer_defects(self):
 
         prob = om.Problem()
@@ -278,6 +279,7 @@ class TestBatteryBranchingPhases(unittest.TestCase):
         soc1 = prob['traj.phase1.states:state_of_charge']
         assert_near_equal(soc1[-1], 1.0, 1e-6)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_optimizer_segments_direct_connections(self):
         prob = om.Problem()
 

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_tandem_phases.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_tandem_phases.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 import openmdao.api as om
 from dymos.utils.doc_utils import save_for_docs
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
 class BrachistochroneArclengthODE(om.ExplicitComponent):
@@ -48,6 +48,7 @@ class BrachistochroneArclengthODE(om.ExplicitComponent):
 class TestBrachistochroneTandemPhases(unittest.TestCase):
 
     @save_for_docs
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_brachistochrone_tandem_phases(self):
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 

--- a/dymos/examples/brachistochrone/test/ex_brachistochrone.py
+++ b/dymos/examples/brachistochrone/test/ex_brachistochrone.py
@@ -3,6 +3,7 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
 import openmdao.api as om
+from openmdao.utils.testing_utils import require_pyoptsparse
 
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
@@ -10,6 +11,7 @@ from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneOD
 SHOW_PLOTS = True
 
 
+@require_pyoptsparse(optimizer='SLSQP')
 def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, transcription_order=3,
                              compressed=True, optimizer='SLSQP', run_driver=True, force_alloc_complex=False,
                              solve_segments=False):

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_callable_ode_class.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_callable_ode_class.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 import openmdao.api as om
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from openmdao.utils.assert_utils import assert_near_equal
 import dymos as dm
 
@@ -11,6 +11,7 @@ import dymos as dm
 @use_tempdirs
 class TestBrachExecCompODE(unittest.TestCase):
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def _make_problem(self, transcription='gauss-lobatto', num_segments=8, transcription_order=3,
                       compressed=True, optimizer='SLSQP', run_driver=True, force_alloc_complex=False,
                       solve_segments=False):
@@ -132,7 +133,7 @@ class TestBrachExecCompODE(unittest.TestCase):
 
 @use_tempdirs
 class TestInvalidCallableODEClass(unittest.TestCase):
-
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_invalid_callable(self):
         num_segments = 10
         transcription_order = 3
@@ -232,6 +233,7 @@ class TestBrachCallableODE(unittest.TestCase):
     def setUp(self):
         self.ode = CallableBrachistochroneODE(num_nodes=1)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def _make_problem(self, transcription='gauss-lobatto', num_segments=8, transcription_order=3,
                       compressed=True, optimizer='SLSQP', run_driver=True,
                       force_alloc_complex=False,

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_parameter.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_parameter.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import openmdao.api as om
 from dymos.utils.testing_utils import assert_timeseries_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
 class BrachistochroneODE(om.ExplicitComponent):
@@ -88,6 +88,7 @@ class TestBrachistochroneIntegratedParameter(unittest.TestCase):
             if os.path.exists(filename):
                 os.remove(filename)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_brachistochrone_integrated_param_gauss_lobatto(self):
         import numpy as np
         import openmdao.api as om
@@ -157,6 +158,7 @@ class TestBrachistochroneIntegratedParameter(unittest.TestCase):
         assert_timeseries_near_equal(t_sol, v_sol, t_sim, v_sim, tolerance=5.0E-3)
         assert_timeseries_near_equal(t_sol, theta_sol, t_sim, theta_sim, tolerance=5.0E-3)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_brachistochrone_integrated_parameter_radau_ps(self):
         import numpy as np
         import openmdao.api as om

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_solve_segments.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_solve_segments.py
@@ -7,13 +7,14 @@ import dymos as dm
 import dymos.examples.brachistochrone.test.ex_brachistochrone_vector_states as ex_brachistochrone_vs
 import dymos.examples.brachistochrone.test.ex_brachistochrone as ex_brachistochrone
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 
 OPT, OPTIMIZER = set_pyoptsparse_opt('SLSQP')
 
 
+@require_pyoptsparse(optimizer='SLSQP')
 def _make_problem(transcription='gauss-lobatto', num_segments=8, transcription_order=3,
                   compressed=True, optimizer='SLSQP', run_driver=True, force_alloc_complex=False,
                   solve_segments=False):

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_varying_order_control_simulation.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_varying_order_control_simulation.py
@@ -2,7 +2,7 @@ import unittest
 from numpy.testing import assert_almost_equal
 
 import openmdao.api as om
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
@@ -14,6 +14,7 @@ OPT, OPTIMIZER = set_pyoptsparse_opt('SNOPT', fallback=True)
 @use_tempdirs
 class TestBrachistochroneVaryingOrderControlSimulation(unittest.TestCase):
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_gauss_lobatto(self):
         p = om.Problem(model=om.Group())
 
@@ -90,6 +91,7 @@ class TestBrachistochroneVaryingOrderControlSimulation(unittest.TestCase):
 
         assert_almost_equal(thetaf, 100.12, decimal=0)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_radau(self):
         p = om.Problem(model=om.Group())
 

--- a/dymos/examples/brachistochrone/test/test_state_rate_introspection.py
+++ b/dymos/examples/brachistochrone/test/test_state_rate_introspection.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 import dymos as dm
 from dymos.utils.testing_utils import assert_timeseries_near_equal
@@ -221,6 +221,7 @@ class TestIntegrateControl(unittest.TestCase):
         assert_timeseries_near_equal(t_sol, int_theta_sol, t_sol, theta_sol, tolerance=1.0E-2)
         assert_timeseries_near_equal(t_sim, int_theta_sim, t_sim, theta_sim, tolerance=1.0E-2)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def _test_integrate_control_rate2(self, transcription):
         #
         # Define the OpenMDAO problem
@@ -564,6 +565,7 @@ class TestIntegratePolynomialControl(unittest.TestCase):
         assert_timeseries_near_equal(t_sol, int_theta_sol, t_sol, theta_sol, tolerance=1.0E-3)
         # assert_timeseries_near_equal(t_sol, int_theta_sim, t_sol, theta_sim, tolerance=1.0E-3)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def _test_integrate_polynomial_control_rate2(self, transcription):
         #
         # Define the OpenMDAO problem

--- a/dymos/examples/brachistochrone/test/test_tandem_phases.py
+++ b/dymos/examples/brachistochrone/test/test_tandem_phases.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
@@ -68,6 +68,7 @@ def make_brachistochrone_phase(transcription='gauss-lobatto', num_segments=8, tr
 
 
 @use_tempdirs
+@require_pyoptsparse(optimizer='SLSQP')
 class TestTandemPhases(unittest.TestCase):
 
     def _run_transcription(self, transcription):

--- a/dymos/examples/brachistochrone/test/test_timeseries_units.py
+++ b/dymos/examples/brachistochrone/test/test_timeseries_units.py
@@ -1,7 +1,7 @@
 import unittest
 
 import openmdao.api as om
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from openmdao.utils.assert_utils import assert_near_equal
 import dymos as dm
 
@@ -9,6 +9,7 @@ import dymos as dm
 @use_tempdirs
 class TestTimeseriesUnits(unittest.TestCase):
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def _make_problem(self, transcription='gauss-lobatto', num_segments=8, transcription_order=3,
                       compressed=True, optimizer='SLSQP', run_driver=True, force_alloc_complex=False,
                       solve_segments=False):

--- a/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
+++ b/dymos/examples/cannonball/doc/test_doc_two_phase_cannonball.py
@@ -4,13 +4,14 @@ import matplotlib.pyplot as plt
 plt.switch_backend('Agg')
 
 from dymos.utils.doc_utils import save_for_docs
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
 @use_tempdirs
 class TestTwoPhaseCannonballForDocs(unittest.TestCase):
 
     @save_for_docs
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_two_phase_cannonball_for_docs(self):
         import numpy as np
         from scipy.interpolate import interp1d

--- a/dymos/examples/cannonball/test/test_cannonball_matrix_state.py
+++ b/dymos/examples/cannonball/test/test_cannonball_matrix_state.py
@@ -3,7 +3,7 @@ import dymos as dm
 
 import unittest
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
 class ODEComp(om.ExplicitComponent):
@@ -30,6 +30,7 @@ class ODEComp(om.ExplicitComponent):
 @use_tempdirs
 class TestCannonballMatrixState(unittest.TestCase):
     """ Tests to verify that dymos can use matrix-states"""
+    @require_pyoptsparse(optimizer='SLSQP')
     def _make_problem(self, tx):
         p = om.Problem()
 
@@ -132,6 +133,7 @@ class TestCannonballMatrixState(unittest.TestCase):
 @use_tempdirs
 class TestCannonballMatrixStateExplicitShape(unittest.TestCase):
     """ Tests to verify that dymos can use matrix-states"""
+    @require_pyoptsparse(optimizer='SLSQP')
     def _make_problem(self, tx):
         p = om.Problem()
 

--- a/dymos/examples/cannonball/test/test_connect_control_to_parameter.py
+++ b/dymos/examples/cannonball/test/test_connect_control_to_parameter.py
@@ -5,7 +5,7 @@ import numpy as np
 import openmdao
 import openmdao.api as om
 
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 from dymos.examples.cannonball.cannonball_ode import rho_interp
 
@@ -82,6 +82,7 @@ class TestConnectControlToParameter(unittest.TestCase):
 
     @unittest.skipIf(om_version < (3, 4, 1) or (om_version == (3, 4, 1) and om_dev_version),
                      'test requires OpenMDAO >= 3.4.1')
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_connect_control_to_parameter(self):
         """ Test that the final value of a control in one phase can be connected as the value
         of a parameter in a subsequent phase. """

--- a/dymos/examples/cannonball/test/test_phase_linkage_compliance.py
+++ b/dymos/examples/cannonball/test/test_phase_linkage_compliance.py
@@ -2,12 +2,13 @@ import unittest
 
 import matplotlib.pyplot as plt
 plt.switch_backend('Agg')
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
 @use_tempdirs
 class TestTwoPhaseCannonballODEOutputLinkage(unittest.TestCase):
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_link_fixed_states_final_to_initial(self):
         """ Test that linking phases with states that are fixed at the linkage point raises an exception. """
 
@@ -105,6 +106,7 @@ class TestTwoPhaseCannonballODEOutputLinkage(unittest.TestCase):
                                            'value of "gam" in ascent to initial value of "gam" in '
                                            'descent.  Values on both sides of the linkage are fixed.')
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_link_fixed_states_final_to_final(self):
         """ Test that linking phases with states that are fixed at the linkage point raises an exception. """
 
@@ -205,6 +207,7 @@ class TestTwoPhaseCannonballODEOutputLinkage(unittest.TestCase):
                                            'value of "h" in ascent to final value of "h" in '
                                            'descent.  Values on both sides of the linkage are fixed.')
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_link_fixed_states_initial_to_initial(self):
         """ Test that linking phases with states that are fixed at the linkage point raises an exception. """
 
@@ -305,6 +308,7 @@ class TestTwoPhaseCannonballODEOutputLinkage(unittest.TestCase):
                                            'value of "h" in ascent to initial value of "h" in '
                                            'descent.  Values on both sides of the linkage are fixed.')
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_link_fixed_times_final_to_initial(self):
         """ Test that linking phases with times that are fixed at the linkage point raises an exception. """
 
@@ -401,6 +405,7 @@ class TestTwoPhaseCannonballODEOutputLinkage(unittest.TestCase):
                                            'value of "time" in ascent to initial value of "time" in '
                                            'descent.  Values on both sides of the linkage are fixed.')
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_link_bounded_times_final_to_initial(self):
         """ Test that linking phases with times that are fixed at the linkage point raises an exception. """
 

--- a/dymos/examples/cannonball/test/test_two_phase_cannonball_ode_output_linkage.py
+++ b/dymos/examples/cannonball/test/test_two_phase_cannonball_ode_output_linkage.py
@@ -2,12 +2,13 @@ import unittest
 
 import matplotlib.pyplot as plt
 plt.switch_backend('Agg')
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
 @use_tempdirs
 class TestTwoPhaseCannonballODEOutputLinkage(unittest.TestCase):
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_two_phase_cannonball_ode_output_linkage(self):
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal
@@ -206,6 +207,7 @@ class TestTwoPhaseCannonballODEOutputLinkage(unittest.TestCase):
 
         plt.show()
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_traj_param_target_none(self):
         # Tests a bug where you couldn't specify None as a target for a specific phase.
         import openmdao.api as om

--- a/dymos/examples/double_integrator/doc/test_doc_double_integrator.py
+++ b/dymos/examples/double_integrator/doc/test_doc_double_integrator.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
 from dymos.utils.doc_utils import save_for_docs
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
 @use_tempdirs
@@ -20,6 +20,7 @@ class TestDoubleIntegratorForDocs(unittest.TestCase):
                 os.remove(filename)
 
     @save_for_docs
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_double_integrator_for_docs(self):
         import matplotlib.pyplot as plt
         import openmdao.api as om

--- a/dymos/examples/double_integrator/test/test_double_integrator.py
+++ b/dymos/examples/double_integrator/test/test_double_integrator.py
@@ -4,12 +4,13 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 import dymos as dm
 from dymos.examples.double_integrator.double_integrator_ode import DoubleIntegratorODE
 
 
+@require_pyoptsparse(optimizer='SLSQP')
 def double_integrator_direct_collocation(transcription='gauss-lobatto', compressed=True):
 
     p = om.Problem(model=om.Group())
@@ -129,6 +130,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         assert_near_equal(v[0], 0.0, tolerance=1.0E-4)
         assert_near_equal(v[-1], 0.0, tolerance=1.0E-4)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_ex_double_integrator_input_times_uncompressed(self):
         """
         Tests that externally connected t_initial and t_duration function as expected.
@@ -178,6 +180,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         exp_out = phase.simulate()
         self._assert_results(exp_out, traj=False, tol=1.0E-2)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_ex_double_integrator_input_times_compressed(self):
         """
         Tests that externally connected t_initial and t_duration function as expected.

--- a/dymos/examples/double_integrator/test/test_double_integrator_timeseries_units.py
+++ b/dymos/examples/double_integrator/test/test_double_integrator_timeseries_units.py
@@ -4,13 +4,14 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 import dymos as dm
 from dymos.examples.double_integrator.double_integrator_ode import DoubleIntegratorODE
 from dymos.utils.testing_utils import assert_timeseries_near_equal
 
 
+@require_pyoptsparse(optimizer='SLSQP')
 def double_integrator_direct_collocation(transcription=dm.GaussLobatto, compressed=True):
 
     p = om.Problem(model=om.Group())

--- a/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise_bokeh_plots.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise_bokeh_plots.py
@@ -6,6 +6,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
+from openmdao.utils.testing_utils import require_pyoptsparse
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
 
@@ -109,6 +110,7 @@ def make_traj(transcription='gauss-lobatto', transcription_order=3, compressed=F
     return traj
 
 
+@require_pyoptsparse(optimizer='SLSQP')
 def two_burn_orbit_raise_problem(transcription='gauss-lobatto', optimizer='SLSQP', r_target=3.0,
                                  transcription_order=3, compressed=False,
                                  show_output=True):

--- a/dymos/examples/flying_robot/test/test_flying_robot.py
+++ b/dymos/examples/flying_robot/test/test_flying_robot.py
@@ -4,12 +4,13 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 import dymos as dm
 from dymos.examples.flying_robot.flying_robot_ode import FlyingRobotODE
 
 
+@require_pyoptsparse(optimizer='SLSQP')
 def flying_robot_direct_collocation(transcription='gauss-lobatto', compressed=True):
 
     p = om.Problem(model=om.Group())

--- a/dymos/examples/hyper_sensitive/doc/test_doc_hyper_sensitive.py
+++ b/dymos/examples/hyper_sensitive/doc/test_doc_hyper_sensitive.py
@@ -10,7 +10,7 @@ matplotlib.use('Agg')
 plt.style.use('ggplot')
 
 from dymos.utils.doc_utils import save_for_docs
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
 tf = np.float128(10)
@@ -39,6 +39,7 @@ class TestHyperSensitive(unittest.TestCase):
                 os.remove(filename)
 
     @save_for_docs
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_hyper_sensitive_for_docs(self):
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal

--- a/dymos/examples/hyper_sensitive/test/test_hyper_sensitive.py
+++ b/dymos/examples/hyper_sensitive/test/test_hyper_sensitive.py
@@ -27,6 +27,7 @@ class TestHyperSensitive(unittest.TestCase):
             if os.path.exists(filename):
                 os.remove(filename)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def make_problem(self, transcription=GaussLobatto, optimizer='SLSQP', numseg=30):
         p = Problem(model=Group())
         p.driver = pyOptSparseDriver()

--- a/dymos/examples/min_time_climb/doc/test_doc_min_time_climb.py
+++ b/dymos/examples/min_time_climb/doc/test_doc_min_time_climb.py
@@ -6,13 +6,14 @@ import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
 from dymos.utils.doc_utils import save_for_docs
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
 @use_tempdirs
 class TestMinTimeClimbForDocs(unittest.TestCase):
 
     @save_for_docs
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_min_time_climb_for_docs_gauss_lobatto(self):
         import matplotlib.pyplot as plt
 

--- a/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
+++ b/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
@@ -4,9 +4,10 @@ import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 import dymos as dm
 from dymos.examples.min_time_climb.min_time_climb_ode import MinTimeClimbODE
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
+@require_pyoptsparse(optimizer='SLSQP')
 def min_time_climb(optimizer='SLSQP', num_seg=3, transcription='gauss-lobatto',
                    transcription_order=3, force_alloc_complex=False):
 

--- a/dymos/examples/min_time_climb/test/test_refine_with_shaped_parameter.py
+++ b/dymos/examples/min_time_climb/test/test_refine_with_shaped_parameter.py
@@ -2,7 +2,7 @@ import unittest
 
 from openmdao.utils.assert_utils import assert_near_equal
 import dymos as dm
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 import openmdao.api as om
 from dymos.models.atmosphere import USatm1976Comp
@@ -47,6 +47,7 @@ class _TestODE(om.Group):
         self.add_subsystem('testcomp', om.ExecComp('testout=test', shape=40), promotes=['*'])
 
 
+@require_pyoptsparse(optimizer='SLSQP')
 def min_time_climb(optimizer='SLSQP', num_seg=3, transcription='gauss-lobatto',
                    transcription_order=3, force_alloc_complex=False):
 

--- a/dymos/examples/robot_arm/doc/test_doc_robot_arm.py
+++ b/dymos/examples/robot_arm/doc/test_doc_robot_arm.py
@@ -23,6 +23,7 @@ class TestRobotArm(unittest.TestCase):
             if os.path.exists(filename):
                 os.remove(filename)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def make_problem(self, transcription=Radau, optimizer='SLSQP', numseg=30):
         p = Problem(model=Group())
         p.driver = pyOptSparseDriver()

--- a/dymos/examples/robot_arm/test/test_robot_arm.py
+++ b/dymos/examples/robot_arm/test/test_robot_arm.py
@@ -18,6 +18,7 @@ show_plots = True
 
 
 @use_tempdirs
+@require_pyoptsparse(optimizer='SLSQP')
 class TestRobotArm(unittest.TestCase):
 
     def tearDown(self):
@@ -25,6 +26,7 @@ class TestRobotArm(unittest.TestCase):
             if os.path.exists(filename):
                 os.remove(filename)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def make_problem(self, transcription=Radau, optimizer='SLSQP', numseg=30):
         p = Problem(model=Group())
         p.driver = pyOptSparseDriver()

--- a/dymos/examples/shuttle_reentry/doc/test_doc_reentry.py
+++ b/dymos/examples/shuttle_reentry/doc/test_doc_reentry.py
@@ -7,7 +7,7 @@ plt.style.use('ggplot')
 import numpy as np
 
 from dymos.utils.doc_utils import save_for_docs
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
 @use_tempdirs
@@ -19,6 +19,7 @@ class TestReentryForDocs(unittest.TestCase):
                 os.remove(filename)
 
     @save_for_docs
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_reentry(self):
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal

--- a/dymos/examples/shuttle_reentry/test/test_reentry.py
+++ b/dymos/examples/shuttle_reentry/test/test_reentry.py
@@ -15,6 +15,7 @@ expected_results = {'constrained': {'time': 2198.67, 'theta': 30.6255},
 
 
 @use_tempdirs
+@require_pyoptsparse(optimizer='SLSQP')
 class TestReentry(unittest.TestCase):
 
     def make_problem(self, constrained=True, transcription=GaussLobatto, optimizer='SLSQP',

--- a/dymos/examples/ssto/doc/test_doc_ssto_earth.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_earth.py
@@ -3,7 +3,7 @@ import unittest
 import matplotlib.pyplot as plt
 
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from dymos.utils.doc_utils import save_for_docs
 
 
@@ -11,6 +11,7 @@ from dymos.utils.doc_utils import save_for_docs
 class TestDocSSTOEarth(unittest.TestCase):
 
     @save_for_docs
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_doc_ssto_earth(self):
         import matplotlib.pyplot as plt
         import openmdao.api as om

--- a/dymos/examples/ssto/doc/test_doc_ssto_linear_tangent_guidance.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_linear_tangent_guidance.py
@@ -6,13 +6,14 @@ import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
 from dymos.utils.doc_utils import save_for_docs
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
 @use_tempdirs
 class TestDocSSTOLinearTangentGuidance(unittest.TestCase):
 
     @save_for_docs
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_doc_ssto_linear_tangent_guidance(self):
         import numpy as np
         import matplotlib.pyplot as plt

--- a/dymos/examples/ssto/doc/test_doc_ssto_polynomial_control.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_polynomial_control.py
@@ -6,13 +6,14 @@ import matplotlib.pyplot as plt
 plt.style.use('ggplot')
 
 from dymos.utils.doc_utils import save_for_docs
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
 @use_tempdirs
 class TestDocSSTOPolynomialControl(unittest.TestCase):
 
     @save_for_docs
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_doc_ssto_polynomial_control(self):
         import numpy as np
         import matplotlib.pyplot as plt

--- a/dymos/examples/ssto/test/test_simulate_root_trajectory.py
+++ b/dymos/examples/ssto/test/test_simulate_root_trajectory.py
@@ -4,12 +4,13 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 plt.style.use('ggplot')
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
 @use_tempdirs
 class TestSSTOSimulateRootTrajectory(unittest.TestCase):
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_ssto_simulate_root_trajectory(self):
         """
         Tests that we can properly simulate a trajectory even if the trajectory is the root

--- a/dymos/grid_refinement/test/test_error_estimation.py
+++ b/dymos/grid_refinement/test/test_error_estimation.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
@@ -17,6 +17,7 @@ OPT, OPTIMIZER = set_pyoptsparse_opt('SLSQP', fallback=True)
 @use_tempdirs
 class TestBrachistochroneExample(unittest.TestCase):
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def _run_brachistochrone(self, transcription_class=dm.Radau, control_type='control', g=9.80665):
         p = om.Problem(model=om.Group())
 

--- a/dymos/models/eom/test/test_flight_path_eom_2d.py
+++ b/dymos/models/eom/test/test_flight_path_eom_2d.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from dymos.utils.testing_utils import assert_check_partials
 
 import dymos as dm
@@ -21,6 +21,7 @@ class _CannonballODE(FlightPathEOM2D):
 @use_tempdirs
 class TestFlightPathEOM2D(unittest.TestCase):
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def setUp(self):
         self.p = om.Problem(model=om.Group())
 

--- a/dymos/phase/test/test_add_boundary_constraint_array.py
+++ b/dymos/phase/test/test_add_boundary_constraint_array.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from openmdao.utils.assert_utils import assert_near_equal
 
 import dymos as dm
@@ -53,6 +53,7 @@ class BrachistochroneVectorStatesODE(om.ExplicitComponent):
 @use_tempdirs
 class TestAddBoundaryConstraint(unittest.TestCase):
 
+    @require_pyoptsparse
     def test_simple_no_exception(self):
         p = om.Problem(model=om.Group())
 

--- a/dymos/phase/test/test_add_parameter_types.py
+++ b/dymos/phase/test/test_add_parameter_types.py
@@ -3,6 +3,11 @@ import unittest
 import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs
 
+try:
+    from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
+except:
+    pyOptSparseDriver = None
+
 import dymos as dm
 
 
@@ -66,6 +71,7 @@ def add_parameter_test(testShape=None):
 
 
 @use_tempdirs
+@unittest.skipIf(pyOptSparseDriver, "pyOptSparse is required.")
 class TestParameterTypes(unittest.TestCase):
     def test_tuple(self):
         add_parameter_test((3, ))

--- a/dymos/phase/test/test_sized_input_parameters.py
+++ b/dymos/phase/test/test_sized_input_parameters.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 import dymos as dm
 from dymos.utils.lgl import lgl
@@ -14,6 +14,7 @@ from dymos.models.eom import FlightPathEOM2D
 @use_tempdirs
 class TestParameterConnections(unittest.TestCase):
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_dynamic_parameter_connections_radau(self):
 
         class TrajectoryODE(om.Group):
@@ -79,6 +80,7 @@ class TestParameterConnections(unittest.TestCase):
                                    (p.model.phase0.options['transcription'].grid_data.num_nodes, 2, 2))
         assert_near_equal(p.get_val('phase0.rhs_all.sum.m'), expected)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_static_parameter_connections_radau(self):
 
         class TrajectoryODE(om.Group):
@@ -139,6 +141,7 @@ class TestParameterConnections(unittest.TestCase):
         expected = np.array([[1, 2], [3, 4]])
         assert_near_equal(p.get_val('phase0.rhs_all.sum.m'), expected)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_dynamic_parameter_connections_gl(self):
 
         class TrajectoryODE(om.Group):
@@ -206,6 +209,7 @@ class TestParameterConnections(unittest.TestCase):
                                    (gd.subset_num_nodes['col'], 2, 2))
         assert_near_equal(p.get_val('phase0.rhs_col.sum.m'), expected)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_static_parameter_connections_gl(self):
 
         class TrajectoryODE(om.Group):

--- a/dymos/phase/test/test_timeseries.py
+++ b/dymos/phase/test/test_timeseries.py
@@ -6,7 +6,7 @@ from scipy.interpolate import interp1d
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
@@ -245,6 +245,7 @@ class MinTimeClimbODEDuplicateOutput(om.Group):
         self.connect('prop.thrust', 'flight_dynamics.T')
 
 
+@require_pyoptsparse(optimizer='SLSQP')
 def min_time_climb(num_seg=3, transcription_class=dm.Radau, transcription_order=3,
                    force_alloc_complex=False):
 

--- a/dymos/test/test_run_problem.py
+++ b/dymos/test/test_run_problem.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_almost_equal
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 import dymos as dm
 from dymos.examples.hyper_sensitive.hyper_sensitive_ode import HyperSensitiveODE
@@ -21,6 +21,7 @@ _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
 class TestRunProblem(unittest.TestCase):
 
     @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_run_HS_problem_radau(self):
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()
@@ -87,6 +88,7 @@ class TestRunProblem(unittest.TestCase):
                           tolerance=5e-4)
 
     @unittest.skipIf(optimizer != 'IPOPT', 'IPOPT not available')
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_run_HS_problem_gl(self):
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()
@@ -151,6 +153,7 @@ class TestRunProblem(unittest.TestCase):
                           J,
                           tolerance=5e-4)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_run_brachistochrone_problem(self):
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()
@@ -196,6 +199,7 @@ class TestRunProblem(unittest.TestCase):
         case = cr.get_case('final')
         assert_almost_equal(case.outputs['traj.phase0.timeseries.time'].max(), 1.8016, decimal=4)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_run_brachistochrone_vector_states_problem(self):
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()
@@ -239,6 +243,7 @@ class TestRunProblem(unittest.TestCase):
 
         assert_near_equal(p.get_val('phase0.time')[-1], 1.8016, tolerance=1.0E-3)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_run_brachistochrone_problem_with_simulate(self):
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()
@@ -334,6 +339,7 @@ class TestRunProblem(unittest.TestCase):
 
 @use_tempdirs
 class TestRunProblemPlotting(unittest.TestCase):
+    @require_pyoptsparse(optimizer='SLSQP')
     def setUp(self):
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()

--- a/dymos/test/test_upgrade_guide.py
+++ b/dymos/test/test_upgrade_guide.py
@@ -6,12 +6,13 @@ import openmdao.api as om
 import dymos as dm
 
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
 @use_tempdirs
 class TestUpgrade_0_16_0(unittest.TestCase):
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_parameters(self):
         """
         # upgrade_doc: begin set_val
@@ -261,6 +262,7 @@ class TestUpgrade_0_16_0(unittest.TestCase):
 
         assert_near_equal(range, tas*time, tolerance=1.0E-4)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_glob_timeseries_outputs(self):
         """
         # upgrade_doc: begin glob_timeseries_outputs
@@ -363,6 +365,7 @@ class TestUpgrade_0_16_0(unittest.TestCase):
                             ('f_drag', 'N')]:
             self.assertEqual(op_dict[f'traj.phase0.timeseries.{name}'], units)
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_sequence_timeseries_outputs(self):
         """
         # upgrade_doc: begin sequence_timeseries_outputs
@@ -654,6 +657,7 @@ class TestUpgrade_0_19_0(unittest.TestCase):
         if os.path.exists('dymos_simulation.db'):
             os.remove('dymos_simulation.db')
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def _make_problem(self, transcription='gauss-lobatto', num_segments=8, transcription_order=3,
                       compressed=True, optimizer='SLSQP', run_driver=True,
                       force_alloc_complex=False,

--- a/dymos/trajectory/test/test_trajectory_input_parameters.py
+++ b/dymos/trajectory/test/test_trajectory_input_parameters.py
@@ -9,9 +9,10 @@ _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
 
 import dymos as dm
 from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
+@require_pyoptsparse(optimizer='SLSQP')
 def make_traj(transcription='gauss-lobatto', transcription_order=3, compressed=False,
               connected=False, param_mode='param_sequence'):
 
@@ -135,6 +136,7 @@ def make_traj(transcription='gauss-lobatto', transcription_order=3, compressed=F
     return traj
 
 
+@require_pyoptsparse(optimizer='SLSQP')
 def two_burn_orbit_raise_problem(transcription='gauss-lobatto', optimizer='SLSQP', r_target=3.0,
                                  transcription_order=3, compressed=False,
                                  show_output=True, connected=False, param_mode='param_sequence'):

--- a/dymos/transcriptions/pseudospectral/test/test_ps_base.py
+++ b/dymos/transcriptions/pseudospectral/test/test_ps_base.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 import dymos as dm
 from dymos import Trajectory, GaussLobatto, Phase, Radau
@@ -38,6 +38,7 @@ class crtbp_ode(om.ExplicitComponent):
         self.add_output('vz_dot', val=np.ones(nn), desc='computed acceleration in the rotating frame')
 
 
+@require_pyoptsparse(optimizer='SLSQP')
 def make_problem(transcription=GaussLobatto, num_segments=10, order=3, compressed=True):
     p = om.Problem(model=om.Group())
     p.driver = om.pyOptSparseDriver()

--- a/dymos/visualization/test/test_timeseries_plots.py
+++ b/dymos/visualization/test/test_timeseries_plots.py
@@ -17,6 +17,7 @@ from dymos.visualization.timeseries_plots import timeseries_plots
 @use_tempdirs
 class TestTimeSeriesPlotsBasics(unittest.TestCase):
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def setUp(self):
         optimizer = 'SLSQP'
         num_segments = 8

--- a/joss/test/test_cannonball_for_joss.py
+++ b/joss/test/test_cannonball_for_joss.py
@@ -1,11 +1,12 @@
 import unittest
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from openmdao.utils.assert_utils import assert_near_equal
 
 
 @use_tempdirs
 class TestCannonballForJOSS(unittest.TestCase):
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_results(self):
         # begin code for paper
         import numpy as np


### PR DESCRIPTION
### Summary

Added `@require_pyoptsparse` to all tests that use pyOptSparseDriver so testflo will skip them if PyOpt is not installed

### Related Issues

- Resolves #580

### Status

- [ ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
