### PR TITLE
Speed improvement for time series compute

### DIFF
--- a/dymos/transcriptions/common/timeseries_output_comp.py
+++ b/dymos/transcriptions/common/timeseries_output_comp.py
@@ -227,9 +227,11 @@ class PseudospectralTimeseriesOutputComp(TimeseriesOutputCompBase):
         """
         for (input_name, output_name, _) in self._vars.values():
             scale, offset = self._conversion_factors[output_name]
+
             inp = inputs[input_name]
             if len(inp.shape) > 2:
-                interp_vals = self.interpolation_matrix.dot(inp.swapaxes(0, 1))
-            else:
-                interp_vals = self.interpolation_matrix.dot(inp)
+                # Dot product always performs the sum product over axis 2.
+                inp = inp.swapaxes(0, 1)
+
+            interp_vals = self.interpolation_matrix.dot(inp)
             outputs[output_name] = scale * (interp_vals + offset)


### PR DESCRIPTION
### Summary

Replaced the tensordot in the compute method of `timeseries_output_comp` with a regular dot product to remove a performance bottleneck. 

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
