### PR TITLE
Resolved jaxlib issue on pypi for Python 3.11

### DIFF
--- a/.github/workflows/dymos_docs_workflow.yml
+++ b/.github/workflows/dymos_docs_workflow.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
   workflow_dispatch:
 
 jobs:
@@ -44,7 +44,7 @@ jobs:
             SNOPT: 7.7
             OPENMDAO: 'dev'
             OPTIONAL: '[docs]'
-            JAX: True
+            JAX: 'dev'
             PUBLISH_DOCS: 0
 
     steps:
@@ -105,8 +105,13 @@ jobs:
           echo "============================================================="
           echo "Install jax"
           echo "============================================================="
-          pip install jax
-          pip install jaxlib
+          if [[ "${{ matrix.JAX }}" == "dev" ]]; then
+            python -m pip install git+https://github.com/google/jax
+          elif [[ "${{ matrix.OPENMDAO }}" == "latest" || "${{ matrix.JAX }}" == "True" ]]; then
+            python -m pip install jax jaxlib
+          else
+            python -m pip install jax=${{ matrix.JAX }} jaxlib=${{ matrix.JAX }}
+          fi
 
       - name: Install PETSc
         if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest') && matrix.PETSc

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -69,7 +69,7 @@ jobs:
             SNOPT: 7.7
             OPENMDAO: 'dev'
             OPTIONAL: '[test]'
-            JAX: True
+            JAX: 'dev'
             DOCS: 0
 
           # oldest supported versions
@@ -144,8 +144,13 @@ jobs:
           echo "============================================================="
           echo "Install jax"
           echo "============================================================="
-          pip install jax
-          pip install jaxlib
+          if [[ "${{ matrix.JAX }}" == "dev" ]]; then
+            python -m pip install git+https://github.com/google/jax
+          elif [[ "${{ matrix.OPENMDAO }}" == "latest" || "${{ matrix.JAX }}" == "True" ]]; then
+            python -m pip install jax jaxlib
+          else
+            python -m pip install jax=${{ matrix.JAX }} jaxlib=${{ matrix.JAX }}
+          fi
 
       - name: Install PETSc
         if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest') && matrix.PETSc

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Summary

Resolves jaxlib issue on pypi for Python 3.11 by installing jax from Google's github repo under the 'latest' matrix test entry.

### Related Issues

- Resolves #848

### Backwards incompatibilities

None

### New Dependencies

None
