### PR TITLE
Trajectory.phases subgroup is now available before setup.

### DIFF
--- a/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise_mpi.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise_mpi.py
@@ -17,7 +17,7 @@ from dymos.examples.finite_burn_orbit_raise.finite_burn_orbit_raise_problem impo
 class TestExampleTwoBurnOrbitRaiseMPI(unittest.TestCase):
     N_PROCS = 3
 
-    def test_ex_two_burn_orbit_raise(self):
+    def test_ex_two_burn_orbit_raise_mpi(self):
         optimizer = 'IPOPT'
 
         p = two_burn_orbit_raise_problem(transcription='gauss-lobatto', transcription_order=3,
@@ -26,6 +26,17 @@ class TestExampleTwoBurnOrbitRaiseMPI(unittest.TestCase):
 
         if p.model.traj.phases.burn2 in p.model.traj.phases._subsystems_myproc:
             assert_near_equal(p.get_val('traj.burn2.states:deltav')[-1], 0.3995,
+                              tolerance=2.0E-3)
+
+    def test_ex_two_burn_orbit_raise_connected_mpi(self):
+        optimizer = 'IPOPT'
+
+        p = two_burn_orbit_raise_problem(transcription='gauss-lobatto', transcription_order=3,
+                                         compressed=False, optimizer=optimizer, simulate=False,
+                                         connected=True, show_output=False)
+
+        if p.model.traj.phases.burn2 in p.model.traj.phases._subsystems_myproc:
+            assert_near_equal(p.get_val('traj.burn2.states:deltav')[0], 0.3995,
                               tolerance=2.0E-3)
 
 

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -35,14 +35,27 @@ class Trajectory(om.Group):
     ----------
     **kwargs : dict
         Dictionary of optional arguments.
+
+    Attributes
+    ----------
+    parameter_options : dict
+        A dictionary of parameter names and their associated TrajectoryParameterOptionsDictionary
+    phases : om.Group or om.ParallelGroup
+        The Group which contains phases for this Trajectory.
+
+    _linkages : OrderedDict
+        A dictionary containing phase linkage information for the Trajectory.
+    _phases : dict
+        A dictionary of phase names as keys with the Phase objects being their associated values.
     """
     def __init__(self, **kwargs):
         super(Trajectory, self).__init__(**kwargs)
 
+        self._linkages = {}
+        self._phases = {}
+
         self.parameter_options = {}
-        self._linkages = OrderedDict()
-        self._phases = OrderedDict()
-        self._phase_add_kwargs = {}
+        self.phases = om.ParallelGroup()
 
     def initialize(self):
         """
@@ -71,8 +84,7 @@ class Trajectory(om.Group):
         PhaseBase
             The Phase object added to the trajectory.
         """
-        self._phases[name] = phase
-        self._phase_add_kwargs[name] = kwargs
+        self._phases[name] = self.phases.add_subsystem(name, phase, **kwargs)
         return phase
 
     def set_parameter_options(self, name, units=_unspecified, val=_unspecified, desc=_unspecified, opt=False,
@@ -324,10 +336,8 @@ class Trajectory(om.Group):
         if self.parameter_options:
             self._setup_parameters()
 
-        phases_group = self.add_subsystem('phases', subsys=om.ParallelGroup())
-
-        for name, phs in self._phases.items():
-            phases_group.add_subsystem(name, phs, **self._phase_add_kwargs[name])
+        # This will override the existing phases attribute with the same thing.
+        self.add_subsystem('phases', subsys=self.phases)
 
         if self._linkages:
             self._setup_linkages()


### PR DESCRIPTION
### Summary

In situations where the user might want to change attributes of the `Trajectory.phases` ParallelGroup, such as setting solvers, this should be done before setup time. 
This was previously not possible because `phases` wasn't instantiated until `setup`. 
This pull request instantiates `phases` at Trajectory instantiation.

### Related Issues

- Resolves #776

### Backwards incompatibilities

None

### New Dependencies

None
