### PR TITLE
A few minor cleanups for the cartpole example.

### DIFF
--- a/docs/dymos_book/examples/cart_pole/cart_pole.ipynb
+++ b/docs/dymos_book/examples/cart_pole/cart_pole.ipynb
@@ -147,6 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.display_source(\"dymos.examples.cart_pole.cartpole_dynamics\")"
    ]
   },
@@ -209,7 +210,7 @@
     "phase.add_state('energy', fix_initial=True, rate_source='e_dot', shape=(1,), ref=1, defect_ref=1, units='N**2*s')  # integration of force**2. This does not have the energy unit, but I call it \"energy\" anyway.\n",
     "\n",
     "# declare control inputs\n",
-    "phase.add_control('f', fix_initial=False, rate_continuity=False, lower=-20, upper=20, shape=(1,), ref=10, units='N')\n",
+    "phase.add_control('f', fix_initial=False, rate_continuity=False, lower=-20, upper=20, shape=(1,), ref=0.01, units='N')\n",
     "\n",
     "# add cart-pole parameters (set static_target=True because these params are not time-depencent)\n",
     "phase.add_parameter('m_cart', val=1., units='kg', static_target=True)\n",
@@ -381,7 +382,7 @@
    }
   },
   "kernelspec": {
-   "display_name": "Python 3.7.4 64-bit",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -395,7 +396,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.10.5"
   },
   "vscode": {
    "interpreter": {

--- a/dymos/examples/cart_pole/cartpole_dynamics.py
+++ b/dymos/examples/cart_pole/cartpole_dynamics.py
@@ -70,7 +70,6 @@ class CartPoleDynamics(om.ExplicitComponent):
         # partials of outputs w.r.t. cart-pole parameters. We will use complex-step, but still declare the sparsity structure.
         # NOTE: since the cart-pole parameters are fixed during optimization, these partials are not necessary to declare.
         self.declare_partials(of=["*"], wrt=["m_cart", "m_pole", "l_pole"], method="cs", rows=np.arange(nn), cols=np.zeros(nn))
-        self.declare_coloring(wrt=["m_cart", "m_pole", "l_pole"], method="cs", show_summary=False)
         self.set_check_partial_options(wrt=["m_cart", "m_pole", "l_pole"], method="fd", step=1e-7)
 
     def compute(self, inputs, outputs):

--- a/dymos/examples/cart_pole/test/test_cartpole_opt.py
+++ b/dymos/examples/cart_pole/test/test_cartpole_opt.py
@@ -39,7 +39,7 @@ class TestCartPoleOptimization(unittest.TestCase):
         )  # integration of force**2. This does not have the energy unit, but I call it "energy" anyway.
 
         # declare control inputs
-        phase.add_control("f", fix_initial=False, rate_continuity=False, lower=-20, upper=20, shape=(1,), ref=10, units="N")
+        phase.add_control("f", fix_initial=False, rate_continuity=False, lower=-20, upper=20, shape=(1,), ref=0.01, units="N")
 
         # add cart-pole parameters (set static_target=True because these params are not time-depencent)
         phase.add_parameter("m_cart", val=1.0, units="kg", static_target=True)
@@ -51,12 +51,12 @@ class TestCartPoleOptimization(unittest.TestCase):
         phase.add_boundary_constraint("x", loc="final", equals=1, ref=1.0, units="m")  # final horizontal displacement
         phase.add_boundary_constraint("theta", loc="final", equals=np.pi, ref=1.0, units="rad")  # final pole angle
         phase.add_boundary_constraint("x_dot", loc="final", equals=0, ref=1.0, units="m/s")  # 0 velocity at the and
-        phase.add_boundary_constraint("theta_dot", loc="final", equals=0, ref=0.1, units="rad/s")  # 0 angular velocity at the end
+        phase.add_boundary_constraint("theta_dot", loc="final", equals=0, ref=1.0, units="rad/s")  # 0 angular velocity at the end
         phase.add_boundary_constraint("f", loc="final", equals=0, ref=1.0, units="N")  # 0 force at the end
 
         # --- set objective function ---
         # we minimize the integral of force**2.
-        phase.add_objective("energy", loc="final", ref=100)
+        phase.add_objective("energy", loc="final", ref=1.0)
 
         # --- configure optimizer ---
         p.driver = om.pyOptSparseDriver()


### PR DESCRIPTION
### Summary

Cartpole was having trouble converging on local OS X machines using IPOPT.
1. Removed declare_coloring call for partial coloring wrt the static parameters, since those subjacobians are dense.
2. Added an extra `import openmdao.api as om` before the `display_source` call in the doc, since the first import would not have been performed on colab.
3. Changed ref values to 1.0 except for the control, which has its ref set to 0.01.  This results in significantly faster convergence on OS X (36 iterations, as opposed to failing after hundreds of iterations).

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
