### PR TITLE
USatm1976Comp now accepts altitude as either geopotential or geodetic

### DIFF
--- a/docs/dymos_book/examples/min_time_climb/min_time_climb.ipynb
+++ b/docs/dymos_book/examples/min_time_climb/min_time_climb.ipynb
@@ -128,7 +128,7 @@
     "        nn = self.options['num_nodes']\n",
     "\n",
     "        self.add_subsystem(name='atmos',\n",
-    "                           subsys=USatm1976Comp(num_nodes=nn),\n",
+    "                           subsys=USatm1976Comp(num_nodes=nn, h_def='geodetic'),\n",
     "                           promotes_inputs=['h'])\n",
     "\n",
     "        self.add_subsystem(name='aero',\n",

--- a/dymos/examples/min_time_climb/min_time_climb_ode.py
+++ b/dymos/examples/min_time_climb/min_time_climb_ode.py
@@ -14,7 +14,7 @@ class MinTimeClimbODE(om.Group):
         nn = self.options['num_nodes']
 
         self.add_subsystem(name='atmos',
-                           subsys=USatm1976Comp(num_nodes=nn),
+                           subsys=USatm1976Comp(num_nodes=nn, h_def='geodetic'),
                            promotes_inputs=['h'])
 
         self.add_subsystem(name='aero',

--- a/dymos/models/atmosphere/atmos_1976.py
+++ b/dymos/models/atmosphere/atmos_1976.py
@@ -1237,6 +1237,8 @@ class USatm1976Comp(om.ExplicitComponent):
     Component model for the United States standard atmosphere 1976 tables.
 
     Data for the model was obtained from http://www.digitaldutch.com/atmoscalc/index.htm.
+    Based on the original model documented in https://www.ngdc.noaa.gov/stp/space-weather/online-publications/
+    miscellaneous/us-standard-atmosphere-1976/us-standard-atmosphere_st76-1562_noaa.pdf
 
     Parameters
     ----------
@@ -1255,11 +1257,24 @@ class USatm1976Comp(om.ExplicitComponent):
         gas_c = 1716.49  # Gas constant (ft lbf)/(slug R)
         self._K = gamma * gas_c
 
+        self.options.declare('h_def', values=('geopotential', 'geodetic'), default='geopotential',
+                             desc='The definition of altitude provided as input to the component.  If "geodetic",'
+                                  'it will be converted to geopotential based on Equation 19 in the original standard.')
+
     def setup(self):
         """
         Add component inputs and outputs.
         """
         nn = self.options['num_nodes']
+
+        if self.options['h_def'] == 'geodetic':
+            R0 = 6_356_766 / 0.3048  # Value of R0 from the original standard
+            self._h = lambda z: z / (R0 + z) * R0
+            self._dh_dz = lambda z: (R0 / (R0 + z)) ** 2
+        else:
+            self._h = lambda z: z
+            self._dh_dz = lambda z: np.ones_like(z)
+
         self.add_input('h', val=1. * np.ones(nn), units='ft')
 
         self.add_output('temp', val=1. * np.ones(nn), units='degR')
@@ -1269,7 +1284,7 @@ class USatm1976Comp(om.ExplicitComponent):
         self.add_output('drhos_dh', val=1. * np.ones(nn), units='slug/ft**4')
         self.add_output('sos', val=1 * np.ones(nn), units='ft/s')
 
-        arange = np.arange(nn)
+        arange = np.arange(nn, dtype=int)
         self.declare_partials(['temp', 'pres', 'rho', 'viscosity', 'drhos_dh', 'sos'], 'h',
                               rows=arange, cols=arange)
 
@@ -1285,7 +1300,7 @@ class USatm1976Comp(om.ExplicitComponent):
             `Vector` containing outputs.
         """
         table_points = USatm1976Data.alt
-        h = inputs['h']
+        h = self._h(inputs['h'])
 
         idx = np.searchsorted(table_points, h, side='left')
         h_bin_left = np.hstack((table_points[0], table_points))
@@ -1318,7 +1333,8 @@ class USatm1976Comp(om.ExplicitComponent):
             Subjac components written to partials[output_name, input_name].
         """
         table_points = USatm1976Data.alt
-        h = inputs['h']
+        h = self._h(inputs['h'])
+        dh_dz = self._dh_dz(inputs['h'])
 
         idx = np.searchsorted(table_points, h, side='left')
         h_index = np.hstack((table_points[0], table_points))
@@ -1341,11 +1357,12 @@ class USatm1976Comp(om.ExplicitComponent):
         d2rho_dh2 = coeffs[:, 1] + dx * (2.0 * coeffs[:, 2] + 3.0 * coeffs[:, 3] * dx)
 
         partials['temp', 'h'] = dT_dh.ravel()
-        partials['pres', 'h'] = dP_dh.ravel()
-        partials['rho', 'h'] = drho_dh.ravel()
-        partials['viscosity', 'h'] = dvisc_dh.ravel()
-        partials['drhos_dh', 'h'] = d2rho_dh2.ravel()
-        partials['sos', 'h'][...] = 0.5 / np.sqrt(self._K * T) * partials['temp', 'h'] * self._K
+        partials['pres', 'h'] = dP_dh.ravel() * dh_dz
+        partials['rho', 'h'] = drho_dh.ravel() * dh_dz
+        partials['viscosity', 'h'] = dvisc_dh.ravel() * dh_dz
+        partials['drhos_dh', 'h'] = d2rho_dh2.ravel() * dh_dz ** 2
+        partials['sos', 'h'][...] = (0.5 / np.sqrt(self._K * T) * partials['temp', 'h'] * self._K) * dh_dz
+        partials['temp', 'h'] = partials['temp', 'h'] * dh_dz
 
 
 if __name__ == "__main__":

--- a/dymos/models/atmosphere/test/test_atmos.py
+++ b/dymos/models/atmosphere/test/test_atmos.py
@@ -9,7 +9,7 @@ from dymos.models.atmosphere.atmos_1976 import USatm1976Comp, USatm1976Data
 
 class TestAtmosphere(unittest.TestCase):
 
-    def test_temperature_comp(self):
+    def test_atmos_comp_geopotential(self):
         n = USatm1976Data.alt.size
 
         p = om.Problem(model=om.Group())
@@ -28,12 +28,45 @@ class TestAtmosphere(unittest.TestCase):
         rho = p.get_val('atmos.rho', units='slug/ft**3')
         sos = p.get_val('atmos.sos', units='ft/s')
 
-        assert_near_equal(T, USatm1976Data.T, tolerance=1.0E-2)
-        assert_near_equal(P, USatm1976Data.P, tolerance=1.0E-2)
-        assert_near_equal(rho, USatm1976Data.rho, tolerance=1.0E-2)
-        assert_near_equal(sos, USatm1976Data.a, tolerance=1.0E-2)
+        assert_near_equal(T, USatm1976Data.T, tolerance=1.0E-4)
+        assert_near_equal(P, USatm1976Data.P, tolerance=1.0E-4)
+        assert_near_equal(rho, USatm1976Data.rho, tolerance=1.0E-4)
+        assert_near_equal(sos, USatm1976Data.a, tolerance=1.0E-4)
 
         cpd = p.check_partials(method='cs', out_stream=None)
+        assert_check_partials(cpd)
+
+    def test_atmos_comp_geodetic(self):
+        n = USatm1976Data.alt.size
+
+        p = om.Problem(model=om.Group())
+
+        ivc = p.model.add_subsystem('ivc', subsys=om.IndepVarComp(), promotes_outputs=['*'])
+        ivc.add_output(name='alt', val=USatm1976Data.alt, units='ft')
+
+        p.model.add_subsystem('atmos', subsys=USatm1976Comp(num_nodes=n, h_def='geodetic'))
+        p.model.connect('alt', 'atmos.h')
+
+        p.setup(force_alloc_complex=True)
+
+        h = USatm1976Data.alt * 0.3048  # altitude data in meters
+        R0 = 6_356_766  # US 1976 std atm R0 in m
+        p.set_val('alt', R0 / (R0 - h) * h, units='m')  # US 1976 std atm geopotential altitude to geodetic (m)
+
+        p.run_model()
+
+        T = p.get_val('atmos.temp', units='degR')
+        P = p.get_val('atmos.pres', units='psi')
+        rho = p.get_val('atmos.rho', units='slug/ft**3')
+        sos = p.get_val('atmos.sos', units='ft/s')
+
+        assert_near_equal(T, USatm1976Data.T, tolerance=1.0E-4)
+        assert_near_equal(P, USatm1976Data.P, tolerance=1.0E-4)
+        assert_near_equal(rho, USatm1976Data.rho, tolerance=1.0E-4)
+        assert_near_equal(sos, USatm1976Data.a, tolerance=1.0E-4)
+
+        with np.printoptions(linewidth=100000):
+            cpd = p.check_partials(method='cs')
         assert_check_partials(cpd)
 
 


### PR DESCRIPTION
### Summary

The atmosphere component included in dymos has started to be used more widely.  In order to make it more accurate, it will now convert the input (geodetic) altitude to the geopotential altitude used for interpolating the atmosphere table.

In the future the default altitude type will be switched to geodetic, but for now the behavior remains the same by default.
Users can enable the geodetic input conversion by giving `USatm1976Comp` the `h_def='geodetic'` option.

### Related Issues

- Resolves #725 

### Backwards incompatibilities

None

### New Dependencies

None
