### PR TITLE
Update GitHub workflow

### DIFF
--- a/.github/workflows/dymos_docs_workflow.yml
+++ b/.github/workflows/dymos_docs_workflow.yml
@@ -3,11 +3,13 @@
 name: Dymos Docs
 
 on:
-  # Trigger on push, pull request or workflow dispatch events for the master branch
+  # Trigger on push, pull request
   push:
     branches: [ master ]
   pull_request:
     branches: [ master, develop ]
+
+  # Trigger via workflow_dispatch event
   workflow_dispatch:
 
 jobs:
@@ -31,7 +33,7 @@ jobs:
             PYOPTSPARSE: 'v2.8.3'
             OPENMDAO: 'latest'
             OPTIONAL: '[docs]'
-            JAX: True
+            JAX: '0.3.24'
             PUBLISH_DOCS: 1
 
           # make sure the latest versions of things don't break the docs
@@ -44,12 +46,11 @@ jobs:
             SNOPT: 7.7
             OPENMDAO: 'dev'
             OPTIONAL: '[docs]'
-            JAX: 'dev'
+            JAX: '0.3.24'
             PUBLISH_DOCS: 0
 
     steps:
       - name: Display run details
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
         run: |
           echo "============================================================="
           echo "Run #${GITHUB_RUN_NUMBER}"
@@ -60,7 +61,6 @@ jobs:
           echo "============================================================="
 
       - name: Create SSH key
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
         shell: bash
         env:
           SSH_PRIVATE_KEY: ${{secrets.SSH_PRIVATE_KEY}}
@@ -72,16 +72,13 @@ jobs:
           echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
 
       - name: Checkout code
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
         uses: actions/checkout@v2
 
       - name: Fetch tags
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
         run: |
           git fetch --prune --unshallow --tags
 
       - name: Setup conda
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
         uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.PY }}
@@ -90,7 +87,6 @@ jobs:
           channel-priority: true
 
       - name: Install Numpy/Scipy
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -99,22 +95,16 @@ jobs:
           conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
       - name: Install jax
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest') && matrix.JAX
+        if: matrix.JAX
         shell: bash -l {0}
         run: |
           echo "============================================================="
           echo "Install jax"
           echo "============================================================="
-          if [[ "${{ matrix.JAX }}" == "dev" ]]; then
-            python -m pip install git+https://github.com/google/jax
-          elif [[ "${{ matrix.OPENMDAO }}" == "latest" || "${{ matrix.JAX }}" == "True" ]]; then
-            python -m pip install jax jaxlib
-          else
-            python -m pip install jax=${{ matrix.JAX }} jaxlib=${{ matrix.JAX }}
-          fi
+          python -m pip install jaxlib==${{ matrix.JAX }} jax==${{ matrix.JAX }}
 
       - name: Install PETSc
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest') && matrix.PETSc
+        if: matrix.PETSc
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -137,7 +127,7 @@ jobs:
           echo "OMPI_MCA_rmaps_base_oversubscribe=1" >> $GITHUB_ENV
 
       - name: Install pyOptSparse
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest') && matrix.PYOPTSPARSE
+        if: matrix.PYOPTSPARSE
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -183,7 +173,7 @@ jobs:
           fi
 
       - name: Install OpenMDAO
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest') && matrix.OPENMDAO
+        if: matrix.OPENMDAO
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -198,7 +188,6 @@ jobs:
           fi
 
       - name: Install juptyter-book and jupyter
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -208,7 +197,6 @@ jobs:
 
 
       - name: Install bokeh
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -217,7 +205,6 @@ jobs:
           conda install bokeh
 
       - name: Install Dymos
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -226,7 +213,6 @@ jobs:
           pip install .${{ matrix.OPTIONAL }}
 
       - name: Display environment info
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
         shell: bash -l {0}
         run: |
           conda info
@@ -245,7 +231,6 @@ jobs:
                     f'Scipy version {scipy.__version__} is not the requested version (${{ matrix.SCIPY }})'"
 
       - name: Build docs
-        if: (github.event_name != 'workflow_dispatch')
         id: build_docs
         shell: bash -l {0}
         run: |
@@ -259,9 +244,7 @@ jobs:
 
       - name: Display doc build reports
         continue-on-error: True
-        if: |
-          github.event_name != 'workflow_dispatch' &&
-          failure() && steps.build_docs.outcome == 'failure'
+        if: failure() && steps.build_docs.outcome == 'failure'
         run: |
           for f in /home/runner/work/dymos/dymos/docs/dymos_book/_build/html/reports/*; do
             echo "============================================================="

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -6,11 +6,13 @@
 name: Dymos Tests
 
 on:
-  # Trigger on push, pull request or workflow dispatch events for the master branch
+  # Trigger on push, pull request
   push:
     branches: [ master ]
   pull_request:
     branches: [ master, develop ]
+
+  # Trigger via workflow_dispatch event
   workflow_dispatch:
 
 jobs:
@@ -34,7 +36,7 @@ jobs:
             SNOPT: 7.7
             OPENMDAO: 'latest'
             OPTIONAL: '[test]'
-            JAX: True
+            JAX: '0.3.24'
             DOCS: 0
 
           # baseline versions except no pyoptsparse or SNOPT
@@ -69,7 +71,7 @@ jobs:
             SNOPT: 7.7
             OPENMDAO: 'dev'
             OPTIONAL: '[test]'
-            JAX: 'dev'
+            JAX: '0.3.24'
             DOCS: 0
 
           # oldest supported versions
@@ -88,7 +90,6 @@ jobs:
 
     steps:
       - name: Display run details
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
         run: |
           echo "============================================================="
           echo "Run #${GITHUB_RUN_NUMBER}"
@@ -98,8 +99,20 @@ jobs:
           echo "Initiated by: ${GITHUB_ACTOR}"
           echo "============================================================="
 
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [[ "${{ matrix.NAME }}" == "latest" ]]; then
+              echo "Triggered by 'workflow_dispatch' event, will run '${{ matrix.NAME }}' build."
+              echo "RUN_BUILD=true" >> $GITHUB_ENV
+            else
+              echo "Triggered by 'workflow_dispatch' event, will not run '${{ matrix.NAME }}' build."
+            fi
+          else
+            echo "Triggered by '${{ github.event_name }}' event, running all builds."
+            echo "RUN_BUILD=true" >> $GITHUB_ENV
+          fi
+
       - name: Create SSH key
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
+        if: env.RUN_BUILD
         shell: bash
         env:
           SSH_PRIVATE_KEY: ${{secrets.SSH_PRIVATE_KEY}}
@@ -111,16 +124,16 @@ jobs:
           echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
 
       - name: Checkout code
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
+        if: env.RUN_BUILD
         uses: actions/checkout@v2
 
       - name: Fetch tags
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
+        if: env.RUN_BUILD
         run: |
           git fetch --prune --unshallow --tags
 
       - name: Setup conda
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
+        if: env.RUN_BUILD
         uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.PY }}
@@ -129,7 +142,7 @@ jobs:
           channel-priority: true
 
       - name: Install Numpy/Scipy
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
+        if: env.RUN_BUILD
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -138,22 +151,16 @@ jobs:
           conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
       - name: Install jax
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest') && matrix.JAX
+        if: env.RUN_BUILD && matrix.JAX
         shell: bash -l {0}
         run: |
           echo "============================================================="
           echo "Install jax"
           echo "============================================================="
-          if [[ "${{ matrix.JAX }}" == "dev" ]]; then
-            python -m pip install git+https://github.com/google/jax
-          elif [[ "${{ matrix.OPENMDAO }}" == "latest" || "${{ matrix.JAX }}" == "True" ]]; then
-            python -m pip install jax jaxlib
-          else
-            python -m pip install jax=${{ matrix.JAX }} jaxlib=${{ matrix.JAX }}
-          fi
+          python -m pip install jaxlib==${{ matrix.JAX }} jax==${{ matrix.JAX }}
 
       - name: Install PETSc
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest') && matrix.PETSc
+        if: env.RUN_BUILD && matrix.PETSc
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -177,7 +184,8 @@ jobs:
           echo "-----------------------"
 
       - name: Install pyOptSparse
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest') && matrix.PYOPTSPARSE
+        id: build_pyoptsparse
+        if: env.RUN_BUILD && matrix.PYOPTSPARSE
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -223,7 +231,7 @@ jobs:
           fi
 
       - name: Install OpenMDAO
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest') && matrix.OPENMDAO
+        if: env.RUN_BUILD && matrix.OPENMDAO
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -238,7 +246,7 @@ jobs:
           fi
 
       - name: Install optional dependencies
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest') && matrix.OPTIONAL == '[all]'
+        if: env.RUN_BUILD && matrix.OPTIONAL == '[all]'
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -247,7 +255,7 @@ jobs:
           pip install bokeh
 
       - name: Install Dymos
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
+        if: env.RUN_BUILD
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -256,7 +264,7 @@ jobs:
           pip install .${{ matrix.OPTIONAL }}
 
       - name: Display environment info
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
+        if: env.RUN_BUILD
         shell: bash -l {0}
         run: |
           conda info
@@ -275,7 +283,7 @@ jobs:
                     f'Scipy version {scipy.__version__} is not the requested version (${{ matrix.SCIPY }})'"
 
       - name: Run tests
-        if: (github.event_name != 'workflow_dispatch' || matrix.NAME == 'latest')
+        if: env.RUN_BUILD
         env:
           DYMOS_CHECK_PARTIALS: True
         shell: bash -l {0}
@@ -308,7 +316,7 @@ jobs:
           coveralls --basedir $SITE_DIR
 
       - name: Build docs
-        if: (github.event_name != 'workflow_dispatch') && (matrix.DOCS == '1' || matrix.DOCS == '2')
+        if: env.RUN_BUILD && (matrix.DOCS == '1' || matrix.DOCS == '2')
         id: build_docs
         shell: bash -l {0}
         run: |
@@ -323,9 +331,7 @@ jobs:
       - name: Display doc build reports
         continue-on-error: True
         if: |
-          github.event_name != 'workflow_dispatch' &&
-          failure() &&
-          (matrix.DOCS == '1' || matrix.DOCS == '2') &&
+          env.RUN_BUILD && (matrix.DOCS == '1' || matrix.DOCS == '2') &&
           steps.build_docs.outcome == 'failure'
         run: |
           for f in /home/runner/work/dymos/dymos/docs/dymos_book/_build/html/reports/*; do

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -332,7 +332,7 @@ jobs:
         continue-on-error: True
         if: |
           env.RUN_BUILD && (matrix.DOCS == '1' || matrix.DOCS == '2') &&
-          steps.build_docs.outcome == 'failure'
+          failure() && steps.build_docs.outcome == 'failure'
         run: |
           for f in /home/runner/work/dymos/dymos/docs/dymos_book/_build/html/reports/*; do
             echo "============================================================="

--- a/docs/dymos_book/examples/brachistochrone/brachistochrone_tandem_phases.ipynb
+++ b/docs/dymos_book/examples/brachistochrone/brachistochrone_tandem_phases.ipynb
@@ -321,7 +321,7 @@
     "    legend_contents.append((label, [circle, line]))\n",
     "    i += 1\n",
     "    \n",
-    "p1 = figure(plot_width=800, plot_height=300)\n",
+    "p1 = figure(width=800, height=300)\n",
     "add_plot(p1, sol_t0, sol_x, 'x (m)', i)\n",
     "add_plot(p1, sol_t0, sol_y, 'y (m)', i)\n",
     "add_plot(p1, sol_t0, sol_v, 'v', i)\n",

--- a/dymos/visualization/timeseries_plots.py
+++ b/dymos/visualization/timeseries_plots.py
@@ -185,8 +185,8 @@ def _bokeh_timeseries_plots(time_units, var_units, phase_names, phases_node_path
         # add labels, title, and legend
         padding = 0.05 * (max_time - min_time)
         fig = figure(title=title, background_fill_color=bg_fill_color,
-                     x_range=(min_time - padding, max_time + padding), plot_width=180,
-                     plot_height=180)
+                     x_range=(min_time - padding, max_time + padding),
+                     width=180, height=180)
         fig.xaxis.axis_label = time_label
         fig.yaxis.axis_label = var_label
         fig.xgrid.grid_line_color = grid_line_color
@@ -235,7 +235,7 @@ def _bokeh_timeseries_plots(time_units, var_units, phase_names, phases_node_path
 
     # ## Use a dummy figure for the LEGEND
     dum_fig = figure(outline_line_alpha=0, toolbar_location=None,
-                     background_fill_color=bg_fill_color, plot_width=250, max_width=250)
+                     background_fill_color=bg_fill_color, width=250, max_width=250)
 
     # set the components of the figure invisible
     for fig_component in [dum_fig.grid, dum_fig.ygrid, dum_fig.xaxis, dum_fig.yaxis]:


### PR DESCRIPTION
### Summary

The original intent was to update the GitHub workflow to get a working Python 3.11 build.  That was overcome by events, as `conda-forge` was updated with a compatible version of PETSc in the past few days.

A new version of `jax`/`jaxlib` was also published, which addressed another problem with the `latest` build.

This PR updates the workflow with the following changes:

- sets the version of `jax` and `jaxlib` to the latest, working version for all builds
- removes the `workflow_dispatch` logic from the docs workflow where it does not apply
- cleans up the `workflow_dispatch` logic in the tests workflow to be more readable and less messy
- fixes an issue with a deprecation that was removed from `bokeh`

### Related Issues

- Resolves #850

### Backwards incompatibilities

None

### New Dependencies

None
