### PR TITLE
Update run_problem.py to return success state

### DIFF
--- a/dymos/run_problem.py
+++ b/dymos/run_problem.py
@@ -83,5 +83,5 @@ def run_problem(problem, refine_method='hp', refine_iteration_limit=0, run_drive
         else:
             timeseries_plots(solution_record_file, simulation_record_file=None,
                              plot_dir=plot_dir)
-            
+
     return failed

--- a/dymos/run_problem.py
+++ b/dymos/run_problem.py
@@ -61,10 +61,10 @@ def run_problem(problem, refine_method='hp', refine_iteration_limit=0, run_drive
         load_case(problem, case)
 
     if run_driver:
-        problem.run_driver()
+        failed = problem.run_driver()
         _refine_iter(problem, refine_iteration_limit, refine_method)
     else:
-        problem.run_model()
+        failed = problem.run_model()
         if refine_iteration_limit > 0:
             warnings.warn("Refinement not performed. Set run_driver to True to perform refinement.")
 
@@ -83,3 +83,5 @@ def run_problem(problem, refine_method='hp', refine_iteration_limit=0, run_drive
         else:
             timeseries_plots(solution_record_file, simulation_record_file=None,
                              plot_dir=plot_dir)
+            
+    return failed


### PR DESCRIPTION
### Summary

OpenMDAO returns a boolean "failed" telling if the optimization failed or succeeded. Changed run_problem.py in dymos to forward the boolean. This can be a helpful parameter for automating multiple optimizations.

### Related Issues

- Resolves #

### Status

- [X ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
