### PR TITLE
Fixed condition under which trajectory linkage reports are generated.

### DIFF
--- a/dymos/visualization/linkage/report.py
+++ b/dymos/visualization/linkage/report.py
@@ -249,8 +249,8 @@ def _run_linkage_report(prob):
     for sysname, sysinfo in prob.model._subsystems_allprocs.items():
         if isinstance(sysinfo.system, dm.Trajectory):
             traj = sysinfo.system
-            # Only create a report for a trajectory with multiple phases
-            if len(traj._phases) > 1:
+            # Only create a report for a trajectory with linkages
+            if traj._linkages:
                 report_filename = f'{sysname}_{_default_linkage_report_filename}'
                 report_path = str(Path(prob.get_reports_dir()) / report_filename)
                 create_linkage_report(traj, report_path)


### PR DESCRIPTION
### Summary

Changes the condition under which a linkage report is generated from "trajectory has more than one phase" to "trajectory contains linkages".  This was causing a reports to not be generated in cases where a single-phase trajectory uses linkages to couple the various initial/final conditions of the phase together, such as in the racecar example.

### Related Issues

- Resolves #827 

### Backwards incompatibilities

None

### New Dependencies

None
