### PR TITLE
Updated optimizer settings to improve convergence of the racecar example.

### DIFF
--- a/benchmark/benchmark_racecar.py
+++ b/benchmark/benchmark_racecar.py
@@ -129,9 +129,11 @@ def _run_racecar_problem(transcription, timeseries=False):
     p.driver.opt_settings['compl_inf_tol'] = 1e-3
     p.driver.opt_settings['acceptable_iter'] = 0
     p.driver.opt_settings['tol'] = 1e-3
-    p.driver.opt_settings['nlp_scaling_method'] = 'none'
     p.driver.opt_settings['print_level'] = 5
     p.driver.opt_settings['nlp_scaling_method'] = 'gradient-based'  # for faster convergence
+    p.driver.opt_settings['alpha_for_y'] = 'safer-min-dual-infeas'
+    p.driver.opt_settings['mu_strategy'] = 'monotone'
+    p.driver.opt_settings['bound_mult_init_method'] = 'mu-based'
 
     # Allow OpenMDAO to automatically determine our sparsity pattern.
     # Doing so can significant speed up the execution of Dymos.
@@ -182,3 +184,7 @@ class BenchmarkRacecar(unittest.TestCase):
 
     def benchmark_radau_timeseries(self):
         _run_racecar_problem(dm.Radau, timeseries=True)
+
+
+if __name__ == '__main__':
+    _run_racecar_problem(dm.GaussLobatto, timeseries=False)

--- a/docs/dymos_book/examples/racecar/racecar.ipynb
+++ b/docs/dymos_book/examples/racecar/racecar.ipynb
@@ -380,6 +380,7 @@
     "p.driver.opt_settings['nlp_scaling_method'] = 'gradient-based'  # for faster convergence\n",
     "p.driver.opt_settings['alpha_for_y'] = 'safer-min-dual-infeas'\n",
     "p.driver.opt_settings['mu_strategy'] = 'monotone'\n",
+    "p.driver.opt_settings['bound_mult_init_method'] = 'mu-based'\n",
     "p.driver.options['print_results'] = False\n",
     "\n",
     "# Allow OpenMDAO to automatically determine our sparsity pattern.\n",

--- a/dymos/examples/racecar/doc/test_doc_racecar.py
+++ b/dymos/examples/racecar/doc/test_doc_racecar.py
@@ -141,6 +141,7 @@ class TestRaceCarForDocs(unittest.TestCase):
         p.driver.opt_settings['nlp_scaling_method'] = 'gradient-based'  # for faster convergence
         p.driver.opt_settings['alpha_for_y'] = 'safer-min-dual-infeas'
         p.driver.opt_settings['mu_strategy'] = 'monotone'
+        p.driver.opt_settings['bound_mult_init_method'] = 'mu-based'
         # p.driver.options['print_results'] = False
 
         # Allow OpenMDAO to automatically determine our sparsity pattern.


### PR DESCRIPTION
### Summary

The racecar example was not converging cleanly, exiting at the accepted solution but after a failure in the restoration phase.
Adding IPOPT's `bound_mult_init_method = 'mu-based'` seems to have resolved the issue.

### Related Issues

- Resolves #750

### Backwards incompatibilities

None

### New Dependencies

None
