### PR TITLE
Warn user if bounds are applied to a state during solve_segments.

### DIFF
--- a/dymos/transcriptions/pseudospectral/components/state_independents.py
+++ b/dymos/transcriptions/pseudospectral/components/state_independents.py
@@ -76,6 +76,11 @@ class StateIndependentsComp(om.ImplicitComponent):
                 default_val = np.repeat(default_val[np.newaxis, ...], num_state_input_nodes, axis=0)
             var_names = self.var_names[state_name]
 
+            if solved and (options['lower'] or options['upper']):
+                om.issue_warning(f'State {state_name} has bounds but they are not enforced when '
+                                 f'using `solve_segments.` Apply a path constraint to {state_name} '
+                                 f'to enforce bounds.', om.UnusedOptionWarning)
+
             # only need the implicit variable if this state is solved.
             # Note: we don't add scaling and bounds here. This may be revisited.
             self.add_output(name=f'states:{state_name}',

--- a/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_sol_opt.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_sol_opt.py
@@ -93,10 +93,12 @@ class TestCollocationCompSolOpt(unittest.TestCase):
 
         state_options = {'x': {'units': 'm', 'shape': (1, ), 'fix_initial': True,
                                'fix_final': False, 'solve_segments': False,
-                               'connected_initial': False, 'val': 1.0},
+                               'connected_initial': False, 'val': 1.0, 'lower': None,
+                               'upper': None},
                          'v': {'units': 'm/s', 'shape': (3, 2), 'fix_initial': False,
                                'fix_final': True, 'solve_segments': True,
-                               'connected_initial': False, 'val': np.ones((3, 2))}}
+                               'connected_initial': False, 'val': np.ones((3, 2)),
+                               'lower': None, 'upper': None}}
 
         indep_comp = om.IndepVarComp()
         p.model.add_subsystem('indep', indep_comp, promotes_outputs=['*'])


### PR DESCRIPTION
### Summary

Enforcing bounds at the solver level is generally counter productive.  Instead, warn the user of the situation and suggest they use a path constraint for bounds enforcement instead.

### Related Issues

- Resolves #579

### Backwards incompatibilities

None

### New Dependencies

None
