### PR TITLE
Fix to allow parameters with `static_targets=True` to work with ExplicitShooting

### DIFF
--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -1816,7 +1816,12 @@ class Phase(om.Group):
                                  'variable to be interpolated was not provided.\nPlease specify '
                                  'the name of the interpolated variable or a node subset.')
             elif name in self.state_options:
-                node_locations = gd.node_ptau[gd.subset_node_indices['state_input']]
+                # For states in explicit shooting phases, interp should just return the initial
+                # value.
+                if isinstance(self.options['transcription'], dm.ExplicitShooting):
+                    node_locations = np.array([-1.0])
+                else:
+                    node_locations = gd.node_ptau[gd.subset_node_indices['state_input']]
             elif name in self.control_options:
                 node_locations = gd.node_ptau[gd.subset_node_indices['control_input']]
             elif name in self.polynomial_control_options:

--- a/dymos/transcriptions/explicit_shooting/ode_evaluation_group.py
+++ b/dymos/transcriptions/explicit_shooting/ode_evaluation_group.py
@@ -201,7 +201,6 @@ class ODEEvaluationGroup(om.Group):
 
     def _configure_params(self):
         vec_size = self.vec_size
-        src_rows = np.zeros(vec_size, dtype=int)
 
         for name, options in self.parameter_options.items():
             shape = options['shape']
@@ -212,9 +211,15 @@ class ODEEvaluationGroup(om.Group):
             self._ivc.add_output(var_name, shape=shape, units=units)
             self.add_design_var(var_name)
 
+            if options['static_target']:
+                src_idxs = om.slicer[...]
+            else:
+                src_rows = np.zeros(vec_size, dtype=int)
+                src_idxs = om.slicer[src_rows, ...]
+
             # Promote targets from the ODE
             for tgt in targets:
-                self.promotes('ode', inputs=[(tgt, var_name)], src_indices=om.slicer[src_rows, ...],
+                self.promotes('ode', inputs=[(tgt, var_name)], src_indices=src_idxs,
                               src_shape=options['shape'])
             if targets:
                 self.set_input_defaults(name=var_name,

--- a/dymos/transcriptions/explicit_shooting/test/test_explicit_shooting.py
+++ b/dymos/transcriptions/explicit_shooting/test/test_explicit_shooting.py
@@ -588,3 +588,98 @@ class TestExplicitShooting(unittest.TestCase):
                     prob.setup(force_alloc_complex=True)
 
                 self.assertIn(msg, [str(w.message) for w in ctx])
+
+    def test_brachistochrone_static_gravity_explicit_shooting(self):
+        import openmdao.api as om
+        from openmdao.utils.assert_utils import assert_near_equal
+        import dymos as dm
+        from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
+
+        #
+        # Initialize the Problem and the optimization driver
+        #
+        p = om.Problem(model=om.Group())
+        p.driver = om.ScipyOptimizeDriver()
+        p.driver.declare_coloring()
+
+        #
+        # Create a trajectory and add a phase to it
+        #
+        traj = p.model.add_subsystem('traj', dm.Trajectory())
+
+        phase = traj.add_phase('phase0',
+                               dm.Phase(ode_class=BrachistochroneODE,
+                                        ode_init_kwargs={'static_gravity': True},
+                                        transcription=dm.ExplicitShooting(num_segments=10, num_steps_per_segment=10)))
+
+        #
+        # Set the variables
+        #
+        phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
+
+        phase.add_state('x', rate_source='xdot',
+                        targets=None,
+                        units='m',
+                        fix_initial=True)
+
+        phase.add_state('y', rate_source='ydot',
+                        targets=None,
+                        units='m',
+                        fix_initial=True)
+
+        phase.add_state('v', rate_source='vdot',
+                        targets=['v'],
+                        units='m/s',
+                        fix_initial=True)
+
+        phase.add_control('theta', targets=['theta'],
+                          continuity=True, rate_continuity=True,
+                          units='deg', lower=0.01, upper=179.9)
+
+        phase.add_parameter('g', targets=['g'], static_target=True, opt=False)
+
+        #
+        # Constrain the final values of x and y
+        #
+        phase.add_boundary_constraint('x', loc='final', equals=10)
+        phase.add_boundary_constraint('y', loc='final', equals=5)
+
+        #
+        # Minimize time at the end of the phase
+        #
+        phase.add_objective('time', loc='final', scaler=10)
+
+        #
+        # Setup the Problem
+        #
+        p.setup()
+
+        #
+        # Set the initial values
+        # The initial time is fixed, and we set that fixed value here.
+        # The optimizer is allowed to modify t_duration, but an initial guess is provided here.
+        #
+        p.set_val('traj.phase0.t_initial', 0.0)
+        p.set_val('traj.phase0.t_duration', 2.0)
+
+        # Guesses for states are provided at all state_input nodes.
+        # We use the phase.interpolate method to linearly interpolate values onto the state input nodes.
+        # Since fix_initial=True for all states and fix_final=True for x and y, the initial or final
+        # values of the interpolation provided here will not be changed by the optimizer.
+        p.set_val('traj.phase0.states:x', phase.interp('x', [0, 10]))
+        p.set_val('traj.phase0.states:y', phase.interp('y', [10, 5]))
+        p.set_val('traj.phase0.states:v', phase.interp('v', [0, 9.9]))
+
+        # Guesses for controls are provided at all control_input node.
+        # Here phase.interpolate is used to linearly interpolate values onto the control input nodes.
+        p.set_val('traj.phase0.controls:theta', phase.interp('theta', [5, 100.5]))
+
+        # Set the value for gravitational acceleration.
+        p.set_val('traj.phase0.parameters:g', 9.80665)
+
+        #
+        # Solve for the optimal trajectory
+        #
+        dm.run_problem(p, simulate=False)
+
+        assert_near_equal(p.get_val('traj.phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)

--- a/dymos/utils/introspection.py
+++ b/dymos/utils/introspection.py
@@ -598,6 +598,8 @@ def get_target_metadata(ode, name, user_targets=_unspecified, user_units=_unspec
         The shape of the variable.  If not specified, shape is taken from the ODE targets.
     units : str
         The units of the variable.  If not specified, units are taken from the ODE targets.
+    static_target : bool
+        True if the target is static, otherwise False.
 
     Notes
     -----


### PR DESCRIPTION
### Summary

Parameters with `static_targets=True` set should now work correctly in ExplicitShooting phases.

`phase.interp` now returns only the initial value when used with an ExplicitShooting phase.  This means users need to change fewer things in a run script when switching between ExplicitShooting and other transcriptions.

### Related Issues

- Resolves #676 
- Resolves #677

### Backwards incompatibilities

None

### New Dependencies

None
