### PR TITLE
update github workflow and setup.py

### DIFF
--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -16,7 +16,7 @@ on:
 jobs:
 
   test_ubuntu:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     timeout-minutes: 90
 
@@ -26,12 +26,11 @@ jobs:
         include:
           # baseline versions
           - NAME: baseline
-            PY: 3.8
-            NUMPY: 1.18
-            SCIPY: 1.4
-            PETSc: 3.12
-            OPENMPI: '4.0'
-            PYOPTSPARSE: 'v2.1.5'
+            PY: '3.10'
+            NUMPY: 1.22
+            SCIPY: 1.7
+            PETSc: 3.17
+            PYOPTSPARSE: 'v2.8.3'
             SNOPT: 7.7
             MBI: 1
             OPENMDAO: 'latest'
@@ -41,11 +40,10 @@ jobs:
 
           # baseline versions except no pyoptsparse or SNOPT
           - NAME: no_pyoptsparse
-            PY: 3.8
-            NUMPY: 1.18
-            SCIPY: 1.4
-            PETSc: 3.12
-            OPENMPI: '4.0'
+            PY: '3.10'
+            NUMPY: 1.22
+            SCIPY: 1.7
+            PETSc: 3.17
             MBI: 1
             OPENMDAO: 'latest'
             OPTIONAL: '[all]'
@@ -54,12 +52,11 @@ jobs:
           # baseline versions except with pyoptsparse but no SNOPT
           # build docs to verify those that use pyoptsparse do not use SNOPT
           - NAME: no_snopt
-            PY: 3.8
-            NUMPY: 1.18
-            SCIPY: 1.4
-            PETSc: 3.12
-            OPENMPI: '4.0'
-            PYOPTSPARSE: 'v2.1.5'
+            PY: '3.10'
+            NUMPY: 1.22
+            SCIPY: 1.7
+            PETSc: 3.17
+            PYOPTSPARSE: 'v2.8.3'
             MBI: 1
             OPENMDAO: 'latest'
             OPTIONAL: '[all]'
@@ -71,8 +68,7 @@ jobs:
             NUMPY: 1
             SCIPY: 1
             PETSc: 3
-            OPENMPI: '4'
-            PYOPTSPARSE: 'v2.1.5'
+            PYOPTSPARSE: 'main'
             SNOPT: 7.7
             MBI: 1
             OPENMDAO: 'dev'
@@ -82,10 +78,12 @@ jobs:
 
           # oldest supported versions
           - NAME: oldest
-            PY: 3.7
-            NUMPY: 1.17
-            SCIPY: 1.2
-            PETSc: 3.10.2
+            PY: 3.8
+            NUMPY: 1.22
+            SCIPY: 1.7
+            OPENMPI: '4.0'
+            MPI4PY: '3.0'
+            PETSc: 3.12
             PYOPTSPARSE: 'v1.2'
             SNOPT: 7.2
             MBI: 1
@@ -157,15 +155,6 @@ jobs:
           pip install jax
           pip install jaxlib
 
-      - name: Install libscotch
-        if: (github.event_name != 'workflow_dispatch' && matrix.name == 'oldest')
-        shell: bash -l {0}
-        run: |
-          echo "============================================================="
-          echo "Install libscotch"
-          echo "============================================================="
-          sudo apt-get install -y libscotch-6.0
-
       - name: Install PETSc
         if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest') && matrix.PETSc
         shell: bash -l {0}
@@ -174,9 +163,12 @@ jobs:
           echo "Install PETSc"
           echo "============================================================="
           if [[ "${{ matrix.OPENMPI }}" ]]; then
-            conda install -c conda-forge openmpi=${{ matrix.OPENMPI }} mpi4py petsc=${{ matrix.PETSc }} petsc4py -q -y
+            conda install -c conda-forge openmpi=${{ matrix.OPENMPI }} -q -y
+          fi
+          if [[ "${{ matrix.MPI4PY }}" ]]; then
+            conda install -c conda-forge mpi4py=${{ matrix.MPI4PY }} petsc4py=${{ matrix.PETSc }} -q -y
           else
-            conda install -c conda-forge mpi4py petsc=${{ matrix.PETSc }} petsc4py -q -y
+            conda install -c conda-forge mpi4py petsc4py=${{ matrix.PETSc }} -q -y
           fi
           echo "OMPI_MCA_rmaps_base_oversubscribe=1" >> $GITHUB_ENV
 
@@ -262,6 +254,18 @@ jobs:
         run: |
           conda info
           conda list
+
+          echo "============================================================="
+          echo "Check installed versions of Python, Numpy and Scipy"
+          echo "============================================================="
+          python -c "import sys; assert str(sys.version).startswith(str(${{ matrix.PY }})), \
+                    f'Python version {sys.version} is not the requested version (${{ matrix.PY }})'"
+
+          python -c "import numpy; assert str(numpy.__version__).startswith(str(${{ matrix.NUMPY }})), \
+                    f'Numpy version {numpy.__version__} is not the requested version (${{ matrix.NUMPY }})'"
+
+          python -c "import scipy; assert str(scipy.__version__).startswith(str(${{ matrix.SCIPY }})), \
+                    f'Scipy version {scipy.__version__} is not the requested version (${{ matrix.SCIPY }})'"
 
       - name: Run tests
         if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')

--- a/setup.py
+++ b/setup.py
@@ -62,11 +62,11 @@ The software has two primary objectives:
     ],
     license='Apache License',
     packages=find_packages(),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         'openmdao>=3.17.0',
-        'numpy>=1.17',
-        'scipy>=1.2'
+        'numpy',
+        'scipy'
     ],
     extras_require=optional_dependencies,
     zip_safe=False,


### PR DESCRIPTION
### Summary

- update github workflow to test against more recent version of python, numpy, scipy and pyoptsparse
- update github workflow to use numpy 1.22 as the oldest version that passes the security audit
- add checks to github workflow to make sure python, numpy and scipy versions are not changed during install
- update setup.py to reflect a minum version python 3.8 and leave numpy and scipy versions to be resolved

### Related Issues

- Resolves #766

### Backwards incompatibilities

None

### New Dependencies

None
