### PR TITLE
Fixed `simulate=True` setting under MPI

### DIFF
--- a/dymos/examples/vanderpol/test/test_vanderpol.py
+++ b/dymos/examples/vanderpol/test/test_vanderpol.py
@@ -19,7 +19,7 @@ class TestVanderpolExample(unittest.TestCase):
     def test_vanderpol_simulate_true(self):
         # simulate true
         p = vanderpol(transcription='radau-ps', num_segments=30, transcription_order=3,
-                    compressed=True, optimizer='SLSQP', delay=0.005, distrib=True, use_pyoptsparse=True)
+                      compressed=True, optimizer='SLSQP', delay=0.005, distrib=True, use_pyoptsparse=True)
 
         dm.run_problem(p, run_driver=True, simulate=True)
 

--- a/dymos/examples/vanderpol/test/test_vanderpol.py
+++ b/dymos/examples/vanderpol/test/test_vanderpol.py
@@ -16,6 +16,13 @@ class TestVanderpolExample(unittest.TestCase):
         p = vanderpol(transcription='gauss-lobatto', num_segments=75)
         p.run_model()
 
+    def test_vanderpol_simulate_true(self):
+        # simulate true
+        p = vanderpol(transcription='radau-ps', num_segments=30, transcription_order=3,
+                    compressed=True, optimizer='SLSQP', delay=0.005, distrib=True, use_pyoptsparse=True)
+
+        dm.run_problem(p, run_driver=True, simulate=True)
+
     def test_vanderpol_optimal(self):
         p = vanderpol(transcription='gauss-lobatto', num_segments=75)
         dm.run_problem(p)  # find optimal control solution to stop oscillation

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -8,6 +8,7 @@ from scipy import interpolate
 
 import openmdao
 import openmdao.api as om
+from openmdao.utils.mpi import MPI
 from openmdao.core.system import System
 import dymos as dm
 
@@ -1855,6 +1856,10 @@ class Phase(om.Group):
             self_path = self.name + '.'
         else:
             self_path = self.pathname.split('.')[0] + '.' + self.name + '.'
+
+        if MPI:
+            op_dict = MPI.COMM_WORLD.bcast(op_dict, root=0)
+
 
         # Set the integration times
         op = op_dict['timeseries.time']

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -1860,7 +1860,6 @@ class Phase(om.Group):
         if MPI:
             op_dict = MPI.COMM_WORLD.bcast(op_dict, root=0)
 
-
         # Set the integration times
         op = op_dict['timeseries.time']
         prob.set_val(f'{self_path}t_initial', op['value'][0, ...])

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -620,7 +620,7 @@ class SolveIVP(TranscriptionBase):
                                src_indices=src_idxs, src_shape=shape)
             else:
                 phase.connect(src_name=self.get_rate_source_path(name, phase),
-                              tgt_name=f'timeseries.all_values:state_rates:{name}')
+                              tgt_name=f'timeseries.all_values:state_rates:{name}', src_indices=om.slicer[:])
 
         for name, options in phase.control_options.items():
             control_units = options['units']


### PR DESCRIPTION
### Summary

Fixed an issue where a dictionary was not broadcast to other ranks when running under `MPI` and `simulate=True` in `run_problem`

### Related Issues

- Resolves #596

### Status

- [ ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
