### PR TITLE
fixed mpi hang caused by constraint_report

### DIFF
--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -773,7 +773,7 @@ class Trajectory(om.Group):
                     _print_on_rank(f'{indent * 2}{prefixed_a:<{padding_a}s} [{loc_a}{str_fixed_a}] ==  '
                                    f'{prefixed_b:<{padding_b}s} [{loc_b}{str_fixed_b}]')
 
-        _print_on_rank('\n* : This quantity is fixed or is an input.\n')
+        _print_on_rank('\n* : Value is fixed or is an input.\n')
 
     def configure(self):
         """


### PR DESCRIPTION
The constraint report calls get_io_metadata internally and that potentially makes a collective MPI call.  This fixes a hang caused by only rank 0 making the collective call.  This is kind of a quick and dirty fix.  I've added a fairly general purpose `get_print_func` function on my current OpenMDAO branch, but I didn't want to make this dependent on that so it doesn't use it.  After that makes it to OpenMDAO/master, we may want to go through dymos and make the handling of this situation wherever it occurs to be more consistent by using the `get_print_func` function.