### PR TITLE
use mamba in github workflow

### DIFF
--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -125,6 +125,7 @@ jobs:
           git fetch --prune --unshallow --tags
 
       - name: Setup mamba
+        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
         uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.PY }}

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -83,7 +83,7 @@ jobs:
             SCIPY: 1.7
             OPENMPI: '4.0'
             MPI4PY: '3.0'
-            PETSc: 3.12
+            PETSc: 3.13
             PYOPTSPARSE: 'v1.2'
             SNOPT: 7.2
             MBI: 1
@@ -124,17 +124,13 @@ jobs:
         run: |
           git fetch --prune --unshallow --tags
 
-      - name: Install miniconda
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
+      - name: Setup mamba
         uses: conda-incubator/setup-miniconda@v2
         with:
-          activate-environment: test
           python-version: ${{ matrix.PY }}
-          channels: conda-forge
-          allow-softlinks: true
-          channel-priority: flexible
-          show-channel-urls: true
-          use-only-tar-bz2: true
+          mamba-version: "*"
+          channels: conda-forge,defaults
+          channel-priority: true
 
       - name: Install Numpy/Scipy
         if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
@@ -143,7 +139,7 @@ jobs:
           echo "============================================================="
           echo "Install Numpy/Scipy"
           echo "============================================================="
-          conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
+          mamba install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
       - name: Install jax
         if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest') && matrix.JAX
@@ -162,14 +158,20 @@ jobs:
           echo "============================================================="
           echo "Install PETSc"
           echo "============================================================="
-          if [[ "${{ matrix.OPENMPI }}" ]]; then
-            conda install -c conda-forge openmpi=${{ matrix.OPENMPI }} -q -y
-          fi
-          if [[ "${{ matrix.MPI4PY }}" ]]; then
-            conda install -c conda-forge mpi4py=${{ matrix.MPI4PY }} petsc4py=${{ matrix.PETSc }} -q -y
+          if [[ "${{ matrix.OPENMPI }}" && "${{ matrix.MPI4PY }}" ]]; then
+            mamba install openmpi=${{ matrix.OPENMPI }} mpi4py=${{ matrix.MPI4PY }} petsc4py=${{ matrix.PETSc }} -q -y
+          elif [[ "${{ matrix.MPI4PY }}" ]]; then
+            mamba install mpi4py=${{ matrix.MPI4PY }} petsc4py=${{ matrix.PETSc }} -q -y
           else
-            conda install -c conda-forge mpi4py petsc4py=${{ matrix.PETSc }} -q -y
+            mamba install mpi4py petsc4py=${{ matrix.PETSc }} -q -y
           fi
+          echo "-----------------------"
+          echo "Quick test of mpi4py:"
+          mpirun -n 2 python -c "from mpi4py import MPI; print(f'Rank: {MPI.COMM_WORLD.rank}')"
+          echo "-----------------------"
+          echo "Quick test of petsc4py:"
+          mpirun -n 2 python -c "import numpy; from mpi4py import MPI; comm = MPI.COMM_WORLD; import petsc4py; petsc4py.init(); x = petsc4py.PETSc.Vec().createWithArray(numpy.ones(5)*comm.rank, comm=comm);  print(x.getArray())"
+          echo "-----------------------"
           echo "OMPI_MCA_rmaps_base_oversubscribe=1" >> $GITHUB_ENV
 
       - name: Install pyOptSparse
@@ -248,7 +250,7 @@ jobs:
           echo "============================================================="
           pip install .${{ matrix.OPTIONAL }}
 
-      - name: Display conda info
+      - name: Display environment info
         if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
### Summary

- Use `mamba` in github workflow to create python environment
- Bump oldest supported PETSc to 3.13 since 3.12 requires gfortran 7 which is not on conda-forge

### Related Issues

- Resolves #773 

### Backwards incompatibilities

None

### New Dependencies

None
