### PR TITLE
Workflow and setup.py updated to reflect later versions of dependencies.

### DIFF
--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -16,9 +16,9 @@ on:
 jobs:
 
   test_ubuntu:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
-    timeout-minutes: 90
+    timeout-minutes: 120
 
     strategy:
       fail-fast: false
@@ -26,10 +26,10 @@ jobs:
         include:
           # baseline versions
           - NAME: baseline
-            PY: 3.8
-            NUMPY: 1.18
-            SCIPY: 1.4
-            PETSc: 3.12
+            PY: '3.10'
+            NUMPY: 1.22
+            SCIPY: 1.7
+            PETSc: 3.16
             OPENMPI: '4.0'
             PYOPTSPARSE: 'v2.1.5'
             SNOPT: 7.7
@@ -82,10 +82,10 @@ jobs:
 
           # oldest supported versions
           - NAME: oldest
-            PY: 3.7
-            NUMPY: 1.17
-            SCIPY: 1.2
-            PETSc: 3.10.2
+            PY: 3.8
+            NUMPY: 1.21
+            SCIPY: 1.7
+            PETSc: 3.12
             PYOPTSPARSE: 'v1.2'
             SNOPT: 7.2
             MBI: 1

--- a/setup.py
+++ b/setup.py
@@ -62,11 +62,9 @@ The software has two primary objectives:
     ],
     license='Apache License',
     packages=find_packages(),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         'openmdao>=3.17.0',
-        'numpy>=1.17',
-        'scipy>=1.2'
     ],
     extras_require=optional_dependencies,
     zip_safe=False,


### PR DESCRIPTION
### Summary

Workflow now tests against python 3.10.
numpy and scipy dependencies in setup.py removed to be resolved by OpenMDAO's dependencies.

### Related Issues

- Resolves #766 

### Backwards incompatibilities

None

### New Dependencies

None
