### PR TITLE
I682 add CI matrix entry for testing without pyoptsparse

### DIFF
--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -32,12 +32,11 @@ jobs:
 #            OPTIONAL: '[all]'
 #            DOCS: 1
 
-          # baseline versions except no pyoptsparse
+          # baseline versions except no pyoptsparse or SNOPT
           - PY: 3.8
             NUMPY: 1.18
             SCIPY: 1.4
             PETSc: 3.12
-            SNOPT: 7.7
             MBI: 1
             OPENMDAO: 'latest'
             OPTIONAL: '[all]'

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -5,7 +5,7 @@ name: Dymos Tests
 on:
   # Trigger on push or pull request events for the master branch
   push:
-    branches: [ master ]
+    branches: [ master, I682-add-dymos-ci-without-pyoptsparse ]
   pull_request:
     branches: [ master ]
 
@@ -20,17 +20,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # baseline versions
-          - PY: 3.8
-            NUMPY: 1.18
-            SCIPY: 1.4
-            PETSc: 3.12
-            PYOPTSPARSE: 'v2.1.5'
-            SNOPT: 7.7
-            MBI: 1
-            OPENMDAO: 'latest'
-            OPTIONAL: '[all]'
-            DOCS: 1
+#          # baseline versions
+#          - PY: 3.8
+#            NUMPY: 1.18
+#            SCIPY: 1.4
+#            PETSc: 3.12
+#            PYOPTSPARSE: 'v2.1.5'
+#            SNOPT: 7.7
+#            MBI: 1
+#            OPENMDAO: 'latest'
+#            OPTIONAL: '[all]'
+#            DOCS: 1
 
           # baseline versions except no pyoptsparse
           - PY: 3.8

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -5,7 +5,7 @@ name: Dymos Tests
 on:
   # Trigger on push or pull request events for the master branch
   push:
-    branches: [ master ]
+    branches: [ master, moved_decorator ]
   pull_request:
     branches: [ master ]
 
@@ -25,36 +25,36 @@ jobs:
             NUMPY: 1.18
             SCIPY: 1.4
             PETSc: 3.12
-            PYOPTSPARSE: 'v2.1.5'
+#            PYOPTSPARSE: 'v2.1.5'
             SNOPT: 7.7
             MBI: 1
             OPENMDAO: 'latest'
             OPTIONAL: '[all]'
             DOCS: 1
 
-          # try latest versions
-          - PY: 3
-            NUMPY: 1
-            SCIPY: 1
-            # PETSc: 3
-            PYOPTSPARSE: 'v2.1.5'
-            SNOPT: 7.7
-            MBI: 1
-            OPENMDAO: 'dev'
-            OPTIONAL: '[test]'
-            DOCS: 0
-
-          # oldest supported versions
-          - PY: 3.6
-            NUMPY: 1.16
-            SCIPY: 1.2
-            PETSc: 3.10.2
-            PYOPTSPARSE: 'v1.2'
-            SNOPT: 7.2
-            MBI: 1
-            OPENMDAO: 3.13.0
-            OPTIONAL: '[all]'
-            DOCS: 0
+#          # try latest versions
+#          - PY: 3
+#            NUMPY: 1
+#            SCIPY: 1
+#            # PETSc: 3
+#            PYOPTSPARSE: 'v2.1.5'
+#            SNOPT: 7.7
+#            MBI: 1
+#            OPENMDAO: 'dev'
+#            OPTIONAL: '[test]'
+#            DOCS: 0
+#
+#          # oldest supported versions
+#          - PY: 3.6
+#            NUMPY: 1.16
+#            SCIPY: 1.2
+#            PETSc: 3.10.2
+#            PYOPTSPARSE: 'v1.2'
+#            SNOPT: 7.2
+#            MBI: 1
+#            OPENMDAO: 3.13.0
+#            OPTIONAL: '[all]'
+#            DOCS: 0
 
     steps:
       - name: Display run details

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -5,7 +5,7 @@ name: Dymos Tests
 on:
   # Trigger on push or pull request events for the master branch
   push:
-    branches: [ master, I682-add-dymos-ci-without-pyoptsparse ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -5,7 +5,7 @@ name: Dymos Tests
 on:
   # Trigger on push or pull request events for the master branch
   push:
-    branches: [ master, I682-add-dymos-ci-without-pyoptsparse ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 
@@ -20,17 +20,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#          # baseline versions
-#          - PY: 3.8
-#            NUMPY: 1.18
-#            SCIPY: 1.4
-#            PETSc: 3.12
-#            PYOPTSPARSE: 'v2.1.5'
-#            SNOPT: 7.7
-#            MBI: 1
-#            OPENMDAO: 'latest'
-#            OPTIONAL: '[all]'
-#            DOCS: 1
+          # baseline versions
+          - PY: 3.8
+            NUMPY: 1.18
+            SCIPY: 1.4
+            PETSc: 3.12
+            PYOPTSPARSE: 'v2.1.5'
+            SNOPT: 7.7
+            MBI: 1
+            OPENMDAO: 'latest'
+            OPTIONAL: '[all]'
+            DOCS: 1
 
           # baseline versions except no pyoptsparse or SNOPT
           - PY: 3.8

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -5,7 +5,7 @@ name: Dymos Tests
 on:
   # Trigger on push or pull request events for the master branch
   push:
-    branches: [ master, moved_decorator ]
+    branches: [ master, I682-add-dymos-ci-without-pyoptsparse ]
   pull_request:
     branches: [ master ]
 
@@ -25,36 +25,47 @@ jobs:
             NUMPY: 1.18
             SCIPY: 1.4
             PETSc: 3.12
-#            PYOPTSPARSE: 'v2.1.5'
+            PYOPTSPARSE: 'v2.1.5'
             SNOPT: 7.7
             MBI: 1
             OPENMDAO: 'latest'
             OPTIONAL: '[all]'
             DOCS: 1
 
-#          # try latest versions
-#          - PY: 3
-#            NUMPY: 1
-#            SCIPY: 1
-#            # PETSc: 3
-#            PYOPTSPARSE: 'v2.1.5'
-#            SNOPT: 7.7
-#            MBI: 1
-#            OPENMDAO: 'dev'
-#            OPTIONAL: '[test]'
-#            DOCS: 0
-#
-#          # oldest supported versions
-#          - PY: 3.6
-#            NUMPY: 1.16
-#            SCIPY: 1.2
-#            PETSc: 3.10.2
-#            PYOPTSPARSE: 'v1.2'
-#            SNOPT: 7.2
-#            MBI: 1
-#            OPENMDAO: 3.13.0
-#            OPTIONAL: '[all]'
-#            DOCS: 0
+          # baseline versions except no pyoptsparse
+          - PY: 3.8
+            NUMPY: 1.18
+            SCIPY: 1.4
+            PETSc: 3.12
+            SNOPT: 7.7
+            MBI: 1
+            OPENMDAO: 'latest'
+            OPTIONAL: '[all]'
+            DOCS: 1
+
+          # try latest versions
+          - PY: 3
+            NUMPY: 1
+            SCIPY: 1
+            # PETSc: 3
+            PYOPTSPARSE: 'v2.1.5'
+            SNOPT: 7.7
+            MBI: 1
+            OPENMDAO: 'dev'
+            OPTIONAL: '[test]'
+            DOCS: 0
+
+          # oldest supported versions
+          - PY: 3.6
+            NUMPY: 1.16
+            SCIPY: 1.2
+            PETSc: 3.10.2
+            PYOPTSPARSE: 'v1.2'
+            SNOPT: 7.2
+            MBI: 1
+            OPENMDAO: 3.13.0
+            OPTIONAL: '[all]'
+            DOCS: 0
 
     steps:
       - name: Display run details

--- a/benchmark/benchmark_balanced_field.py
+++ b/benchmark/benchmark_balanced_field.py
@@ -243,8 +243,10 @@ def _run_balanced_field_length_problem(tx=dm.GaussLobatto, timeseries=True, sim=
     # Test this example in Dymos' continuous integration
     assert_near_equal(p.get_val('traj.rto.states:r')[-1], 2188.2, tolerance=0.01)
 
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 @use_tempdirs
+@require_pyoptsparse()
 class BenchmarkBalancedFieldLength(unittest.TestCase):
 
     def benchmark_gausslobatto_notimeseries_nosim_nosolveseg(self):

--- a/benchmark/benchmark_balanced_field.py
+++ b/benchmark/benchmark_balanced_field.py
@@ -1,9 +1,9 @@
 import unittest
-from openmdao.utils.testing_utils import use_tempdirs
 
 import openmdao.api as om
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 import dymos as dm
 from dymos.examples.balanced_field.balanced_field_ode import BalancedFieldODEComp
 
@@ -243,7 +243,6 @@ def _run_balanced_field_length_problem(tx=dm.GaussLobatto, timeseries=True, sim=
     # Test this example in Dymos' continuous integration
     assert_near_equal(p.get_val('traj.rto.states:r')[-1], 2188.2, tolerance=0.01)
 
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 @use_tempdirs
 @require_pyoptsparse()

--- a/benchmark/benchmark_brachistochrone.py
+++ b/benchmark/benchmark_brachistochrone.py
@@ -4,7 +4,7 @@ import unittest
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import set_pyoptsparse_opt
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 import dymos as dm
 from dymos.examples.brachistochrone import BrachistochroneODE
 
@@ -68,7 +68,6 @@ def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, tran
 
     return p
 
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 @use_tempdirs
 @require_pyoptsparse()

--- a/benchmark/benchmark_brachistochrone.py
+++ b/benchmark/benchmark_brachistochrone.py
@@ -68,8 +68,10 @@ def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, tran
 
     return p
 
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 @use_tempdirs
+@require_pyoptsparse()
 class BenchmarkBrachistochrone(unittest.TestCase):
     """ Benchmarks for various permutations of the brachistochrone problem."""
 

--- a/benchmark/benchmark_racecar.py
+++ b/benchmark/benchmark_racecar.py
@@ -1,6 +1,6 @@
 import unittest
 
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from openmdao.utils.assert_utils import assert_near_equal
 
 import openmdao.api as om
@@ -165,7 +165,6 @@ def _run_racecar_problem(transcription, timeseries=False):
     t = p.get_val('traj.phase0.timeseries.states:t')
     assert_near_equal(t[-1], 22.2657, tolerance=0.01)
 
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 @use_tempdirs
 @require_pyoptsparse(optimizer='IPOPT')

--- a/benchmark/benchmark_racecar.py
+++ b/benchmark/benchmark_racecar.py
@@ -165,8 +165,10 @@ def _run_racecar_problem(transcription, timeseries=False):
     t = p.get_val('traj.phase0.timeseries.states:t')
     assert_near_equal(t[-1], 22.2657, tolerance=0.01)
 
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 @use_tempdirs
+@require_pyoptsparse(optimizer='IPOPT')
 class BenchmarkRacecar(unittest.TestCase):
     """ Benchmarks for various permutations of the racecar problem."""
 

--- a/dymos/examples/vanderpol/test/test_vanderpol.py
+++ b/dymos/examples/vanderpol/test/test_vanderpol.py
@@ -16,6 +16,7 @@ class TestVanderpolExample(unittest.TestCase):
         p = vanderpol(transcription='gauss-lobatto', num_segments=75)
         p.run_model()
 
+    @require_pyoptsparse(optimizer='SLSQP')
     def test_vanderpol_simulate_true(self):
         # simulate true
         p = vanderpol(transcription='radau-ps', num_segments=30, transcription_order=3,

--- a/dymos/models/eom/test/test_flight_path_eom_2d.py
+++ b/dymos/models/eom/test/test_flight_path_eom_2d.py
@@ -19,9 +19,10 @@ class _CannonballODE(FlightPathEOM2D):
 
 
 @use_tempdirs
+@require_pyoptsparse(optimizer='SLSQP')
 class TestFlightPathEOM2D(unittest.TestCase):
 
-    @require_pyoptsparse(optimizer='SLSQP')
+    # @require_pyoptsparse(optimizer='SLSQP')
     def setUp(self):
         self.p = om.Problem(model=om.Group())
 

--- a/dymos/models/eom/test/test_flight_path_eom_2d.py
+++ b/dymos/models/eom/test/test_flight_path_eom_2d.py
@@ -22,7 +22,6 @@ class _CannonballODE(FlightPathEOM2D):
 @require_pyoptsparse(optimizer='SLSQP')
 class TestFlightPathEOM2D(unittest.TestCase):
 
-    # @require_pyoptsparse(optimizer='SLSQP')
     def setUp(self):
         self.p = om.Problem(model=om.Group())
 

--- a/dymos/test/test_check_partials.py
+++ b/dymos/test/test_check_partials.py
@@ -370,7 +370,7 @@ class TestCheckPartials(unittest.TestCase):
 
         return cpd
 
-    # @require_pyoptsparse(optimizer='SNOPT')
+    @require_pyoptsparse()
     def test_check_partials_yes(self):
         """
         Run check_partials on a series of dymos problems and verify that partials information
@@ -391,7 +391,7 @@ class TestCheckPartials(unittest.TestCase):
 
         assert(len(partials.keys()) > 0)
 
-    # @require_pyoptsparse(optimizer='SNOPT')
+    @require_pyoptsparse()
     def test_check_partials_no(self):
         """
         Run check_partials on a series of dymos problems and verify that partials information

--- a/dymos/test/test_check_partials.py
+++ b/dymos/test/test_check_partials.py
@@ -370,7 +370,7 @@ class TestCheckPartials(unittest.TestCase):
 
         return cpd
 
-    @require_pyoptsparse(optimizer='SNOPT')
+    # @require_pyoptsparse(optimizer='SNOPT')
     def test_check_partials_yes(self):
         """
         Run check_partials on a series of dymos problems and verify that partials information
@@ -391,7 +391,7 @@ class TestCheckPartials(unittest.TestCase):
 
         assert(len(partials.keys()) > 0)
 
-    @require_pyoptsparse(optimizer='SNOPT')
+    # @require_pyoptsparse(optimizer='SNOPT')
     def test_check_partials_no(self):
         """
         Run check_partials on a series of dymos problems and verify that partials information

--- a/dymos/test/test_check_partials.py
+++ b/dymos/test/test_check_partials.py
@@ -369,6 +369,9 @@ class TestCheckPartials(unittest.TestCase):
 
         return cpd
 
+    from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+
+    @require_pyoptsparse(optimizer='SNOPT')
     def test_check_partials_yes(self):
         """
         Run check_partials on a series of dymos problems and verify that partials information
@@ -389,6 +392,8 @@ class TestCheckPartials(unittest.TestCase):
 
         assert(len(partials.keys()) > 0)
 
+
+    @require_pyoptsparse(optimizer='SNOPT')
     def test_check_partials_no(self):
         """
         Run check_partials on a series of dymos problems and verify that partials information

--- a/dymos/test/test_check_partials.py
+++ b/dymos/test/test_check_partials.py
@@ -1,6 +1,5 @@
 import unittest
 import openmdao.api as om
-from openmdao.utils.testing_utils import require_pyoptsparse
 import dymos as dm
 
 
@@ -279,8 +278,7 @@ class TestCheckPartials(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
 
-        p.driver = om.pyOptSparseDriver()
-        p.driver.options['optimizer'] = 'SLSQP'
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.declare_coloring()
 
         #
@@ -370,7 +368,6 @@ class TestCheckPartials(unittest.TestCase):
 
         return cpd
 
-    @require_pyoptsparse()
     def test_check_partials_yes(self):
         """
         Run check_partials on a series of dymos problems and verify that partials information
@@ -391,7 +388,6 @@ class TestCheckPartials(unittest.TestCase):
 
         assert(len(partials.keys()) > 0)
 
-    @require_pyoptsparse()
     def test_check_partials_no(self):
         """
         Run check_partials on a series of dymos problems and verify that partials information

--- a/dymos/test/test_check_partials.py
+++ b/dymos/test/test_check_partials.py
@@ -1,5 +1,6 @@
 import unittest
 import openmdao.api as om
+from openmdao.utils.testing_utils import require_pyoptsparse
 import dymos as dm
 
 
@@ -368,8 +369,6 @@ class TestCheckPartials(unittest.TestCase):
         cpd = {path: data for path, data in cpd.items() if 'rhs_disc' not in path and 'rhs_col' not in path}
 
         return cpd
-
-    from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
     @require_pyoptsparse(optimizer='SNOPT')
     def test_check_partials_yes(self):

--- a/dymos/test/test_check_partials.py
+++ b/dymos/test/test_check_partials.py
@@ -392,7 +392,6 @@ class TestCheckPartials(unittest.TestCase):
 
         assert(len(partials.keys()) > 0)
 
-
     @require_pyoptsparse(optimizer='SNOPT')
     def test_check_partials_no(self):
         """

--- a/dymos/test/test_run_problem.py
+++ b/dymos/test/test_run_problem.py
@@ -340,7 +340,6 @@ class TestRunProblem(unittest.TestCase):
 @use_tempdirs
 @require_pyoptsparse(optimizer='SLSQP')
 class TestRunProblemPlotting(unittest.TestCase):
-    # @require_pyoptsparse(optimizer='SLSQP')
     def setUp(self):
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()

--- a/dymos/test/test_run_problem.py
+++ b/dymos/test/test_run_problem.py
@@ -338,8 +338,9 @@ class TestRunProblem(unittest.TestCase):
 
 
 @use_tempdirs
+@require_pyoptsparse(optimizer='SLSQP')
 class TestRunProblemPlotting(unittest.TestCase):
-    @require_pyoptsparse(optimizer='SLSQP')
+    # @require_pyoptsparse(optimizer='SLSQP')
     def setUp(self):
         p = om.Problem(model=om.Group())
         p.driver = om.pyOptSparseDriver()

--- a/dymos/transcriptions/explicit_shooting/rk_integration_comp.py
+++ b/dymos/transcriptions/explicit_shooting/rk_integration_comp.py
@@ -169,7 +169,6 @@ class RKIntegrationComp(om.ExplicitComponent):
         p.final_setup()
 
         self._deriv_subprob = p = om.Problem(comm=self.comm)
-        p.driver = om.pyOptSparseDriver(optimizer='SNOPT')
         p.model.add_subsystem('ode_eval',
                               ODEEvaluationGroup(self.ode_class, self.time_options,
                                                  self.state_options,

--- a/dymos/transcriptions/explicit_shooting/test/test_explicit_shooting.py
+++ b/dymos/transcriptions/explicit_shooting/test/test_explicit_shooting.py
@@ -83,6 +83,7 @@ class Simple1StateODE(om.ExplicitComponent):
 @use_tempdirs
 class TestExplicitShooting(unittest.TestCase):
 
+    @require_pyoptsparse(optimizer='SNOPT')
     def test_1_state_run_model(self):
         prob = om.Problem()
 
@@ -111,6 +112,7 @@ class TestExplicitShooting(unittest.TestCase):
 
         assert_check_partials(cpd, rtol=1.0E-5)
 
+    @require_pyoptsparse(optimizer='SNOPT')
     def test_2_states_run_model(self):
 
         for method in ['rk4', 'euler', '3/8', 'ralston', 'rkf', 'rkck', 'dopri']:
@@ -589,6 +591,7 @@ class TestExplicitShooting(unittest.TestCase):
 
                 self.assertIn(msg, [str(w.message) for w in ctx])
 
+    @require_pyoptsparse(optimizer='SNOPT')
     def test_brachistochrone_static_gravity_explicit_shooting(self):
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal

--- a/dymos/transcriptions/explicit_shooting/test/test_explicit_shooting.py
+++ b/dymos/transcriptions/explicit_shooting/test/test_explicit_shooting.py
@@ -83,7 +83,7 @@ class Simple1StateODE(om.ExplicitComponent):
 @use_tempdirs
 class TestExplicitShooting(unittest.TestCase):
 
-    @require_pyoptsparse(optimizer='SNOPT')
+    # @require_pyoptsparse(optimizer='SNOPT')
     def test_1_state_run_model(self):
         prob = om.Problem()
 
@@ -112,7 +112,7 @@ class TestExplicitShooting(unittest.TestCase):
 
         assert_check_partials(cpd, rtol=1.0E-5)
 
-    @require_pyoptsparse(optimizer='SNOPT')
+    # @require_pyoptsparse(optimizer='SNOPT')
     def test_2_states_run_model(self):
 
         for method in ['rk4', 'euler', '3/8', 'ralston', 'rkf', 'rkck', 'dopri']:
@@ -591,7 +591,7 @@ class TestExplicitShooting(unittest.TestCase):
 
                 self.assertIn(msg, [str(w.message) for w in ctx])
 
-    @require_pyoptsparse(optimizer='SNOPT')
+    # @require_pyoptsparse(optimizer='SNOPT')
     def test_brachistochrone_static_gravity_explicit_shooting(self):
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal

--- a/dymos/transcriptions/explicit_shooting/test/test_rk_integration_comp.py
+++ b/dymos/transcriptions/explicit_shooting/test/test_rk_integration_comp.py
@@ -39,9 +39,11 @@ class SimpleODE(om.ExplicitComponent):
         t = inputs['t']
         partials['x_dot', 't'] = -2*t
 
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 class TestRKIntegrationComp(unittest.TestCase):
 
+    @require_pyoptsparse(optimizer='SNOPT')
     def test_eval_f_scalar(self):
         gd = dm.transcriptions.grid_data.GridData(num_segments=10, transcription='gauss-lobatto',
                                                   transcription_order=3)
@@ -93,6 +95,9 @@ class TestRKIntegrationComp(unittest.TestCase):
 
         assert_near_equal(f, x - t**2 + theta[2, 0])
 
+    from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+
+    @require_pyoptsparse(optimizer='SNOPT')
     def test_eval_f_derivs_scalar(self):
         gd = dm.transcriptions.grid_data.GridData(num_segments=10, transcription='gauss-lobatto',
                                                   transcription_order=3)
@@ -172,6 +177,7 @@ class TestRKIntegrationComp(unittest.TestCase):
         f_theta_fd = (f_theta_fd - f_nom) / step
         assert_near_equal(f_theta.real[0, 2], f_theta_fd[0, 0], tolerance=1.0E-6)
 
+    @require_pyoptsparse(optimizer='SNOPT')
     def test_fwd_parameters(self):
         time_options = dm.phase.options.TimeOptionsDictionary()
 
@@ -226,6 +232,7 @@ class TestRKIntegrationComp(unittest.TestCase):
             cpd = p.check_partials(method='cs', compact_print=True)
             assert_check_partials(cpd)
 
+    @require_pyoptsparse(optimizer='SNOPT')
     def test_fwd_parameters_controls(self):
         gd = dm.transcriptions.grid_data.GridData(num_segments=5, transcription='gauss-lobatto',
                                                   transcription_order=5, compressed=True)

--- a/dymos/transcriptions/explicit_shooting/test/test_rk_integration_comp.py
+++ b/dymos/transcriptions/explicit_shooting/test/test_rk_integration_comp.py
@@ -8,6 +8,8 @@ from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 from dymos.transcriptions.explicit_shooting.rk_integration_comp import RKIntegrationComp
 
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+
 
 class SimpleODE(om.ExplicitComponent):
     """
@@ -39,7 +41,6 @@ class SimpleODE(om.ExplicitComponent):
         t = inputs['t']
         partials['x_dot', 't'] = -2*t
 
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 class TestRKIntegrationComp(unittest.TestCase):
 

--- a/dymos/transcriptions/explicit_shooting/test/test_rk_integration_comp.py
+++ b/dymos/transcriptions/explicit_shooting/test/test_rk_integration_comp.py
@@ -8,7 +8,7 @@ from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 from dymos.transcriptions.explicit_shooting.rk_integration_comp import RKIntegrationComp
 
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import require_pyoptsparse
 
 
 class SimpleODE(om.ExplicitComponent):
@@ -95,8 +95,6 @@ class TestRKIntegrationComp(unittest.TestCase):
         intg.eval_f(x, t, theta, f)
 
         assert_near_equal(f, x - t**2 + theta[2, 0])
-
-    from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
     @require_pyoptsparse(optimizer='SNOPT')
     def test_eval_f_derivs_scalar(self):

--- a/dymos/transcriptions/explicit_shooting/test/test_rk_integration_comp.py
+++ b/dymos/transcriptions/explicit_shooting/test/test_rk_integration_comp.py
@@ -44,7 +44,7 @@ class SimpleODE(om.ExplicitComponent):
 
 class TestRKIntegrationComp(unittest.TestCase):
 
-    @require_pyoptsparse(optimizer='SNOPT')
+    # @require_pyoptsparse(optimizer='SNOPT')
     def test_eval_f_scalar(self):
         gd = dm.transcriptions.grid_data.GridData(num_segments=10, transcription='gauss-lobatto',
                                                   transcription_order=3)
@@ -96,7 +96,7 @@ class TestRKIntegrationComp(unittest.TestCase):
 
         assert_near_equal(f, x - t**2 + theta[2, 0])
 
-    @require_pyoptsparse(optimizer='SNOPT')
+    # @require_pyoptsparse(optimizer='SNOPT')
     def test_eval_f_derivs_scalar(self):
         gd = dm.transcriptions.grid_data.GridData(num_segments=10, transcription='gauss-lobatto',
                                                   transcription_order=3)
@@ -176,7 +176,7 @@ class TestRKIntegrationComp(unittest.TestCase):
         f_theta_fd = (f_theta_fd - f_nom) / step
         assert_near_equal(f_theta.real[0, 2], f_theta_fd[0, 0], tolerance=1.0E-6)
 
-    @require_pyoptsparse(optimizer='SNOPT')
+    # @require_pyoptsparse(optimizer='SNOPT')
     def test_fwd_parameters(self):
         time_options = dm.phase.options.TimeOptionsDictionary()
 
@@ -231,7 +231,7 @@ class TestRKIntegrationComp(unittest.TestCase):
             cpd = p.check_partials(method='cs', compact_print=True)
             assert_check_partials(cpd)
 
-    @require_pyoptsparse(optimizer='SNOPT')
+    # @require_pyoptsparse(optimizer='SNOPT')
     def test_fwd_parameters_controls(self):
         gd = dm.transcriptions.grid_data.GridData(num_segments=5, transcription='gauss-lobatto',
                                                   transcription_order=5, compressed=True)

--- a/dymos/visualization/test/test_timeseries_plots.py
+++ b/dymos/visualization/test/test_timeseries_plots.py
@@ -15,9 +15,10 @@ from dymos.visualization.timeseries_plots import timeseries_plots
 
 
 @use_tempdirs
+@require_pyoptsparse(optimizer='SLSQP')
 class TestTimeSeriesPlotsBasics(unittest.TestCase):
 
-    @require_pyoptsparse(optimizer='SLSQP')
+    # @require_pyoptsparse(optimizer='SLSQP')
     def setUp(self):
         optimizer = 'SLSQP'
         num_segments = 8

--- a/dymos/visualization/test/test_timeseries_plots.py
+++ b/dymos/visualization/test/test_timeseries_plots.py
@@ -18,7 +18,6 @@ from dymos.visualization.timeseries_plots import timeseries_plots
 @require_pyoptsparse(optimizer='SLSQP')
 class TestTimeSeriesPlotsBasics(unittest.TestCase):
 
-    # @require_pyoptsparse(optimizer='SLSQP')
     def setUp(self):
         optimizer = 'SLSQP'
         num_segments = 8


### PR DESCRIPTION
### Summary

Added CI matrix entry for the case where pyoptsparse is not installed.

Also, moved 3 `require_pyoptsparse` decorators from `setUp` method to test class they were contained in.  Having them on `setUp` was causing problems because the `use_tempdir` decorator, which was also on these classes, was not being completely executed when pyoptsparse was not installed. The `require_pyoptsparse` decorator short-circuited the process and the test never was put back into the home directory. This causes failures in parts of the CI that followed. Specifically, the coveralls part of the CI expected to find the .coverage file in the home directory.

### Related Issues

- Resolves #682 

### Backwards incompatibilities

None

### New Dependencies

None
