### PR TITLE
Grid refinement error estimation fix for state rates not from ODE

### DIFF
--- a/dymos/grid_refinement/error_estimation.py
+++ b/dymos/grid_refinement/error_estimation.py
@@ -265,12 +265,12 @@ def eval_ode_on_grid(phase, transcription):
             src_units = phase.parameter_options[rate_source]['units']
             shape = phase.parameter_options[rate_source]['shape']
             f[name] = om.convert_units(param[rate_source], src_units, rate_units)
-            f[name] = np.broadcast_to(f[name], shape + (grid_data.num_nodes,))
+            f[name] = np.broadcast_to(f[name], (grid_data.num_nodes,) + shape)
         elif rate_source_class in {'ode'}:
-            f[name] = np.atleast_2d(p_refine.get_val(f'ode.{rate_source}', units=rate_units))
+            f[name] = p_refine.get_val(f'ode.{rate_source}', units=rate_units)
 
-        if options['shape'] == (1,):
-            f[name] = f[name].T
+        if len(f[name].shape) == 1:
+            f[name] = np.reshape(f[name], newshape=(f[name].shape[0], 1))
 
     return x, u, p, f
 

--- a/dymos/grid_refinement/test/test_grid_refinement.py
+++ b/dymos/grid_refinement/test/test_grid_refinement.py
@@ -1,0 +1,84 @@
+import unittest
+
+
+import numpy as np
+import openmdao.api as om
+import dymos as dm
+
+
+class _BrysonDenhamODE(om.ExplicitComponent):
+
+    def initialize(self):
+        self.options.declare('num_nodes', types=int)
+
+    def setup(self):
+        nn = self.options['num_nodes']
+
+        self.add_input('x', shape=(nn,), units='m')
+        self.add_input('v', shape=(nn,), units='m/s')
+        self.add_input('u', shape=(nn,), units='m/s**2')
+
+        self.add_output('J_dot', shape=(nn,), units='m**2/s**4',
+                        tags=['dymos.state_rate_source:J',
+                              'dymos.state_units:m**2/s**3'])
+
+        ar = np.arange(nn, dtype=int)
+
+        self.declare_partials(of='J_dot', wrt='u', rows=ar, cols=ar)
+
+    def compute(self, inputs, outputs):
+        u = inputs['u']
+        outputs['J_dot'] = 0.5 * u ** 2
+
+    def compute_partials(self, inputs, partials):
+        partials['J_dot', 'u'] = inputs['u']
+
+
+class TestGridRefinement(unittest.TestCase):
+
+    def test_refine_non_ode_rate_sources(self):
+        p = om.Problem()
+
+        p.driver = om.ScipyOptimizeDriver()
+        p.driver.declare_coloring()
+
+        traj = p.model.add_subsystem('traj', dm.Trajectory())
+        tx = transcription = dm.Radau(num_segments=5)
+        phase = traj.add_phase('phase0', dm.Phase(ode_class=_BrysonDenhamODE, transcription=tx))
+
+        #
+        # Set the variables
+        #
+        phase.set_time_options(fix_initial=True, fix_duration=True)
+
+        phase.add_state('x', fix_initial=True, fix_final=True, rate_source='v')
+        phase.add_state('v', fix_initial=True, fix_final=True, rate_source='u')
+        phase.add_state('J', fix_initial=True, fix_final=False)
+        phase.add_control('u', continuity=True, rate_continuity=False)
+
+        #
+        # Minimize time at the end of the phase
+        #
+        phase.add_objective('J', loc='final', ref=1)
+        phase.add_path_constraint('x', upper=1/9)
+
+        #
+        # Setup the Problem
+        #
+        p.setup()
+
+        #
+        # Set the initial values
+        #
+        p['traj.phase0.t_initial'] = 0.0
+        p['traj.phase0.t_duration'] = 1.0
+
+        p.set_val('traj.phase0.states:x', phase.interp('x', ys=[0, 0]))
+        p.set_val('traj.phase0.states:v', phase.interp('v', ys=[1, -1]))
+        p.set_val('traj.phase0.states:J', phase.interp('J', ys=[0, 1]))
+        p.set_val('traj.phase0.controls:u', np.sin(phase.interp('u', ys=[0, 0])))
+
+        #
+        # Solve for the optimal trajectory
+        #
+        dm.run_problem(p, run_driver=True, simulate=True, refine_iteration_limit=5)


### PR DESCRIPTION
### Summary

State rates taken from other states, controls, or parameters had the wrong (transposed) shape.
This has been fixed and error estimation follows the "nodes are the first index" convention that is in the rest of Dymos.

### Related Issues

- Resolves #701 

### Backwards incompatibilities

None

### New Dependencies

None
