### PR TITLE
Added ability to pass simulate_kwargs from run_problem.

### DIFF
--- a/dymos/grid_refinement/hp_adaptive/hp_adaptive.py
+++ b/dymos/grid_refinement/hp_adaptive/hp_adaptive.py
@@ -292,14 +292,14 @@ class HPAdaptive:
             algorithm.  refine_results is returned by check_error.  This method modifies it
             in place, adding the new_num_segments, new_order, and new_segment_ends.
         iter_number : int
-            Current iteration of the grid refinement.
+            Current iteration of the grid refinement. The first iteration is 1.
 
         Returns
         -------
         dict
             A dictionary of phase paths : phases which were refined.
         """
-        if iter_number == 0:
+        if iter_number == 1:
             self.refine_first_iter(refine_results)
             return
 

--- a/dymos/grid_refinement/ph_adaptive/ph_adaptive.py
+++ b/dymos/grid_refinement/ph_adaptive/ph_adaptive.py
@@ -60,7 +60,7 @@ class PHAdaptive:
             algorithm.  refine_results is returned by check_error.  This method modifies it
             in place, adding the new_num_segments, new_order, and new_segment_ends.
         iter_number : int
-            Iteration number of the grid refinement.
+            Iteration number of the grid refinement. The first iteration is 1.
 
         Returns
         -------

--- a/dymos/run_problem.py
+++ b/dymos/run_problem.py
@@ -13,7 +13,10 @@ def run_problem(problem, refine_method='hp', refine_iteration_limit=0, run_drive
                 solution_record_file='dymos_solution.db',
                 simulation_record_file='dymos_simulation.db',
                 make_plots=False,
-                plot_dir="plots"
+                plot_dir="plots",
+                case_prefix=None,
+                reset_iter_counts=True,
+                simulate_kwargs=None,
                 ):
     """
     A Dymos-specific interface to execute an OpenMDAO problem containing Dymos Trajectories or
@@ -43,6 +46,12 @@ def run_problem(problem, refine_method='hp', refine_iteration_limit=0, run_drive
         Path to case recorder file use to store results from simulation.
     plot_dir : str
         Path to directory for plot files.
+    simulate_kwargs : dict
+        A dictionary of argument: value pairs to be passed to simulate.  These are ignored when simulate=False.
+    case_prefix : str or None
+        Prefix to prepend to coordinates when recording.
+    reset_iter_counts : bool
+        If True and model has been run previously, reset all iteration counters.
     """
     if restart is not None:
         case = om.CaseReader(restart).get_case('final')
@@ -61,20 +70,27 @@ def run_problem(problem, refine_method='hp', refine_iteration_limit=0, run_drive
         load_case(problem, case)
 
     if run_driver:
-        failed = problem.run_driver()
-        _refine_iter(problem, refine_iteration_limit, refine_method)
+        failed = _refine_iter(problem, refine_iteration_limit, refine_method, case_prefix=case_prefix)
     else:
         failed = problem.run_model()
         if refine_iteration_limit > 0:
             warnings.warn("Refinement not performed. Set run_driver to True to perform refinement.")
 
-    problem.record('final')  # save case for potential restart
+    _case_prefix = '' if case_prefix is None else f'{case_prefix}_'
+    problem.record(f'{_case_prefix}final')  # save case for potential restart
     problem.cleanup()
 
     if simulate:
+        _simulate_kwargs = simulate_kwargs if simulate_kwargs is not None else {}
+        if 'record_file' in _simulate_kwargs:
+            raise ValueError('Key "record_file" was found in simulate_kwargs but should instead by provided by the '
+                             'argument "simulation_record_file".')
+        if 'case_prefix' in _simulate_kwargs:
+            raise ValueError('Key "case_prefix" was found in simulate_kwargs but should instead by provided by the '
+                             'argument "case_prefix", not part of the simulate_kwargs dictionary.')
         for subsys in problem.model.system_iter(include_self=True, recurse=True):
             if isinstance(subsys, Trajectory):
-                subsys.simulate(record_file=simulation_record_file)
+                subsys.simulate(record_file=simulation_record_file, case_prefix=case_prefix, **_simulate_kwargs)
 
     if make_plots:
         if simulate:

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -1012,7 +1012,8 @@ class Trajectory(om.Group):
         print('', file=outstream)
 
     def simulate(self, times_per_seg=10, method=_unspecified, atol=_unspecified, rtol=_unspecified,
-                 first_step=_unspecified, max_step=_unspecified, record_file=None):
+                 first_step=_unspecified, max_step=_unspecified, record_file=None, case_prefix=None,
+                 reset_iter_counts=True):
         """
         Simulate the Trajectory using scipy.integrate.solve_ivp.
 
@@ -1034,6 +1035,10 @@ class Trajectory(om.Group):
         record_file : str or None
             If a string, the file to which the result of the simulation will be saved.
             If None, no record of the simulation will be saved.
+        case_prefix : str or None
+            Prefix to prepend to coordinates when recording.
+        reset_iter_counts : bool
+            If True and model has been run previously, reset all iteration counters.
 
         Returns
         -------
@@ -1095,10 +1100,11 @@ class Trajectory(om.Group):
                                              skip_params=skip_params)
 
         print('\nSimulating trajectory {0}'.format(self.pathname))
-        sim_prob.run_model()
+        sim_prob.run_model(case_prefix=case_prefix, reset_iter_counts=reset_iter_counts)
         print('Done simulating trajectory {0}'.format(self.pathname))
         if record_file:
-            sim_prob.record('final')
+            _case_prefix = '' if case_prefix is None else f'{case_prefix}_'
+            sim_prob.record(f'{_case_prefix}final')
         sim_prob.cleanup()
 
         return sim_prob


### PR DESCRIPTION


### Summary

- Added ability to pass a case_prefix via run_problem.
- Added ability to pass reset_iter_count from run_problem.
- During grid refinement, case_prefix includes the refinement method and refinement iteration.
- Refinement iteration now starts with 1, instead of 0.  When refinement is enabled, `{refine_method}_0` will be
tacked onto the case prefix.
- `case_prefix` will be prepended to the `final` case recorded in `dymos_solution.db` and `dymos_simulation.db`.

### Related Issues

- Resolves #718

### Backwards incompatibilities

Post processing scripts that analyze grid refinement could see different behavior since the first iteration is now reported as Iteration 1, but in general users should see no difference.

### New Dependencies

None
