### PR TITLE
Removed solver for connected linkages. Its only needed for solve_segments.

### DIFF
--- a/dymos/transcriptions/pseudospectral/pseudospectral_base.py
+++ b/dymos/transcriptions/pseudospectral/pseudospectral_base.py
@@ -481,7 +481,7 @@ class PseudospectralBase(TranscriptionBase):
                 newton.linesearch = om.BoundsEnforceLS()
 
         # even though you don't need a nl_solver for connections, you still ln_solver since its implicit
-        if self.any_solved_segs or self.any_connected_opt_segs: 
+        if self.any_solved_segs or self.any_connected_opt_segs:
             if isinstance(phase.linear_solver, om.LinearRunOnce):
                 phase.linear_solver = om.DirectSolver()
 


### PR DESCRIPTION
### Summary

Removes un-needed newton solver for connected linkages. 

### Related Issues

 Resolves #667

### Backwards incompatibilities

None

### New Dependencies

None
