### PR TITLE
`run_problem` argument `restart` now allows a specific Case to be provided.

### DIFF
--- a/docs/build_source_docs.py
+++ b/docs/build_source_docs.py
@@ -4,24 +4,19 @@ import json
 IGNORE_LIST = []
 
 packages = [
-    'approximation_schemes',
-    'components',
-    'core',
-    'drivers',
-    'error_checking',
-    'jacobians',
-    'matrices',
-    'proc_allocators',
-    'recorders',
-    'solvers.linear',
-    'solvers.linesearch',
-    'solvers.nonlinear',
-    'surrogate_models',
-    'test_suite.components',
-    'test_suite.scripts',
+    'grid_refinement',
+    'grid_refinement.hp_adaptive',
+    'grid_refinement.ph_adaptive',
+    'models',
+    'models.atmosphere',
+    'phase',
+    'trajectory',
+    'transcriptions',
+    'transcriptions.common',
+    'transcriptions.explicit_shooting',
+    'transcriptions.pseudospectral',
+    'transcriptions.solve_ivp',
     'utils',
-    'vectors',
-    'visualization',
 ]
 
 index_top = """
@@ -82,7 +77,7 @@ def _header_cell():
     return template
 
 
-def build_src_docs(top, src_dir, project_name='openmdao'):
+def build_src_docs(top, src_dir, project_name='dymos'):
     # docs_dir = os.path.dirname(src_dir)
 
     doc_dir = os.path.join(top, "_srcdocs")
@@ -189,4 +184,4 @@ def build_src_docs(top, src_dir, project_name='openmdao'):
 
 
 if __name__ == '__main__':
-    build_src_docs("openmdao_book/", "..")
+    build_src_docs("dymos_book/", "../dymos")

--- a/docs/dymos_book/_toc.yml
+++ b/docs/dymos_book/_toc.yml
@@ -66,7 +66,7 @@ parts:
   chapters:
   - file: api/api
     sections:
-    - file: api/run_problem
+    - file: api/run_problem_function
     - file: api/phase_api
     - file: api/transcriptions_api
     - file: api/trajectory_api

--- a/docs/dymos_book/api/api.md
+++ b/docs/dymos_book/api/api.md
@@ -1,6 +1,6 @@
 # Dymos Reference API
 
-- [The Dymos run_problem function](run_problem)
+- [The Dymos run_problem function](run_problem_function)
 - [The Phase API](phase_api)
 - [The Transcriptions API](transcriptions_api)
 - [The Trajectory API](trajectory_api)

--- a/docs/dymos_book/api/phase_api.ipynb
+++ b/docs/dymos_book/api/phase_api.ipynb
@@ -205,7 +205,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/docs/dymos_book/api/run_problem_function.ipynb
+++ b/docs/dymos_book/api/run_problem_function.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "active-ipynb",

--- a/docs/dymos_book/api/run_problem_function.ipynb
+++ b/docs/dymos_book/api/run_problem_function.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "tags": [
      "active-ipynb",
@@ -47,13 +47,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# The Dymos run_problem function\n",
+    "# The run_problem function\n",
     "\n",
     "In the Brachistochrone example we used two methods on the OpenMDAO Problem class to execute the model.\n",
     "\n",
-    "**run_model** Takes the current model design variables and runs a single execution of the Problem's model.  \n",
+    "`run_model` Takes the current model design variables and runs a single execution of the Problem's model.  \n",
     "Any iterative systems are converged, but no optimization is performed.\n",
-    "When using Dymos with an optimizer-driven implicit transcription, `run_model` will **not** produce a physically valid trajectory on output.\n",
+    "When using dymos with an optimizer-driven implicit transcription, `run_model` will **not** produce a physically valid trajectory on output.\n",
     "If using a solver-driven transcription, the collocation defects will be satisfied (if possible) and the resulting outputs will provide a physically valid trajectory (to the extent possible given the collocation grid)."
    ]
   },
@@ -61,20 +61,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**run_driver** Runs a driver wrapped around the model (typically done for optimization) and repeatedly executes `run_model` until the associated optimization problem is satisfied.\n",
+    "`run_driver` runs a driver wrapped around the model (typically done for optimization) and repeatedly executes `run_model` until the associated optimization problem is satisfied.\n",
     "This approach will provide a physically valid trajectory, to the extent that the grid is sufficient to accurately model the dynamics.\n",
-    "But what happens if the grid is not dense enough to accurately capture the physics of the problem.\n",
-    "This is the purpose of _grid refinement_.\n",
-    "There have been numerous methods of grid refinment posed for implcit optimal control techniques.\n",
-    "In general, they follow the following procedure:\n",
     "\n",
-    "1. Optimize the trajectory\n",
-    "2. Assess errors in the solution\n",
-    "3. Propose a new grid to reduce these errors to an acceptable level.\n",
-    "4. Repeat until the errors are within some acceptable tolerance.\n",
+    "But commonly, we want to do the following when we run dymos\n",
     "\n",
-    "This requires another layer of iteration outside of the OpenMDAO `run_driver` method.\n",
-    "This is the original motivation for Dymos' `run_problem` function."
+    "- Automatically record states, controls, and parameters at the arrived-upon \"final\" solution.\n",
+    "- Automatically provide explicit simulation of the solution to verify the accuracy of the collocation.\n",
+    "- Automatically load in the results from a previous case as the initial guess for an optimization.\n",
+    "- Iteratively re-optimize the problem with different grid settings to attempt to minimize grid error (i.e. grid refinement).\n",
+    "\n",
+    "To remove the need to repeatedly setup the code to do this, dymos provides a function called `run_problem`."
    ]
   },
   {
@@ -82,7 +79,8 @@
    "metadata": {},
    "source": [
     "```{eval-rst}\n",
-    "dymos.run_problem.run_problem\n",
+    "    .. autofunction:: dymos.run_problem\n",
+    "        :noindex:\n",
     "```"
    ]
   }
@@ -98,7 +96,7 @@
    }
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -112,7 +110,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/docs/dymos_book/examples/ssto_earth/ssto_earth.ipynb
+++ b/docs/dymos_book/examples/ssto_earth/ssto_earth.ipynb
@@ -312,8 +312,8 @@
     "p.set_val('traj.phase0.t_duration', 150.0)\n",
     "p.set_val('traj.phase0.states:x', phase.interp('x', [0, 1.15E5]))\n",
     "p.set_val('traj.phase0.states:y', phase.interp('y', [0, 1.85E5]))\n",
-    "p.set_val('traj.phase0.states:vy', phase.interp('vx', [1.0E-6, 0]))\n",
-    "p.set_val('traj.phase0.states:m', phase.interp('vy', [117000, 1163]))\n",
+    "p.set_val('traj.phase0.states:vy', phase.interp('vy', [1.0E-6, 0]))\n",
+    "p.set_val('traj.phase0.states:m', phase.interp('m', [117000, 1163]))\n",
     "p.set_val('traj.phase0.controls:theta', phase.interp('theta', [1.5, -0.76]))\n",
     "p.set_val('traj.phase0.parameters:thrust', 2.1, units='MN')\n",
     "\n",
@@ -433,7 +433,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Summary

The `restart` argument of `run_problem` now allows the user to provide a file, or a specific case from a Case recorder.
Fixed the run_problem documentation to allow the run_problem API to be listed there.

### Related Issues

- Resolves #794 
- Resolves #795

### Backwards incompatibilities

None

### New Dependencies

None
