### PR TITLE
Updated assert_timeseriea_near_equal for more general use.

### DIFF
--- a/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_parameter.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_parameter.py
@@ -153,10 +153,10 @@ class TestBrachistochroneIntegratedParameter(unittest.TestCase):
         v_sim = sim_out.get_val('phase0.timeseries.states:v')
         theta_sim = sim_out.get_val('phase0.timeseries.states:theta')
 
-        assert_timeseries_near_equal(t_sol, x_sol, t_sim, x_sim, tolerance=5.0E-3)
-        assert_timeseries_near_equal(t_sol, y_sol, t_sim, y_sim, tolerance=5.0E-3)
-        assert_timeseries_near_equal(t_sol, v_sol, t_sim, v_sim, tolerance=5.0E-3)
-        assert_timeseries_near_equal(t_sol, theta_sol, t_sim, theta_sim, tolerance=5.0E-3)
+        assert_timeseries_near_equal(t_sol, x_sol, t_sim, x_sim, rtol=5.0E-3, atol=5.0E-3)
+        assert_timeseries_near_equal(t_sol, y_sol, t_sim, y_sim, rtol=5.0E-3, atol=5.0E-3)
+        assert_timeseries_near_equal(t_sol, v_sol, t_sim, v_sim, rtol=5.0E-3, atol=5.0E-3)
+        assert_timeseries_near_equal(t_sol, theta_sol, t_sim, theta_sim, rtol=5.0E-3, atol=5.0E-3)
 
     @require_pyoptsparse(optimizer='SLSQP')
     def test_brachistochrone_integrated_parameter_radau_ps(self):
@@ -223,10 +223,10 @@ class TestBrachistochroneIntegratedParameter(unittest.TestCase):
         v_sim = sim_out.get_val('phase0.timeseries.states:v')
         theta_sim = sim_out.get_val('phase0.timeseries.states:theta')
 
-        assert_timeseries_near_equal(t_sol, x_sol, t_sim, x_sim, tolerance=1.0E-3)
-        assert_timeseries_near_equal(t_sol, y_sol, t_sim, y_sim, tolerance=1.0E-3)
-        assert_timeseries_near_equal(t_sol, v_sol, t_sim, v_sim, tolerance=1.0E-3)
-        assert_timeseries_near_equal(t_sol, theta_sol, t_sim, theta_sim, tolerance=1.0E-3)
+        assert_timeseries_near_equal(t_sol, x_sol, t_sim, x_sim, rtol=1.0E-3, atol=1.0E-3)
+        assert_timeseries_near_equal(t_sol, y_sol, t_sim, y_sim, rtol=1.0E-3, atol=1.0E-3)
+        assert_timeseries_near_equal(t_sol, v_sol, t_sim, v_sim, rtol=1.0E-3, atol=1.0E-3)
+        assert_timeseries_near_equal(t_sol, theta_sol, t_sim, theta_sim, rtol=1.0E-3, atol=1.0E-3)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/examples/brachistochrone/test/test_state_rate_introspection.py
+++ b/dymos/examples/brachistochrone/test/test_state_rate_introspection.py
@@ -108,11 +108,11 @@ class TestIntegrateControl(unittest.TestCase):
         theta_rate_sol = sol.get_val('traj.phase0.timeseries.controls:theta_rate')
         theta_rate_sim = sim.get_val('traj.phase0.timeseries.controls:theta_rate')
 
-        assert_timeseries_near_equal(t_sol, x_sol, t_sim, x_sim, tolerance=1.0E-3)
-        assert_timeseries_near_equal(t_sol, y_sol, t_sim, y_sim, tolerance=1.0E-3)
-        assert_timeseries_near_equal(t_sol, v_sol, t_sim, v_sim, tolerance=1.0E-3)
-        assert_timeseries_near_equal(t_sol, int_theta_sol, t_sim, int_theta_sim, tolerance=1.0E-3)
-        assert_timeseries_near_equal(t_sol, theta_rate_sol, t_sim, theta_rate_sim, tolerance=1.0E-3)
+        assert_timeseries_near_equal(t_sol, x_sol, t_sim, x_sim, rtol=1.0E-2, atol=1.0E-2)
+        assert_timeseries_near_equal(t_sol, y_sol, t_sim, y_sim, rtol=1.0E-2, atol=1.0E-2)
+        assert_timeseries_near_equal(t_sol, v_sol, t_sim, v_sim, rtol=1.0E-2, atol=1.0E-2)
+        assert_timeseries_near_equal(t_sol, int_theta_sol, t_sim, int_theta_sim, rtol=1.0E-2, atol=1.0E-2)
+        assert_timeseries_near_equal(t_sol, theta_rate_sol, t_sim, theta_rate_sim, rtol=1.0E-2, atol=1.0E-2)
 
     def _test_integrate_control_rate(self, transcription):
 
@@ -213,10 +213,10 @@ class TestIntegrateControl(unittest.TestCase):
         theta_sol = sol.get_val('traj.phase0.timeseries.controls:theta')
         theta_sim = sim.get_val('traj.phase0.timeseries.controls:theta')
 
-        assert_timeseries_near_equal(t_sol, x_sol, t_sim, x_sim, tolerance=1.0E-3)
-        assert_timeseries_near_equal(t_sol, y_sol, t_sim, y_sim, tolerance=1.0E-3)
-        assert_timeseries_near_equal(t_sol, v_sol, t_sim, v_sim, tolerance=1.0E-3)
-        assert_timeseries_near_equal(t_sol, int_theta_sol, t_sim, int_theta_sim, tolerance=1.0E-3)
+        assert_timeseries_near_equal(t_sol, x_sol, t_sim, x_sim, rtol=1.0E-2, atol=1.0E-2)
+        assert_timeseries_near_equal(t_sol, y_sol, t_sim, y_sim, rtol=1.0E-2, atol=1.0E-2)
+        assert_timeseries_near_equal(t_sol, v_sol, t_sim, v_sim, rtol=1.0E-2, atol=1.0E-2)
+        assert_timeseries_near_equal(t_sol, int_theta_sol, t_sim, int_theta_sim, rtol=1.0E-2, atol=1.0E-2)
 
         assert_timeseries_near_equal(t_sol, int_theta_sol, t_sol, theta_sol, tolerance=1.0E-2)
         assert_timeseries_near_equal(t_sim, int_theta_sim, t_sim, theta_sim, tolerance=1.0E-2)
@@ -451,9 +451,9 @@ class TestIntegratePolynomialControl(unittest.TestCase):
         theta_rate_sol = sol.get_val('traj.phase0.timeseries.polynomial_controls:theta_rate')
         theta_rate_sim = sim.get_val('traj.phase0.timeseries.polynomial_controls:theta_rate')
 
-        assert_timeseries_near_equal(t_sol, x_sol, t_sim, x_sim, tolerance=1.0E-3)
-        assert_timeseries_near_equal(t_sol, y_sol, t_sim, y_sim, tolerance=1.0E-3)
-        assert_timeseries_near_equal(t_sol, v_sol, t_sim, v_sim, tolerance=1.0E-3)
+        assert_timeseries_near_equal(t_sol, x_sol, t_sim, x_sim, rtol=1.0E-2, atol=1.0E-2)
+        assert_timeseries_near_equal(t_sol, y_sol, t_sim, y_sim, rtol=1.0E-2, atol=1.0E-2)
+        assert_timeseries_near_equal(t_sol, v_sol, t_sim, v_sim, rtol=1.0E-2, atol=1.0E-2)
         assert_timeseries_near_equal(t_sol, int_theta_sol, t_sim, int_theta_sim, tolerance=1.0E-2)
         assert_timeseries_near_equal(t_sol, theta_rate_sol, t_sim, theta_rate_sim, tolerance=1.0E-2)
 
@@ -556,14 +556,14 @@ class TestIntegratePolynomialControl(unittest.TestCase):
         theta_sol = sol.get_val('traj.phase0.timeseries.polynomial_controls:theta')
         theta_sim = sim.get_val('traj.phase0.timeseries.polynomial_controls:theta')
 
-        assert_timeseries_near_equal(t_sol, x_sol, t_sim, x_sim, tolerance=1.0E-3)
-        assert_timeseries_near_equal(t_sol, y_sol, t_sim, y_sim, tolerance=1.0E-3)
-        assert_timeseries_near_equal(t_sol, v_sol, t_sim, v_sim, tolerance=1.0E-3)
+        assert_timeseries_near_equal(t_sol, x_sol, t_sim, x_sim, rtol=1.0E-3, atol=1.0E-3)
+        assert_timeseries_near_equal(t_sol, y_sol, t_sim, y_sim, rtol=1.0E-3, atol=1.0E-3)
+        assert_timeseries_near_equal(t_sol, v_sol, t_sim, v_sim, rtol=1.0E-3, atol=1.0E-3)
         assert_timeseries_near_equal(t_sol, int_theta_sol, t_sim, int_theta_sim,
-                                     tolerance=1.0E-3)
+                                     rtol=1.0E-3, atol=1.0E-3)
 
-        assert_timeseries_near_equal(t_sol, int_theta_sol, t_sol, theta_sol, tolerance=1.0E-3)
-        # assert_timeseries_near_equal(t_sol, int_theta_sim, t_sol, theta_sim, tolerance=1.0E-3)
+        assert_timeseries_near_equal(t_sol, int_theta_sol, t_sol, theta_sol, rtol=1.0E-3, atol=1.0E-3)
+        # assert_timeseries_near_equal(t_sol, int_theta_sim, t_sol, theta_sim, rtol=1.0E-3, atol=1.0E-3)
 
     @require_pyoptsparse(optimizer='SLSQP')
     def _test_integrate_polynomial_control_rate2(self, transcription):

--- a/dymos/examples/double_integrator/test/test_double_integrator_timeseries_units.py
+++ b/dymos/examples/double_integrator/test/test_double_integrator_timeseries_units.py
@@ -88,7 +88,7 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         for var in ['states:x', 'states:v', 'state_rates:x', 'state_rates:v', 'controls:u']:
             sol = sol_case.get_val(f'traj.phase0.timeseries.{var}')
             sim = sim_case.get_val(f'traj.phase0.timeseries.{var}')
-            assert_timeseries_near_equal(t_sol, sol, t_sim, sim, tolerance=1.0E-3)
+            assert_timeseries_near_equal(t_sol, sol, t_sim, sim, rtol=1.0E-2, atol=1.0E-3)
 
     def test_timeseries_units_radau(self):
         double_integrator_direct_collocation(dm.Radau, compressed=True)
@@ -102,4 +102,4 @@ class TestDoubleIntegratorExample(unittest.TestCase):
         for var in ['states:x', 'states:v', 'state_rates:x']:
             sol = sol_case.get_val(f'traj.phase0.timeseries.{var}')
             sim = sim_case.get_val(f'traj.phase0.timeseries.{var}')
-            assert_timeseries_near_equal(t_sol, sol, t_sim, sim, tolerance=1.0E-3)
+            assert_timeseries_near_equal(t_sol, sol, t_sim, sim, rtol=1.0E-2, atol=1.0E-3)

--- a/dymos/examples/finite_burn_orbit_raise/test/test_multi_phase_restart.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_multi_phase_restart.py
@@ -166,8 +166,8 @@ def two_burn_orbit_raise_problem(transcription='gauss-lobatto', optimizer='SLSQP
         p.driver.opt_settings['nlp_scaling_method'] = 'gradient-based'
         p.driver.opt_settings['print_level'] = 4
         p.driver.opt_settings['linear_solver'] = 'mumps'
-        p.driver.opt_settings['mu_strategy'] = 'adaptive'
-        # p.driver.opt_settings['derivative_test'] = 'first-order'
+        p.driver.opt_settings['mu_strategy'] = 'monotone'
+        p.driver.opt_settings['mu_init'] = 1.0E-3
     p.driver.declare_coloring()
 
     traj = make_traj(transcription=transcription, transcription_order=transcription_order,

--- a/dymos/test/test_testing_utils.py
+++ b/dymos/test/test_testing_utils.py
@@ -197,29 +197,37 @@ class TestAssertTimeseriesNearEqual(unittest.TestCase):
         x1 = np.atleast_2d(np.sin(t1)).T
         x2 = np.atleast_2d(np.sin(t2)).T
 
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaises(AssertionError) as e:
             assert_timeseries_near_equal(t1, x1, t2, x2)
 
-        expected = "The initial time of the two timeseries is not the same. t1[0]=0.0  " \
-                   "t2[0]=5.0  difference: 5.0"
+        expected = 'The initial value of time in the two timeseries differ by more than the allowable tolerance.\n' \
+                   't1_initial: 0.0  t2_initial: 5.0\n' \
+                   'Pass argument `check_time=False` to ignore this error and only compare the values in the two ' \
+                   'timeseries in the overlapping region of time.'
 
         self.assertEqual(str(e.exception), expected)
 
+        assert_timeseries_near_equal(t1, x1, t2, x2, check_time=False)
+
     def test_assert_different_final_time(self):
 
-        t1 = np.linspace(0, 100, 50)
-        t2 = np.linspace(0, 102, 50)
+        t1 = np.linspace(0, 3.0, 50)
+        t2 = np.linspace(0, 3.14, 50)
 
         x1 = np.atleast_2d(np.sin(t1)).T
         x2 = np.atleast_2d(np.sin(t2)).T
 
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaises(AssertionError) as e:
             assert_timeseries_near_equal(t1, x1, t2, x2)
 
-        expected = "The final time of the two timeseries is not the same. t1[0]=100.0  " \
-                   "t2[0]=102.0  difference: 2.0"
+        expected = 'The final value of time in the two timeseries differ by more than the allowable tolerance.\n' \
+                   't1_final: 3.0  t2_final: 3.14\n' \
+                   'Pass argument `check_time=False` to ignore this error and only compare the values in the two ' \
+                   'timeseries in the overlapping region of time.'
 
         self.assertEqual(str(e.exception), expected)
+
+        assert_timeseries_near_equal(t1, x1, t2, x2, check_time=False, tolerance=1.0E-6)
 
     def test_assert_different_values(self):
 

--- a/dymos/test/test_testing_utils.py
+++ b/dymos/test/test_testing_utils.py
@@ -230,7 +230,7 @@ class TestAssertTimeseriesNearEqual(unittest.TestCase):
 
         assert_timeseries_near_equal(t1, x1, t2, x2, assert_time=False, tolerance=1.0E-2)
 
-    def test_assert_different_values(self):
+    def test_assert_different_values_rel_err(self):
 
         t1 = t2 = np.linspace(0, 3.14159, 50)
 
@@ -240,13 +240,29 @@ class TestAssertTimeseriesNearEqual(unittest.TestCase):
         with self.assertRaises(AssertionError) as e:
             assert_timeseries_near_equal(t1, x1, t2, x2, atol=1.0E-6, rtol=1.0E-6)
 
-        expected = 'The two timeseries do not agree to the specified tolerance (atol: 1e-06 rtol: 1e-06).\n' \
-                   'The largest discrepancy is:\n' \
-                   'time: 2.372221\n' \
-                   'x_nom: [0.695684]\n' \
-                   'x_check (interpolated): [-0.718348]\n' \
-                   'rel err: [2.032578]\n' \
-                   'abs err: [1.414032]'
+        expected = 'Relative error between timeseries exceeded tolerance (0.000001)\n' \
+                   'time: 3.077476\n' \
+                   'rel_err: [376848.99756974]\n' \
+                   'x_nom: [2.65358979e-06]\n' \
+                   'x_check (interpolated): [-1.]'
+
+        self.assertEqual(str(e.exception), expected)
+
+    def test_assert_different_values_abs_err(self):
+
+        t1 = t2 = np.linspace(0, 3.14159, 50)
+
+        x2 = np.atleast_2d(np.sin(t2)).T
+        x1 = np.zeros_like(x2)
+
+        with self.assertRaises(AssertionError) as e:
+            assert_timeseries_near_equal(t1, x1, t2, x2, atol=1.0E-3, rtol=1E-6)
+
+        expected = 'Absolute error between timeseries exceeded tolerance (0.001000)\n' \
+                   'time: 1.602852\n' \
+                   'abs_err: [0.99948626]\n' \
+                   'x_nom: [0.]\n' \
+                   'x_check (interpolated): [0.99948626]'
 
         self.assertEqual(str(e.exception), expected)
 

--- a/dymos/test/test_testing_utils.py
+++ b/dymos/test/test_testing_utils.py
@@ -191,8 +191,8 @@ class TestAssertTimeseriesNearEqual(unittest.TestCase):
 
     def test_assert_different_initial_time(self):
 
-        t1 = np.linspace(0, 100, 50)
-        t2 = np.linspace(5, 100, 50)
+        t1 = np.linspace(0, 3.14, 50)
+        t2 = np.linspace(0.5, 3.14, 50)
 
         x1 = np.atleast_2d(np.sin(t1)).T
         x2 = np.atleast_2d(np.sin(t2)).T
@@ -201,7 +201,7 @@ class TestAssertTimeseriesNearEqual(unittest.TestCase):
             assert_timeseries_near_equal(t1, x1, t2, x2)
 
         expected = 'The initial value of time in the two timeseries differ by more than the allowable tolerance.\n' \
-                   't1_initial: 0.0  t2_initial: 5.0\n' \
+                   't1_initial: 0.0  t2_initial: 0.5\n' \
                    'Pass argument `check_time=False` to ignore this error and only compare the values in the two ' \
                    'timeseries in the overlapping region of time.'
 
@@ -237,9 +237,9 @@ class TestAssertTimeseriesNearEqual(unittest.TestCase):
         x2 = np.atleast_2d(np.cos(t2)).T
 
         with self.assertRaises(AssertionError) as e:
-            assert_timeseries_near_equal(t1, x1, t2, x2)
+            assert_timeseries_near_equal(t1, x1, t2, x2, atol=1.0E-6, rtol=1.0E-6)
 
-        expected = 'The two timeseries do not agree to the specified tolerance (atol: 0.01 rtol: 0.01).\n' \
+        expected = 'The two timeseries do not agree to the specified tolerance (atol: 1e-06 rtol: 1e-06).\n' \
                    'The largest discrepancy is:\n' \
                    'time: 2.372221\n' \
                    'x1: [0.695684]\n' \

--- a/dymos/test/test_testing_utils.py
+++ b/dymos/test/test_testing_utils.py
@@ -227,15 +227,24 @@ class TestAssertTimeseriesNearEqual(unittest.TestCase):
 
         self.assertEqual(str(e.exception), expected)
 
-        assert_timeseries_near_equal(t1, x1, t2, x2, check_time=False, tolerance=1.0E-6)
+        assert_timeseries_near_equal(t1, x1, t2, x2, check_time=False, tolerance=1.0E-2)
 
     def test_assert_different_values(self):
 
-        t1 = np.linspace(0, 100, 50)
-        t2 = np.linspace(0, 100, 50)
+        t1 = t2 = np.linspace(0, 3.14159, 50)
 
         x1 = np.atleast_2d(np.sin(t1)).T
         x2 = np.atleast_2d(np.cos(t2)).T
 
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaises(AssertionError) as e:
             assert_timeseries_near_equal(t1, x1, t2, x2)
+
+        expected = 'The two timeseries do not agree to the specified tolerance (atol: 0.01 rtol: 0.01).\n' \
+                   'The largest discrepancy is:\n' \
+                   'time: 2.372221\n' \
+                   'x1: [0.695684]\n' \
+                   'x2: [-0.718348]\n' \
+                   'rel err: [2.032578]\n' \
+                   'abs err: [1.414032]'
+
+        self.assertEqual(str(e.exception), expected)

--- a/dymos/utils/testing_utils.py
+++ b/dymos/utils/testing_utils.py
@@ -213,20 +213,21 @@ def assert_timeseries_near_equal(t1, x1, t2, x2, tolerance=None, atol=1.0E-2, rt
     num_points = shape_to_len(t_check.shape)
     x_interp = np.reshape(interp(t_check), newshape=(num_points,) + shape1)
 
-    # assert_array_less(np.abs(x_check - x_interp), rtol * np.abs(x_check) + atol, verbose=False)
-
     error_calc = np.abs(x_check - x_interp) < rtol * np.abs(x_check) + atol
 
-    if not error_calc.any():
+    if not error_calc.all():
         max_err_idx = np.argmax(np.abs(x_check - x_interp) - rtol * np.abs(x_check) + atol)
         x1_at_err = x_interp[max_err_idx] if nn1 > nn2 else x_check[max_err_idx]
         x2_at_err = x_check[max_err_idx] if nn1 > nn2 else x_interp[max_err_idx]
+        abs_err = np.abs(x_check[max_err_idx] - x_interp[max_err_idx])
+        rel_err = abs_err / np.abs(x_check[max_err_idx])
+
         msg = f'The two timeseries do not agree to the specified tolerance (atol: {atol} rtol: {rtol}).\n' \
               'The largest discrepancy is:\n' \
-              f'time: {t_check[max_err_idx]}\n' \
-              f'x1: {x1_at_err}\n' \
-              f'x2: {x2_at_err}\n' \
-              f'rel err: {np.abs(x_check[max_err_idx] - x_interp[max_err_idx])/np.abs(x_check[max_err_idx])}\n' \
-              f'abs err: {np.abs(x_check[max_err_idx] - x_interp[max_err_idx])}\n'
+              f'time: {np.round(t_check[max_err_idx], 6)}\n' \
+              f'x1: {np.round(x1_at_err, 6)}\n' \
+              f'x2: {np.round(x2_at_err, 6)}\n' \
+              f'rel err: {np.round(rel_err, 6)}\n' \
+              f'abs err: {np.round(abs_err, 6)}'
 
         assert np.all(np.abs(x_check - x_interp) < rtol * np.abs(x_check) + atol), msg

--- a/dymos/utils/testing_utils.py
+++ b/dymos/utils/testing_utils.py
@@ -231,7 +231,7 @@ def assert_timeseries_near_equal(t1, x1, t2, x2, tolerance=None, atol=1.0E-2, rt
 
             msg = f'The two timeseries do not agree to the specified tolerance (atol: {atol} rtol: {rtol}).\n' \
                   'The largest discrepancy is:\n' \
-                  f'time: {t_check[max_err_idx]}\n' \
+                  f'time: {t_check[max_err_idx]:0.{sigfigs}f}\n' \
                   f'x1: {x1_at_err}\n' \
                   f'x2: {x2_at_err}\n' \
                   f'rel err: {rel_err}\n' \


### PR DESCRIPTION
### Summary

The assert_timeseriea_near_equal function will now _optionally_ compare the initial and final time of the two given timeseries to see if they are nearly equal.  Passing `check_time=False` will skip this test.  In that case, the timeseries are only compared on the range of time for which they overlap.

The `tolerance` option has also been deprecated replaced by a specification of `atol` and `rtol`.

Two timeseries of `x` are considered a match if `np.abs(x_check - x_interp) < rtol * np.abs(x_check) + atol` for each time.
The more dense timeseries is linearly interpolated to the times of the more sparse timeseries before matching.

### Related Issues

- Resolves #751 

### Backwards incompatibilities

The `tolerance` option to `assert_timeseries_near_equal` is now deprecated.  Users should replace it with specification of `atol` and `rtol` instead. 

### New Dependencies

None
