### PR TITLE
added ExplicitShooting to transcription 

### DIFF
--- a/dymos/__init__.py
+++ b/dymos/__init__.py
@@ -1,7 +1,7 @@
 __version__ = '1.2.1-dev'
 
 from .phase import Phase
-from .transcriptions import GaussLobatto, Radau
+from .transcriptions import GaussLobatto, Radau, ExplicitShooting
 from .trajectory.trajectory import Trajectory
 from .run_problem import run_problem
 from .load_case import load_case


### PR DESCRIPTION
### Summary

Previously you would have to call `dm.transcription.ExplicitShooting` 
Now you can call it simply with `dm.ExplicitShooting`
This matches implementation for `dm.Radau` and `dm.GaussLobatto`

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
