### PR TITLE
Added a better error message when the time units are None and introspection fails.

### DIFF
--- a/dymos/phase/test/test_time_units.py
+++ b/dymos/phase/test/test_time_units.py
@@ -1,0 +1,63 @@
+import unittest
+
+import openmdao.api as om
+import dymos as dm
+
+
+class ODENoTaggedStateUnits(om.ExplicitComponent):
+
+    def initialize(self):
+        self.options.declare('num_nodes', types=int)
+
+    def setup(self):
+        nn = self.options['num_nodes']
+
+        # Inputs
+        self.add_input('v', shape=(nn,), desc='velocity', units='m/s')
+
+        self.add_input('g', val=9.80665, desc='grav. acceleration', units='m/s/s', tags=['dymos.static_target'])
+
+        self.add_input('theta', shape=(nn,), desc='angle of wire', units='rad')
+
+        self.add_output('xdot', shape=(nn,), desc='velocity component in x', units='m/s',
+                        tags=['dymos.state_rate_source:x'])
+
+        self.add_output('ydot', shape=(nn,), desc='velocity component in y', units='m/s',
+                        tags=['dymos.state_rate_source:y', 'dymos.state_units:m'])
+
+        self.add_output('vdot', shape=(nn,), desc='acceleration magnitude', units='m/s**2',
+                        tags=['dymos.state_rate_source:v', 'dymos.state_units:m/s'])
+
+    def compute(self, inputs, outputs):
+        pass
+
+    def compute_partials(self, inputs, partials):
+        pass
+
+
+class TestTimeUnits(unittest.TestCase):
+
+    def test_time_units_none(self):
+        p = om.Problem(model=om.Group())
+
+        transcription = dm.Radau(num_segments=10, order=3, compressed=True)
+
+        traj = dm.Trajectory()
+        phase = dm.Phase(ode_class=ODENoTaggedStateUnits,
+                         transcription=transcription)
+        traj.add_phase('phase0', phase)
+
+        p.model.add_subsystem('traj0', traj)
+
+        phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10), units=None)
+
+        with self.assertRaises(RuntimeError) as e:
+            p.setup(check=True, force_alloc_complex=False)
+
+        expected = "Unable to infer the units of state variable `x` from\nthe rate units because the " \
+                   "time units of the phase are set to None.\nChange the time units to something other " \
+                   "than None, or explicitly\nset the state units using one of the following options:\n" \
+                   "- Tag the state rate source `xdot` with `dymos.state_units:{units}`\n" \
+                   "- Use the `set_state_options('x', units={units})` method on the phase."
+
+        self.assertEqual(str(e.exception.__cause__), expected)

--- a/dymos/utils/introspection.py
+++ b/dymos/utils/introspection.py
@@ -513,7 +513,18 @@ def configure_states_introspection(state_options, time_options, control_options,
             options['shape'] = rate_src_shape
 
         if options['units'] is _unspecified:
-            options['units'] = time_units if rate_src_units is None else f'{rate_src_units}*{time_units}'
+            if rate_src_units is None:
+                options['units'] = time_units
+            else:
+                if time_units is None:
+                    raise RuntimeError(f'Unable to infer the units of state variable `{state_name}` from\n'
+                                       f'the rate units because the time units of the phase are set to None.\n'
+                                       f'Change the time units to something other than None, or explicitly\n'
+                                       f'set the state units using one of the following options:\n'
+                                       f'- Tag the state rate source `{rate_src}` with `dymos.state_units:{{units}}`\n'
+                                       f'- Use the `set_state_options(\'{state_name}\', units={{units}})` method on the phase.')
+                else:
+                    options['units'] = f'{rate_src_units}*{time_units}'
 
 
 def configure_analytic_states_introspection(state_options, ode):


### PR DESCRIPTION
### Summary

When using introspection to infer the units of a state variable from a tagged state rate, time units of `None` will result in incompatible units. The provided error message was not helpful, and a more useful one has been developed.  In this situation, if time units are truly `None` then it is the responsibility of the user to provide better time units.

### Related Issues

- Resolves #847 

### Backwards incompatibilities

None

### New Dependencies

None
