### PR TITLE
Fixed an error when an invalid rate source is provided for a state.

### DIFF
--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -1549,9 +1549,13 @@ class Phase(om.Group):
                 raise ValueError(f'Invalid parameter in phase `{self.pathname}`.\n{str(e)}') from e
 
         self.configure_state_discovery()
-        configure_states_introspection(self.state_options, self.time_options, self.control_options,
-                                       self.parameter_options, self.polynomial_control_options,
-                                       ode)
+
+        try:
+            configure_states_introspection(self.state_options, self.time_options, self.control_options,
+                                           self.parameter_options, self.polynomial_control_options,
+                                           ode)
+        except RuntimeError as val_err:
+            raise RuntimeError(f'Error during configure_states_introspection in phase {self.pathname}.') from val_err
 
         transcription.configure_time(self)
         transcription.configure_controls(self)

--- a/dymos/utils/introspection.py
+++ b/dymos/utils/introspection.py
@@ -989,7 +989,7 @@ def get_source_metadata(ode, src, user_units, user_shape):
     ode_outputs = ode if isinstance(ode, dict) else get_promoted_vars(ode, iotypes='output')
 
     if src not in ode_outputs:
-        raise ValueError(f'Unable to find the source {src} in the ODE at {ode.pathname}.')
+        raise RuntimeError(f'Unable to find the source {src} in the ODE.')
 
     if user_units in {None, _unspecified}:
         units = ode_outputs[src]['units']


### PR DESCRIPTION
### Summary

Fixed an error raised during configure_states_introspection due to ODE outputs being passed in rather than the ODE itself.

### Related Issues

- Resolves #760 

### Backwards incompatibilities

None

### New Dependencies

None
