### PR TITLE
test against dev & latest versions of openmdao

### DIFF
--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -170,8 +170,7 @@ jobs:
           echo "Install OpenMDAO"
           echo "============================================================="
           if [[ "${{ matrix.OPENMDAO }}" == "dev" ]]; then
-            git clone -q https://github.com/OpenMDAO/OpenMDAO
-            pip install ./OpenMDAO
+            pip install git+https://github.com/OpenMDAO/OpenMDAO
           elif [[ "${{ matrix.OPENMDAO }}" == "latest" ]]; then
             pip install openmdao
           else

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -171,7 +171,7 @@ jobs:
           echo "============================================================="
           if [[ "${{ matrix.OPENMDAO }}" == "latest" ]]; then
             git clone -q https://github.com/OpenMDAO/OpenMDAO
-            pip install OpenMDAO
+            pip install ./OpenMDAO
           else
             pip install openmdao==${{ matrix.OPENMDAO }}
           fi

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -40,7 +40,7 @@ jobs:
             PYOPTSPARSE: 'v2.1.5'
             SNOPT: 7.7
             MBI: 1
-            OPENMDAO: 'latest'
+            OPENMDAO: 'dev'
             OPTIONAL: '[test]'
             DOCS: 0
 
@@ -169,9 +169,11 @@ jobs:
           echo "============================================================="
           echo "Install OpenMDAO"
           echo "============================================================="
-          if [[ "${{ matrix.OPENMDAO }}" == "latest" ]]; then
+          if [[ "${{ matrix.OPENMDAO }}" == "dev" ]]; then
             git clone -q https://github.com/OpenMDAO/OpenMDAO
             pip install ./OpenMDAO
+          elif [[ "${{ matrix.OPENMDAO }}" == "latest" ]]; then
+            pip install openmdao
           else
             pip install openmdao==${{ matrix.OPENMDAO }}
           fi


### PR DESCRIPTION
### Summary

In the workflow jobs that specified `OPENMDAO: 'latest'` we were cloning the latest dev version from GitHub, but then pip installing the latest release version.  `latest` now tests against the last release while `dev` tests against the current development version.
 
### Related Issues

- Resolves #

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
