### PR TITLE
Fixed a bug where trajectory parameters connected to an element from a timeseries encountered shape errors.

### DIFF
--- a/dymos/examples/brachistochrone/test/test_brachistochrone_timeseries_feedback.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_timeseries_feedback.py
@@ -1,0 +1,166 @@
+import unittest
+
+import numpy as np
+
+import openmdao.api as om
+from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.assert_utils import assert_near_equal
+
+
+class BrachistochroneODE(om.ExplicitComponent):
+
+    def initialize(self):
+        self.options.declare('num_nodes', types=int)
+
+    def setup(self):
+        nn = self.options['num_nodes']
+
+        # Inputs
+        self.add_input('v', val=np.zeros(nn), desc='velocity', units='m/s')
+        self.add_input('g', val=9.80665, desc='acceleration of gravity', units='m/s**2')
+        self.add_input('theta', val=np.zeros(nn), desc='angle of wire', units='rad')
+        self.add_input('final_time', val=0.0, desc='expected final time', units='s')
+        self.add_output('xdot', val=np.zeros(nn), desc='horizontal velocity', units='m/s')
+        self.add_output('ydot', val=np.zeros(nn), desc='vertical velocity', units='m/s')
+        self.add_output('vdot', val=np.zeros(nn), desc='acceleration mag.', units='m/s**2')
+
+        # Setup partials
+        arange = np.arange(self.options['num_nodes'], dtype=int)
+
+        self.declare_partials(of='vdot', wrt='g', rows=arange, cols=np.zeros(nn, dtype=int))
+        self.declare_partials(of='vdot', wrt='theta', rows=arange, cols=arange)
+
+        self.declare_partials(of='xdot', wrt='v', rows=arange, cols=arange)
+        self.declare_partials(of='xdot', wrt='theta', rows=arange, cols=arange)
+
+        self.declare_partials(of='ydot', wrt='v', rows=arange, cols=arange)
+        self.declare_partials(of='ydot', wrt='theta', rows=arange, cols=arange)
+
+    def compute(self, inputs, outputs):
+        theta = inputs['theta']
+        cos_theta = np.cos(theta)
+        sin_theta = np.sin(theta)
+        g = inputs['g']
+        v = inputs['v']
+
+        outputs['vdot'] = g * cos_theta
+        outputs['xdot'] = v * sin_theta
+        outputs['ydot'] = -v * cos_theta
+
+    def compute_partials(self, inputs, jacobian):
+        theta = inputs['theta']
+        cos_theta = np.cos(theta)
+        sin_theta = np.sin(theta)
+        g = inputs['g']
+        v = inputs['v']
+
+        jacobian['vdot', 'g'] = cos_theta
+        jacobian['vdot', 'theta'] = -g * sin_theta
+
+        jacobian['xdot', 'v'] = sin_theta
+        jacobian['xdot', 'theta'] = v * cos_theta
+
+        jacobian['ydot', 'v'] = -cos_theta
+        jacobian['ydot', 'theta'] = v * sin_theta
+
+
+@use_tempdirs
+class TestBrachistochroneTimeseriesFeedback(unittest.TestCase):
+
+    def test_timeseries_feedback(self):
+        import itertools
+        import numpy as np
+        import openmdao.api as om
+        import dymos as dm
+
+        #
+        # Define the OpenMDAO problem
+        #
+        p = om.Problem(model=om.Group())
+
+        #
+        # Define a Trajectory object
+        #
+        traj = dm.Trajectory()
+
+        p.model.add_subsystem('traj', subsys=traj)
+
+        #
+        # Define a Dymos Phase object with GaussLobatto Transcription
+        #
+        phase = dm.Phase(ode_class=BrachistochroneODE,
+                         transcription=dm.GaussLobatto(num_segments=10, order=3))
+
+        traj.add_phase(name='phase0', phase=phase)
+
+        phase.add_parameter('final_time', units='s', static_target=True, opt=False)
+        traj.add_parameter('final_time', units='s', static_target=True, opt=False)
+
+        traj.connect(src_name='phase0.timeseries.time', tgt_name='parameters:final_time', src_indices=om.slicer[-1, ...])
+
+        # The feedback connection introduced iterative behavior, so now nonlinear solver and linear solver are needed.
+        traj.nonlinear_solver = om.NonlinearBlockGS()
+        traj.linear_solver = om.DirectSolver()
+
+        #
+        # Set the time options
+        # Time has no targets in our ODE.
+        # We fix the initial time so that the it is not a design variable in the optimization.
+        # The duration of the phase is allowed to be optimized, but is bounded on [0.5, 10].
+        #
+        phase.set_time_options(fix_initial=True, duration_bounds=(0.5, 10.0), units='s')
+
+        #
+        # Set the time options
+        # Initial values of positions and velocity are all fixed.
+        # The final value of position are fixed, but the final velocity is a free variable.
+        # The equations of motion are not functions of position, so 'x' and 'y' have no targets.
+        # The rate source points to the output in the ODE which provides the time derivative of the
+        # given state.
+        phase.add_state('x', fix_initial=True, fix_final=True, rate_source='xdot')
+        phase.add_state('y', fix_initial=True, fix_final=True, rate_source='ydot')
+        phase.add_state('v', fix_initial=True, fix_final=False, rate_source='vdot')
+
+        # Define theta as a control.
+        phase.add_control(name='theta', units='rad', lower=0, upper=np.pi)
+
+        # Minimize final time.
+        phase.add_objective('time', loc='final')
+
+        # Set the driver.
+        p.driver = om.ScipyOptimizeDriver()
+
+        # Allow OpenMDAO to automatically determine our sparsity pattern.
+        # Doing so can significant speed up the execution of Dymos.
+        p.driver.declare_coloring()
+
+        # Setup the problem
+        p.setup(check=True)
+
+        # Now that the OpenMDAO problem is setup, we can set the values of the states.
+        p.set_val('traj.phase0.states:x', phase.interp('x', [0, 10]), units='m')
+
+        p.set_val('traj.phase0.states:y', phase.interp('y', [10, 5]), units='m')
+
+        p.set_val('traj.phase0.states:v', phase.interp('v', [0, 5]), units='m/s')
+
+        p.set_val('traj.phase0.controls:theta', phase.interp('theta', [90, 90]), units='deg')
+
+        p.set_val('traj.parameters:final_time', 0.0, units='s')
+
+        # Run the driver to solve the problem
+        dm.run_problem(p, run_driver=True, simulate=True)
+
+        sol_case = om.CaseReader('dymos_solution.db').get_case('final')
+        sim_case = om.CaseReader('dymos_simulation.db').get_case('final')
+
+        final_time_timeseries_sol = sol_case.get_val('traj.phase0.timeseries.time')[-1, ...]
+        final_time_traj_param_sol = sol_case.get_val('traj.parameter_vals:final_time')[0, 0]
+        final_time_timeseries_sim = sol_case.get_val('traj.phase0.timeseries.time')[-1, ...]
+        final_time_traj_param_sim = sol_case.get_val('traj.parameter_vals:final_time')[0, 0]
+
+        p.model.list_outputs(prom_name=True)
+
+        assert_near_equal(final_time_traj_param_sol, final_time_timeseries_sol)
+        assert_near_equal(final_time_traj_param_sim, final_time_timeseries_sol)
+        assert_near_equal(final_time_timeseries_sim, final_time_timeseries_sol)

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -2037,7 +2037,7 @@ class Phase(om.Group):
             The pathname of the system in prob that contains the phases.
         skip_params : None or set
             Parameter names that will be skipped because they have already been initialized at the
-            trajetory level (Deprecated).
+            trajectory level (Deprecated).
         """
         phs = from_phase
 

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -2037,7 +2037,7 @@ class Phase(om.Group):
             The pathname of the system in prob that contains the phases.
         skip_params : None or set
             Parameter names that will be skipped because they have already been initialized at the
-            trajetory level. (Deprecated)
+            trajetory level (Deprecated).
         """
         phs = from_phase
 

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -2037,9 +2037,13 @@ class Phase(om.Group):
             The pathname of the system in prob that contains the phases.
         skip_params : None or set
             Parameter names that will be skipped because they have already been initialized at the
-            trajetory level.
+            trajetory level. (Deprecated)
         """
         phs = from_phase
+
+        if skip_params is not None:
+            om.issue_warning(f'{self.pathname}: Option `skip_params` to Phase.initialize_values_from_phase` is '
+                             f'deprecated and will be removed dymos 2.0.0', category=om.OMDeprecationWarning)
 
         op_dict = dict([(name, options) for (name, options) in phs.list_outputs(units=True,
                                                                                 list_autoivcs=True,
@@ -2091,9 +2095,6 @@ class Phase(om.Group):
         for name in phs.parameter_options:
             units = phs.parameter_options[name]['units']
 
-            if skip_params and name in skip_params:
-                continue
-
             # We use this private function to grab the correctly sized variable from the
             # auto_ivc source.
             if om_version < (3, 4, 1):
@@ -2105,7 +2106,7 @@ class Phase(om.Group):
                 prob_path = f'{phase_path}.{self.name}.parameters:{name}'
             else:
                 prob_path = f'{self.name}.parameters:{name}'
-            prob[prob_path][...] = val
+            prob.set_val(prob_path, val)
 
     def simulate(self, times_per_seg=10, method=_unspecified, atol=_unspecified, rtol=_unspecified,
                  first_step=_unspecified, max_step=_unspecified, record_file=None):

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -1168,31 +1168,13 @@ class Trajectory(om.Group):
         sim_prob.setup()
 
         # Assign trajectory parameter values
-        param_names = [key for key in self.parameter_options.keys()]
-        for name in param_names:
-            prom_path = f'{self.name}.parameters:{name}'
-            src = self.get_source(prom_path)
-
-            # We use this private function to grab the correctly sized variable from the
-            # auto_ivc source.
-            val = self._abs_get_val(src, False, None, 'nonlinear', 'output', False, from_root=True)
+        for name in self.parameter_options:
             sim_prob_prom_path = f'{traj_name}.parameters:{name}'
-            sim_prob[sim_prob_prom_path][...] = val
+            sim_prob.set_val(sim_prob_prom_path, self.get_val(f'parameters:{name}'))
 
         for phase_name, phs in sim_traj._phases.items():
-            skip_params = set(param_names)
-            for name in param_names:
-                targets = self.parameter_options[name]['targets']
-                if targets and phase_name in targets:
-                    targets_phase = targets[phase_name]
-                    if targets_phase is not None:
-                        if isinstance(targets_phase, str):
-                            targets_phase = [targets_phase]
-                        skip_params.update(targets_phase)
-
             phs.initialize_values_from_phase(sim_prob, self._phases[phase_name],
-                                             phase_path=traj_name,
-                                             skip_params=skip_params)
+                                             phase_path=traj_name)
 
         print(f'\nSimulating trajectory {self.pathname}')
         sim_prob.run_model(case_prefix=case_prefix, reset_iter_counts=reset_iter_counts)


### PR DESCRIPTION
### Summary

Trajectory parameters connected to arrays were pulling their values in such a way that shape mismatches were encountered during simulate.

The original code was written before `System.get_val` existed.  Now that that method is available, determining the correct value of a parameter before simulating is much simpler.

Also removed the `skip_params` option to `Phase.initialize_values_from_phase`, which is used during simulate.  There's no need to skip those params whose values come from the trajectory, given the current architecture of the code.  This was an artifact of the way in which parameters used to be promoted to the appropriate level.

### Related Issues

- Resolves #820 

### Backwards incompatibilities

Option `skip_params` in `Phase.initialize_values_from_phase` is deprecated.

### New Dependencies

None
