### PR TITLE
Updated the Issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,3 @@
-### Summary of Issue
-
-<A brief summary of the issue>
-
 ### Issue Type
 
 - [x] Bug

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,10 +6,6 @@ Summary of PR.
 
 - Resolves #
 
-### Status
-
-- [ ] Ready for merge
-
 ### Backwards incompatibilities
 
 None


### PR DESCRIPTION
### Summary

Updates the issue and PR templates for github.

The ready-for-merge checkbox isn't necessary since github supports draft PRs.
The summary and description sections of the issues template were a bit redundant, so summary has been removed.

### Related Issues

- N/A

### Status

- [ ] Ready for merge

### Backwards incompatibilities

None

### New Dependencies

None
