### PR TITLE
fix for example, that doesnt work in google collab

### DIFF
--- a/docs/examples/commercial_aircraft/commercial_aircraft.ipynb
+++ b/docs/examples/commercial_aircraft/commercial_aircraft.ipynb
@@ -527,7 +527,7 @@
     "from dymos.utils.lgl import lgl\n",
     "\n",
     "p = om.Problem(model=om.Group())\n",
-    "p.driver = om.pyOptSparseDriver()\n",
+    "p.driver = om.ScipyOptimizeDriver()\n",
     "p.driver.options['optimizer'] = 'SLSQP'\n",
     "p.driver.declare_coloring()\n",
     "\n",


### PR DESCRIPTION
Doesnt work with p.driver = om.pyOptSparseDriver(), used om.ScipyOptimizeDriver() instead, works fine on google collab.
Include my collab errors below:
pip conflict (maybee this makes OptSparceDriver broken)
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
google-colab 1.0.0 requires tornado~=5.1.0; python_version >= "3.0", but you have tornado 6.1 which is incompatible.
datascience 0.10.6 requires folium==0.2.1, but you have folium 0.8.3 which is incompatible.
RuntimeError                              Traceback (most recent call last)
<ipython-input-7-eb39417396f1> in <module>()
      9 
     10 p = om.Problem(model=om.Group())
---> 11 p.driver = om.pyOptSparseDriver()
     12 p.driver.options['optimizer'] = 'SLSQP'
     13 p.driver.declare_coloring()

/usr/local/lib/python3.7/dist-packages/openmdao/drivers/pyoptsparse_driver.py in __init__(self, **kwargs)
    159         """
    160         if Optimization is None:
--> 161             raise RuntimeError('pyOptSparseDriver is not available, pyOptsparse is not installed.')
    162 
    163         super().__init__(**kwargs)

RuntimeError: pyOptSparseDriver is not available, pyOptsparse is not installed.

### Summary

Summary of PR.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
