### PR TITLE
Linkage report registered with OpenMDAO reports system

### DIFF
--- a/dymos/visualization/linkage/report.py
+++ b/dymos/visualization/linkage/report.py
@@ -246,7 +246,7 @@ def _run_linkage_report(prob):
     """ Function invoked by the reports system """
 
     # Find all Trajectory objects in the Problem. Usually, there's only one
-    for sysname,sysinfo in prob.model._subsystems_allprocs.items():
+    for sysname, sysinfo in prob.model._subsystems_allprocs.items():
         if isinstance(sysinfo.system, dm.Trajectory):
             traj = sysinfo.system
             # Only create a report for a trajectory with multiple phases
@@ -258,5 +258,5 @@ def _run_linkage_report(prob):
 
 def _linkage_report_register():
     rptsys.register_report('linkage', _run_linkage_report, _default_linkage_report_title,
-                    'Problem', 'final_setup', 'post')
+                           'Problem', 'final_setup', 'post')
     rptsys._default_reports.append('linkage')

--- a/dymos/visualization/linkage/report.py
+++ b/dymos/visualization/linkage/report.py
@@ -257,6 +257,6 @@ def _run_linkage_report(prob):
 
 
 def _linkage_report_register():
-    rptsys.register_report('linkage', _run_linkage_report, _default_linkage_report_title,
+    rptsys.register_report('dymos.linkage', _run_linkage_report, _default_linkage_report_title,
                            'Problem', 'final_setup', 'post')
-    rptsys._default_reports.append('linkage')
+    rptsys._default_reports.append('dymos.linkage')

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ The software has two primary objectives:
     },
     entry_points = {
         'openmdao_report': [
-            'linkage=dymos.visualization.linkage.report:_linkage_report_register'
+            'dymos.linkage=dymos.visualization.linkage.report:_linkage_report_register'
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -77,4 +77,9 @@ The software has two primary objectives:
         'dymos.examples.aircraft_steady_flight.aero': ['data/CRM_aero_inputs.dat', 'data/CRM_aero_outputs.dat'],
         'dymos.visualization.linkage': ['report_template.html', 'js/*', 'style/*']
     },
+    entry_points = {
+        'openmdao_report': [
+            'linkage=dymos.visualization.linkage.report:_linkage_report_register'
+        ],
+    },
 )


### PR DESCRIPTION
### Summary

The linkage report now registers with the OpenMDAO reports system and is added to the default reports list. A report will be generated in the reports directory when `OPENMDAO_REPORTS` is true or contains `linkage`. Some additional minor cleanups were also performed.

### Related Issues

- Resolves #819 

### Backwards incompatibilities

None

### New Dependencies

None
