### PR TITLE
fixed to eliminate warning messages related to the recent indexing update to OpenMDAO. [Requires OpenMDAO >= 3.12.0]

### DIFF
--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_upstream_state.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_upstream_state.py
@@ -37,7 +37,7 @@ class TestBrachistochroneUpstreamState(unittest.TestCase):
         # Connect x0 to the state error component so we can constrain the given value of x0
         # to be equal to the value chosen in the phase.
         p.model.connect('x0', 'state_error_comp.x0_target')
-        p.model.connect('traj.phase0.timeseries.states:x', 'state_error_comp.x0_actual', src_indices=[0])
+        p.model.connect('traj.phase0.timeseries.states:x', 'state_error_comp.x0_actual', src_indices=[0], flat_src_indices=True)
 
         #
         # Define a Trajectory object

--- a/dymos/examples/cannonball/test/test_connect_control_to_parameter.py
+++ b/dymos/examples/cannonball/test/test_connect_control_to_parameter.py
@@ -172,7 +172,7 @@ class TestConnectControlToParameter(unittest.TestCase):
         p.model.connect('size_comp.mass', 'traj.parameters:m')
         p.model.connect('size_comp.S', 'traj.parameters:S')
 
-        traj.connect('ascent.timeseries.controls:CD', 'descent.parameters:CD', src_indices=[-1])
+        traj.connect('ascent.timeseries.controls:CD', 'descent.parameters:CD', src_indices=[-1], flat_src_indices=True)
 
         # A linear solver at the top level can improve performance.
         p.model.linear_solver = om.DirectSolver()

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -614,7 +614,7 @@ class Trajectory(om.Group):
                     if phase_b.classify_var(var_b) == 'time':
                         self.connect(f'{phase_name_a}.{src_a}',
                                      f'{phase_name_b}.t_initial',
-                                     src_indices=[-1])
+                                     src_indices=[-1], flat_src_indices=True)
                     elif phase_b.classify_var(var_b) == 'state':
                         tgt_b = f'initial_states:{var_b}'
                         self.connect(f'{phase_name_a}.{src_a}',

--- a/dymos/transcriptions/common/boundary_constraint_comp.py
+++ b/dymos/transcriptions/common/boundary_constraint_comp.py
@@ -51,7 +51,7 @@ class BoundaryConstraintComp(om.ExplicitComponent):
 
             constraint_kwargs = {k: kwargs.get(k, None)
                                  for k in ('lower', 'upper', 'equals', 'ref', 'ref0', 'adder',
-                                           'scaler', 'indices', 'linear')}
+                                           'scaler', 'indices', 'flat_indices', 'linear')}
             self.add_constraint(output_name, **constraint_kwargs)
 
         # Setup partials

--- a/dymos/transcriptions/common/control_group.py
+++ b/dymos/transcriptions/common/control_group.py
@@ -347,7 +347,8 @@ class ControlGroup(om.Group):
                                         adder=coerce_desvar_option('adder'),
                                         ref0=coerce_desvar_option('ref0'),
                                         ref=coerce_desvar_option('ref'),
-                                        indices=desvar_indices)
+                                        indices=desvar_indices,
+                                        flat_indices=True)
 
                 default_val = reshape_val(options['val'], shape, num_input_nodes)
 

--- a/dymos/transcriptions/common/path_constraint_comp.py
+++ b/dymos/transcriptions/common/path_constraint_comp.py
@@ -97,7 +97,8 @@ class PathConstraintComp(om.ExplicitComponent):
         indices = np.nonzero(template)[0]
 
         self.add_constraint(output_name, lower=lower, upper=upper, equals=equals, ref0=ref0,
-                            ref=ref, scaler=scaler, adder=adder, indices=indices, linear=linear)
+                            ref=ref, scaler=scaler, adder=adder, indices=indices, flat_indices=True,
+                            linear=linear)
 
         self._vars.append((input_name, output_name, shape))
 

--- a/dymos/transcriptions/common/polynomial_control_group.py
+++ b/dymos/transcriptions/common/polynomial_control_group.py
@@ -290,4 +290,5 @@ class PolynomialControlGroup(om.Group):
                                     ref0=options['ref0'],
                                     adder=options['adder'],
                                     scaler=options['scaler'],
-                                    indices=desvar_indices)
+                                    indices=desvar_indices,
+                                    flat_indices=True)

--- a/dymos/transcriptions/pseudospectral/gauss_lobatto.py
+++ b/dymos/transcriptions/pseudospectral/gauss_lobatto.py
@@ -71,10 +71,10 @@ class GaussLobatto(PseudospectralBase):
                     disc_src_idxs = col_src_idxs = None
                 phase.connect(name,
                               [f'rhs_col.{t}' for t in targets],
-                              src_indices=col_src_idxs)
+                              src_indices=col_src_idxs, flat_src_indices=True)
                 phase.connect(name,
                               [f'rhs_disc.{t}' for t in targets],
-                              src_indices=disc_src_idxs)
+                              src_indices=disc_src_idxs, flat_src_indices=True)
 
     def configure_controls(self, phase):
         """

--- a/dymos/transcriptions/pseudospectral/pseudospectral_base.py
+++ b/dymos/transcriptions/pseudospectral/pseudospectral_base.py
@@ -213,7 +213,8 @@ class PseudospectralBase(TranscriptionBase):
                                          adder=coerce_desvar_option('adder'),
                                          ref0=coerce_desvar_option('ref0'),
                                          ref=coerce_desvar_option('ref'),
-                                         indices=desvar_indices)
+                                         indices=desvar_indices,
+                                         flat_indices=True)
 
         if isinstance(indep, StateIndependentsComp):
             indep.configure_io(self.state_idx_map)
@@ -258,7 +259,7 @@ class PseudospectralBase(TranscriptionBase):
         phase.state_interp.configure_io()
 
         phase.connect('dt_dstau', 'state_interp.dt_dstau',
-                      src_indices=grid_data.subset_node_indices['col'])
+                      src_indices=grid_data.subset_node_indices['col'], flat_src_indices=True)
 
         for name, options in phase.state_options.items():
             size = np.prod(options['shape'])
@@ -381,7 +382,7 @@ class PseudospectralBase(TranscriptionBase):
         num_seg = grid_data.num_segments
 
         phase.connect('dt_dstau', ('collocation_constraint.dt_dstau'),
-                      src_indices=grid_data.subset_node_indices['col'])
+                      src_indices=grid_data.subset_node_indices['col'], flat_src_indices=True)
 
         phase.collocation_constraint.configure_io()
 

--- a/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
+++ b/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
@@ -64,7 +64,8 @@ class Radau(PseudospectralBase):
             targets = get_targets(phase.rhs_all, name=name, user_targets=usr_tgts)
             if targets:
                 src_idxs = self.grid_data.subset_node_indices['all'] if dynamic else None
-                phase.connect(name, [f'rhs_all.{t}' for t in targets], src_indices=src_idxs)
+                phase.connect(name, [f'rhs_all.{t}' for t in targets], src_indices=src_idxs,
+                              flat_src_indices=True if dynamic else None)
 
     def configure_controls(self, phase):
         """
@@ -374,7 +375,7 @@ class Radau(PseudospectralBase):
                         phase.promotes(f'{timeseries_name}',
                                        inputs=[(f'input_values:state_rates:{state_name}',
                                                 f'parameters:{rate_src}')],
-                                       src_indices=src_idxs, flat_src_indices=True, src_shape=shape)
+                                       src_indices=src_idxs, src_shape=shape)
 
                 else:
                     rate_src_path, src_idxs = self.get_rate_source_path(state_name, 'all', phase)

--- a/dymos/transcriptions/pseudospectral/test/test_ps_base.py
+++ b/dymos/transcriptions/pseudospectral/test/test_ps_base.py
@@ -58,20 +58,20 @@ def make_problem(transcription=GaussLobatto, num_segments=10, order=3, compresse
     phase.add_state('z_dot', rate_source='vz_dot', fix_initial=True, units=None)
 
     p.model.add_subsystem('x_periodic_bc', om.ExecComp('bc_defect=final-initial'))
-    p.model.connect('traj.phase.timeseries.states:x', 'x_periodic_bc.initial', src_indices=0)
-    p.model.connect('traj.phase.timeseries.states:x', 'x_periodic_bc.final', src_indices=-1)
+    p.model.connect('traj.phase.timeseries.states:x', 'x_periodic_bc.initial', src_indices=0, flat_src_indices=True)
+    p.model.connect('traj.phase.timeseries.states:x', 'x_periodic_bc.final', src_indices=-1, flat_src_indices=True)
 
     p.model.add_constraint('x_periodic_bc.bc_defect', equals=0)
 
     p.model.add_subsystem('z_periodic_bc', om.ExecComp('bc_defect=final-initial'))
-    p.model.connect('traj.phase.timeseries.states:z', 'z_periodic_bc.initial', src_indices=0)
-    p.model.connect('traj.phase.timeseries.states:z', 'z_periodic_bc.final', src_indices=-1)
+    p.model.connect('traj.phase.timeseries.states:z', 'z_periodic_bc.initial', src_indices=0, flat_src_indices=True)
+    p.model.connect('traj.phase.timeseries.states:z', 'z_periodic_bc.final', src_indices=-1, flat_src_indices=True)
 
     p.model.add_constraint('z_periodic_bc.bc_defect', equals=0)
 
     p.model.add_subsystem('vy_periodic_bc', om.ExecComp('bc_defect=final-initial'))
-    p.model.connect('traj.phase.timeseries.states:y_dot', 'vy_periodic_bc.initial', src_indices=0)
-    p.model.connect('traj.phase.timeseries.states:y_dot', 'vy_periodic_bc.final', src_indices=-1)
+    p.model.connect('traj.phase.timeseries.states:y_dot', 'vy_periodic_bc.initial', src_indices=0, flat_src_indices=True)
+    p.model.connect('traj.phase.timeseries.states:y_dot', 'vy_periodic_bc.final', src_indices=-1, flat_src_indices=True)
 
     p.model.add_constraint('vy_periodic_bc.bc_defect', equals=0)
 

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -620,7 +620,8 @@ class SolveIVP(TranscriptionBase):
                                src_indices=src_idxs, src_shape=shape)
             else:
                 phase.connect(src_name=self.get_rate_source_path(name, phase),
-                              tgt_name=f'timeseries.all_values:state_rates:{name}', src_indices=om.slicer[:])
+                              tgt_name=f'timeseries.all_values:state_rates:{name}', src_indices=om.slicer[:],
+                              flat_src_indices=True)
 
         for name, options in phase.control_options.items():
             control_units = options['units']

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -620,8 +620,8 @@ class SolveIVP(TranscriptionBase):
                                src_indices=src_idxs, src_shape=shape)
             else:
                 phase.connect(src_name=self.get_rate_source_path(name, phase),
-                              tgt_name=f'timeseries.all_values:state_rates:{name}', src_indices=om.slicer[:],
-                              flat_src_indices=True)
+                              tgt_name=f'timeseries.all_values:state_rates:{name}',
+                              src_indices=om.slicer[:], flat_src_indices=True)
 
         for name, options in phase.control_options.items():
             control_units = options['units']

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -123,8 +123,9 @@ class SolveIVP(TranscriptionBase):
             else:
                 src_idxs = np.arange(i * output_nodes_per_seg, output_nodes_per_seg * (i + 1),
                                      dtype=int)
-            phase.connect('time', f'segment_{i}.time', src_indices=src_idxs)
-            phase.connect('time_phase', f'segment_{i}.time_phase', src_indices=src_idxs)
+            phase.connect('time', f'segment_{i}.time', src_indices=src_idxs, flat_src_indices=True)
+            phase.connect('time_phase', f'segment_{i}.time_phase', src_indices=src_idxs,
+                          flat_src_indices=True)
 
         options = phase.time_options
 

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -864,7 +864,7 @@ class TranscriptionBase(object):
 
             from ..phase import Phase
             super(Phase, phase).add_objective(obj_path, ref=options['ref'], ref0=options['ref0'],
-                                              index=obj_index, adder=options['adder'],
+                                              index=obj_index, flat_indices=True, adder=options['adder'],
                                               scaler=options['scaler'],
                                               parallel_deriv_color=options['parallel_deriv_color'])
 

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ The software has two primary objectives:
     packages=find_packages(),
     python_requires=">=3.6",
     install_requires=[
-        'openmdao>=3.10.0',
+        'openmdao>=3.12.0',
         'numpy>=1.14.1',
         'scipy>=1.0.0'
     ],


### PR DESCRIPTION
Basically this just sets flat_src_indices=True or flat_indices=True for several cases that relied on the now deprecated behavior that treated source arrays as flat if the indices that indexed into them appeared to be flat.