### PR TITLE
Added control rates and their derivatives when using ExplicitShooting.

### DIFF
--- a/dymos/transcriptions/explicit_shooting/ode_evaluation_group.py
+++ b/dymos/transcriptions/explicit_shooting/ode_evaluation_group.py
@@ -1,7 +1,7 @@
 import numpy as np
 import openmdao.api as om
 
-from .control_interpolation_comp import ControlInterpolationComp
+from .vandermonde_control_interp_comp import VandermondeControlInterpComp
 from .state_rate_collector_comp import StateRateCollectorComp
 from .tau_comp import TauComp
 
@@ -73,15 +73,15 @@ class ODEEvaluationGroup(om.Group):
             self.add_subsystem('tau_comp', TauComp(grid_data=self.grid_data,
                                                    time_units=self.time_options['units']),
                                promotes_inputs=['time', 't_initial', 't_duration'],
-                               promotes_outputs=['stau', 'ptau', 'time_phase', 'segment_index'])
+                               promotes_outputs=['stau', 'ptau', 'dstau_dt', 'time_phase', 'segment_index'])
 
             # Add control interpolant
             self._control_comp = self.add_subsystem('control_interp',
-                                                    ControlInterpolationComp(grid_data=gd,
-                                                                             control_options=c_options,
-                                                                             polynomial_control_options=pc_options,
-                                                                             time_units=self.time_options['units']),
-                                                    promotes_inputs=['ptau', 'stau', 'segment_index'])
+                                                    VandermondeControlInterpComp(grid_data=gd,
+                                                                                 control_options=c_options,
+                                                                                 polynomial_control_options=pc_options,
+                                                                                 time_units=self.time_options['units']),
+                                                    promotes_inputs=['ptau', 'stau', 'dstau_dt', 'segment_index'])
 
         self.add_subsystem('ode', self.ode_class(num_nodes=1, **self.ode_init_kwargs))
 

--- a/dymos/transcriptions/explicit_shooting/ode_evaluation_group.py
+++ b/dymos/transcriptions/explicit_shooting/ode_evaluation_group.py
@@ -8,6 +8,7 @@ from .tau_comp import TauComp
 from ...utils.introspection import get_targets, configure_controls_introspection,\
     configure_time_introspection, configure_parameters_introspection, \
     configure_states_discovery, configure_states_introspection
+from ...utils.misc import get_rate_units
 
 
 class ODEEvaluationGroup(om.Group):
@@ -190,6 +191,7 @@ class ODEEvaluationGroup(om.Group):
 
     def _configure_controls(self):
         configure_controls_introspection(self.control_options, self.ode)
+        time_units = self.time_options['units']
 
         if self.control_options:
             gd = self.grid_data
@@ -203,14 +205,21 @@ class ODEEvaluationGroup(om.Group):
             for name, options in self.control_options.items():
                 shape = options['shape']
                 units = options['units']
+                rate_units = get_rate_units(units, time_units, deriv=1)
+                rate2_units = get_rate_units(units, time_units, deriv=2)
                 targets = options['targets']
+                rate_targets = options['rate_targets']
+                rate2_targets = options['rate2_targets']
                 uhat_name = f'controls:{name}'
                 u_name = f'control_values:{name}'
+                u_rate_name = f'control_rates:{name}_rate'
+                u_rate2_name = f'control_rates:{name}_rate2'
 
                 self._ivc.add_output(uhat_name, shape=(num_control_input_nodes,) + shape, units=units)
                 self.add_design_var(uhat_name)
 
-                self.promotes('control_interp', inputs=[uhat_name], outputs=[u_name])
+                self.promotes('control_interp', inputs=[uhat_name],
+                              outputs=[u_name, u_rate_name, u_rate2_name])
 
                 # Promote targets from the ODE
                 for tgt in targets:
@@ -220,10 +229,27 @@ class ODEEvaluationGroup(om.Group):
                                             val=np.ones(shape),
                                             units=options['units'])
 
+                # Promote rate targets from the ODE
+                for tgt in rate_targets:
+                    self.promotes('ode', inputs=[(tgt, u_rate_name)])
+                if rate_targets:
+                    self.set_input_defaults(name=u_rate_name,
+                                            val=np.ones(shape),
+                                            units=rate_units)
+
+                # Promote rate2 targets from the ODE
+                for tgt in rate2_targets:
+                    self.promotes('ode', inputs=[(tgt, u_rate2_name)])
+                if rate2_targets:
+                    self.set_input_defaults(name=u_rate2_name,
+                                            val=np.ones(shape),
+                                            units=rate2_units)
+
     def _configure_polynomial_controls(self):
         configure_controls_introspection(self.polynomial_control_options, self.ode)
 
         if self.polynomial_control_options:
+            time_units = self.time_options['units']
             gd = self.grid_data
 
             if gd is None:
@@ -233,15 +259,22 @@ class ODEEvaluationGroup(om.Group):
             for name, options in self.polynomial_control_options.items():
                 shape = options['shape']
                 units = options['units']
+                rate_units = get_rate_units(units, time_units, deriv=1)
+                rate2_units = get_rate_units(units, time_units, deriv=2)
                 targets = options['targets']
+                rate_targets = options['rate_targets']
+                rate2_targets = options['rate2_targets']
                 num_control_input_nodes = options['order'] + 1
                 uhat_name = f'polynomial_controls:{name}'
                 u_name = f'polynomial_control_values:{name}'
+                u_rate_name = f'polynomial_control_rates:{name}_rate'
+                u_rate2_name = f'polynomial_control_rates:{name}_rate2'
 
                 self._ivc.add_output(uhat_name, shape=(num_control_input_nodes,) + shape, units=units)
                 self.add_design_var(uhat_name)
 
-                self.promotes('control_interp', inputs=[uhat_name], outputs=[u_name])
+                self.promotes('control_interp', inputs=[uhat_name],
+                              outputs=[u_name, u_rate_name, u_rate2_name])
 
                 # Promote targets from the ODE
                 for tgt in targets:
@@ -250,6 +283,21 @@ class ODEEvaluationGroup(om.Group):
                     self.set_input_defaults(name=u_name,
                                             val=np.ones(shape),
                                             units=options['units'])
+                # Promote rate targets from the ODE
+                for tgt in rate_targets:
+                    self.promotes('ode', inputs=[(tgt, u_rate_name)])
+                if rate_targets:
+                    self.set_input_defaults(name=u_rate_name,
+                                            val=np.ones(shape),
+                                            units=rate_units)
+
+                # Promote rate2 targets from the ODE
+                for tgt in rate2_targets:
+                    self.promotes('ode', inputs=[(tgt, u_rate2_name)])
+                if rate2_targets:
+                    self.set_input_defaults(name=u_rate2_name,
+                                            val=np.ones(shape),
+                                            units=rate2_units)
 
     def _get_rate_source_path(self, state_var):
         """

--- a/dymos/transcriptions/explicit_shooting/test/test_control_interpolation_comp.py
+++ b/dymos/transcriptions/explicit_shooting/test/test_control_interpolation_comp.py
@@ -6,7 +6,7 @@ import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 import dymos as dm
 
-from dymos.transcriptions.explicit_shooting.control_interpolation_comp import ControlInterpolationComp
+from dymos.transcriptions.explicit_shooting.vandermonde_control_interp_comp import VandermondeControlInterpComp
 
 _TOL = 1.0E-8
 
@@ -27,10 +27,10 @@ class TestControlInterpolationComp(unittest.TestCase):
         control_options['u1']['units'] = 'rad'
 
         p = om.Problem()
-        p.model.add_subsystem('interp', ControlInterpolationComp(grid_data=grid_data,
-                                                                 control_options=control_options,
-                                                                 standalone_mode=True,
-                                                                 time_units='s'))
+        p.model.add_subsystem('interp', VandermondeControlInterpComp(grid_data=grid_data,
+                                                                     control_options=control_options,
+                                                                     standalone_mode=True,
+                                                                     time_units='s'))
         p.setup(force_alloc_complex=True)
 
         p.set_val('interp.segment_index', 1)
@@ -40,33 +40,51 @@ class TestControlInterpolationComp(unittest.TestCase):
         p.run_model()
         assert_near_equal(p.get_val('interp.control_values:u1'), 0.0, tolerance=_TOL)
 
+        with np.printoptions(linewidth=1024):
+            cpd = p.check_partials(compact_print=True, method='cs')
+            assert_check_partials(cpd, atol=_TOL, rtol=_TOL)
+
         p.set_val('interp.stau', 0.0)
         p.run_model()
         assert_near_equal(p.get_val('interp.control_values:u1'), 3.0, tolerance=_TOL)
+        with np.printoptions(linewidth=1024):
+            cpd = p.check_partials(compact_print=True, method='cs')
+            assert_check_partials(cpd, atol=_TOL, rtol=_TOL)
 
         p.set_val('interp.stau', 1.0)
         p.run_model()
         assert_near_equal(p.get_val('interp.control_values:u1'), 3.0, tolerance=_TOL)
+        with np.printoptions(linewidth=1024):
+            cpd = p.check_partials(compact_print=True, method='cs')
+            assert_check_partials(cpd, atol=_TOL, rtol=_TOL)
 
         p.set_val('interp.segment_index', 0)
 
         p.set_val('interp.stau', -1.0)
         p.run_model()
         assert_near_equal(p.get_val('interp.control_values:u1'), 0.0, tolerance=_TOL)
+        with np.printoptions(linewidth=1024):
+            cpd = p.check_partials(compact_print=True, method='cs')
+            assert_check_partials(cpd, atol=_TOL, rtol=_TOL)
 
         p.set_val('interp.stau', 0.0)
         p.run_model()
         assert_near_equal(p.get_val('interp.control_values:u1'), 3.0, tolerance=_TOL)
+        with np.printoptions(linewidth=1024):
+            cpd = p.check_partials(compact_print=True, method='cs')
+            assert_check_partials(cpd, atol=_TOL, rtol=_TOL)
 
         p.set_val('interp.stau', 1.0)
         p.run_model()
         assert_near_equal(p.get_val('interp.control_values:u1'), 0.0, tolerance=_TOL)
+        with np.printoptions(linewidth=1024):
+            cpd = p.check_partials(compact_print=True, method='cs')
+            assert_check_partials(cpd, atol=_TOL, rtol=_TOL)
 
         p.set_val('interp.stau', 0.54262)
         p.run_model()
-
         with np.printoptions(linewidth=1024):
-            cpd = p.check_partials(compact_print=False, method='cs')
+            cpd = p.check_partials(compact_print=True, method='cs')
             assert_check_partials(cpd, atol=_TOL, rtol=_TOL)
 
     def test_eval_control_radau_compressed(self):
@@ -83,10 +101,10 @@ class TestControlInterpolationComp(unittest.TestCase):
         control_options['u1']['units'] = 'rad'
 
         p = om.Problem()
-        p.model.add_subsystem('interp', ControlInterpolationComp(grid_data=grid_data,
-                                                                 control_options=control_options,
-                                                                 standalone_mode=True,
-                                                                 time_units='s'))
+        p.model.add_subsystem('interp', VandermondeControlInterpComp(grid_data=grid_data,
+                                                                     control_options=control_options,
+                                                                     standalone_mode=True,
+                                                                     time_units='s'))
         p.setup(force_alloc_complex=True)
 
         p.set_val('interp.segment_index', 1)
@@ -147,10 +165,10 @@ class TestControlInterpolationComp(unittest.TestCase):
         control_options['u1']['units'] = 'rad'
 
         p = om.Problem()
-        p.model.add_subsystem('interp', ControlInterpolationComp(grid_data=grid_data,
-                                                                 control_options=control_options,
-                                                                 standalone_mode=True,
-                                                                 time_units='s'))
+        p.model.add_subsystem('interp', VandermondeControlInterpComp(grid_data=grid_data,
+                                                                     control_options=control_options,
+                                                                     standalone_mode=True,
+                                                                     time_units='s'))
         p.setup(force_alloc_complex=True)
 
         p.set_val('interp.segment_index', 1)
@@ -203,10 +221,10 @@ class TestControlInterpolationComp(unittest.TestCase):
         control_options['u1']['units'] = 'rad'
 
         p = om.Problem()
-        p.model.add_subsystem('interp', ControlInterpolationComp(grid_data=grid_data,
-                                                                 control_options=control_options,
-                                                                 standalone_mode=True,
-                                                                 time_units='s'))
+        p.model.add_subsystem('interp', VandermondeControlInterpComp(grid_data=grid_data,
+                                                                     control_options=control_options,
+                                                                     standalone_mode=True,
+                                                                     time_units='s'))
         p.setup(force_alloc_complex=True)
 
         p.set_val('interp.segment_index', 1)
@@ -271,13 +289,15 @@ class TestPolynomialControlInterpolation(unittest.TestCase):
         pc_options['u1']['order'] = 6
 
         p = om.Problem()
-        p.model.add_subsystem('interp', ControlInterpolationComp(grid_data=grid_data,
-                                                                 polynomial_control_options=pc_options,
-                                                                 standalone_mode=True,
-                                                                 time_units='s'))
+        p.model.add_subsystem('interp', VandermondeControlInterpComp(grid_data=grid_data,
+                                                                     polynomial_control_options=pc_options,
+                                                                     standalone_mode=True,
+                                                                     time_units='s'))
         p.setup(force_alloc_complex=True)
 
         p.set_val('interp.segment_index', 1)
+        p.set_val('interp.t_duration', 12.2352)
+        p.set_val('interp.dstau_dt', .3526)
         p.set_val('interp.polynomial_controls:u1', [0.0, 3.0, 0.0, 1.5, 4.0, 3.0, 4.0])
 
         p.set_val('interp.ptau', -1.0)
@@ -328,12 +348,13 @@ class TestPolynomialControlInterpolation(unittest.TestCase):
         pc_options['u1']['order'] = 6
 
         p = om.Problem()
-        p.model.add_subsystem('interp', ControlInterpolationComp(grid_data=grid_data,
-                                                                 polynomial_control_options=pc_options,
-                                                                 standalone_mode=True,
-                                                                 time_units='s'))
+        p.model.add_subsystem('interp', VandermondeControlInterpComp(grid_data=grid_data,
+                                                                     polynomial_control_options=pc_options,
+                                                                     standalone_mode=True,
+                                                                     time_units='s'))
         p.setup(force_alloc_complex=True)
 
+        p.set_val('interp.t_duration', 12.252)
         p.set_val('interp.segment_index', 1)
         p.set_val('interp.polynomial_controls:u1', [0.0, 3.0, 0.0, 1.5, 4.0, 3.0, 4.0])
 

--- a/dymos/transcriptions/explicit_shooting/test/test_explicit_shooting.py
+++ b/dymos/transcriptions/explicit_shooting/test/test_explicit_shooting.py
@@ -156,7 +156,7 @@ class TestExplicitShooting(unittest.TestCase):
         prob.driver.opt_settings['iSumm'] = 6
 
         tx = dm.transcriptions.ExplicitShooting(num_segments=5, grid='gauss-lobatto',
-                                                order=3, num_steps_per_segment=10, compressed=True)
+                                                order=5, num_steps_per_segment=10, compressed=True)
 
         phase = dm.Phase(ode_class=BrachistochroneODE, transcription=tx)
 
@@ -193,6 +193,11 @@ class TestExplicitShooting(unittest.TestCase):
             cpd = prob.check_partials(compact_print=True, method='fd')
             assert_check_partials(cpd, atol=1.0E-5, rtol=1.0E-5)
 
+            subprob = prob.model._get_subsystem('phase0.integrator')._prob
+            with np.printoptions(linewidth=1024):
+                cpd = subprob.check_partials(compact_print=True, method='cs')
+            assert_check_partials(cpd, atol=1.0E-5, rtol=1.0E-5)
+
     def test_brachistochrone_explicit_shooting(self):
 
         for method in ['rk4', 'ralston']:
@@ -223,7 +228,7 @@ class TestExplicitShooting(unittest.TestCase):
 
                 phase.add_objective('time', loc='final')
 
-                prob.setup(force_alloc_complex=False)
+                prob.setup(force_alloc_complex=True)
 
                 prob.set_val('phase0.t_initial', 0.0)
                 prob.set_val('phase0.t_duration', 2)
@@ -274,7 +279,7 @@ class TestExplicitShooting(unittest.TestCase):
 
         phase.add_objective('time', loc='final')
 
-        prob.setup(force_alloc_complex=False)
+        prob.setup(force_alloc_complex=True)
 
         prob.set_val('phase0.t_initial', 0.0)
         prob.set_val('phase0.t_duration', 2)
@@ -295,5 +300,5 @@ class TestExplicitShooting(unittest.TestCase):
         assert_near_equal(t_f, 1.8016, tolerance=5.0E-3)
 
         with np.printoptions(linewidth=1024):
-            cpd = prob.check_partials(compact_print=True, method='fd')
+            cpd = prob.check_partials(compact_print=True, method='cs', out_stream=None)
             assert_check_partials(cpd, atol=1.0E-5, rtol=1.0E-5)

--- a/dymos/transcriptions/explicit_shooting/test/test_tau_comp.py
+++ b/dymos/transcriptions/explicit_shooting/test/test_tau_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_check_partials
+from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 import dymos as dm
 
 from dymos.transcriptions.explicit_shooting.tau_comp import TauComp
@@ -20,19 +20,18 @@ class TestTauComp(unittest.TestCase):
         p.setup(force_alloc_complex=True)
 
         p.set_val('tau_comp.t_initial', 0)
-        p.set_val('tau_comp.t_duration', 10)
-
-        t = np.linspace(0, 10, 500)
-        ptau = np.zeros_like(t)
-        stau = np.zeros_like(t)
-
-        for i, time in enumerate(t):
-            p.set_val('tau_comp.time', time)
-            p.run_model()
-            ptau[i] = p.get_val('tau_comp.ptau')
-            stau[i] = p.get_val('tau_comp.stau')
+        p.set_val('tau_comp.t_duration', 15)
 
         p.set_val('tau_comp.time', 1.5)
         p.run_model()
+
+        frac = 0.1
+        ptau_expected = -1 + 2 * frac
+        assert_near_equal(p.get_val('tau_comp.ptau'), ptau_expected)
+
+        frac = 1.5/5.0
+        stau_expected = -1 + 2 * frac
+        assert_near_equal(p.get_val('tau_comp.stau'), stau_expected)
+
         cpd = p.check_partials(method='cs')
         assert_check_partials(cpd)


### PR DESCRIPTION
### Summary

Added control rates and their derivatives to the control interpolation used by ExplicitShooting.
ExplicitShooting's control interpolation component is renamed VandermondeControlInterpComp, to distinguish it from the Lagrange interpolation methods used by the pseudospectral transcriptions.

### Related Issues

- Resolves #639

### Status

- [x] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
