### PR TITLE
Change setup to use setuptools instead of distutils.

### DIFF
--- a/dymos/examples/balanced_field/test/test_balanced_field_func_comp.py
+++ b/dymos/examples/balanced_field/test/test_balanced_field_func_comp.py
@@ -1,4 +1,3 @@
-from distutils.version import LooseVersion
 import unittest
 
 import openmdao.api as om
@@ -139,13 +138,11 @@ def wrap_ode_func(num_nodes, flight_mode, grad_method='jax', jax_jit=True):
 @use_tempdirs
 class TestBalancedFieldFuncComp(unittest.TestCase):
 
-    @unittest.skipIf(LooseVersion(om_version) < LooseVersion('3.14'), 'requires OpenMDAO >= 3.14')
     @unittest.skipIf(jax is None, 'requires jax and jaxlib')
     @require_pyoptsparse('IPOPT')
     def test_balanced_field_func_comp_radau(self):
         self._run_problem(dm.Radau)
 
-    @unittest.skipIf(LooseVersion(om_version) < LooseVersion('3.14'), 'requires OpenMDAO >= 3.14')
     @unittest.skipIf(jax is None, 'requires jax and jaxlib')
     @require_pyoptsparse('IPOPT')
     def test_balanced_field_func_comp_gl(self):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-from distutils.core import setup
-from setuptools import find_packages
+from setuptools import find_packages, setup
 
 # Setup optional dependencies
 optional_dependencies = {


### PR DESCRIPTION
### Summary

`setup.py` now uses `setuptools` instead of the deprecated `distutils.core`.
Removed version test that relied on distutils.LooseVersion - testing against version is no longer necessary as the minimum supported OpenMDAO version is more recent.

### Related Issues

- Resolves #756 

### Backwards incompatibilities

None

### New Dependencies

None
