### PR TITLE
Added ability to control continuity scaling for states and controls.

### DIFF
--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -91,23 +91,37 @@ class ControlOptionsDictionary(om.OptionsDictionary):
                      desc='Enforce continuity of control values at segment boundaries. This '
                           'option is invalid if opt=False.')
 
+        self.declare(name='continuity_scaler', types=(Number,), default=None, allow_none=True,
+                     desc='Scaler for continuity at segment boundaries. This '
+                          'option is invalid if opt=False.')
+
+        self.declare(name='continuity_ref', types=(Number,), default=None, allow_none=True,
+                     desc='Reference unit value for continuity at segment boundaries instead of scaler.'
+                          'This option is invalid if opt=False.')
+
         self.declare(name='rate_continuity', types=(bool, dict), default=True,
                      desc='Enforce continuity of control first derivatives in dimensionless time '
                           'at segment boundaries. '
                           'This option is invalid if opt=False.')
 
-        self.declare(name='rate_continuity_scaler', types=(Number,), default=1.0,
-                     desc='Scaler of the dimensionless rate continuity constraint at '
-                          'segment boundaries. '
+        self.declare(name='rate_continuity_scaler', types=(Number,), default=None, allow_none=True,
+                     desc='Scaler of the rate continuity constraint at segment boundaries. '
+                          'This option is invalid if opt=False.')
+
+        self.declare(name='rate_continuity_ref', types=(Number,), default=None, allow_none=True,
+                     desc='Reference unit value for rate continuity at segment boundaries instead of scaler.'
                           'This option is invalid if opt=False.')
 
         self.declare(name='rate2_continuity', types=(bool, dict), default=False,
                      desc='Enforce continuity of control second derivatives at segment boundaries. '
                           'This option is invalid if opt=False.')
 
-        self.declare(name='rate2_continuity_scaler', types=(Number,), default=1.0,
-                     desc='Scaler of the dimensionless rate continuity constraint at '
-                          'segment boundaries. '
+        self.declare(name='rate2_continuity_scaler', types=(Number,), default=None, allow_none=True,
+                     desc='Scaler of the rate2 continuity constraint at segment boundaries. '
+                          'This option is invalid if opt=False.')
+
+        self.declare(name='rate2_continuity_ref', types=(Number,), default=None, allow_none=True,
+                     desc='Reference unit value for rate2 continuity at segment boundaries instead of scaler.'
                           'This option is invalid if opt=False.')
 
 
@@ -443,6 +457,14 @@ class StateOptionsDictionary(om.OptionsDictionary):
         self.declare(name='continuity', types=(bool, dict), default=True,
                      desc='Enforce continuity of state values at segment boundaries. This '
                           'option is invalid if opt=False.')
+
+        self.declare(name='continuity_scaler', types=(Number,), default=None, allow_none=True,
+                     desc='Scaler for continuity at segment boundaries. This '
+                          'option is invalid if opt=False.')
+
+        self.declare(name='continuity_ref', types=(Number,), default=None, allow_none=True,
+                     desc='Reference unit value for continuity at segment boundaries instead of scaler.'
+                          'This option is invalid if opt=False.')
 
         self.declare(name='solve_segments', default=None, allow_none=True,
                      values=(False, 'forward', 'backward'),

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -215,8 +215,8 @@ class Phase(om.Group):
                           val=_unspecified, fix_initial=_unspecified, fix_final=_unspecified,
                           lower=_unspecified, upper=_unspecified, scaler=_unspecified, adder=_unspecified,
                           ref0=_unspecified, ref=_unspecified, defect_scaler=_unspecified,
-                          continuity_scaler=_unspecified, continuity_ref=_unspecified,
-                          defect_ref=_unspecified, solve_segments=_unspecified, connected_initial=_unspecified,
+                          defect_ref=_unspecified, continuity_scaler=_unspecified, continuity_ref=_unspecified,
+                          solve_segments=_unspecified, connected_initial=_unspecified,
                           source=_unspecified, input_initial=_unspecified, initial_targets=_unspecified,
                           opt=_unspecified, initial_bounds=_unspecified, final_bounds=_unspecified):
         """

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -116,7 +116,8 @@ class Phase(om.Group):
                   val=_unspecified, fix_initial=_unspecified, fix_final=_unspecified,
                   lower=_unspecified, upper=_unspecified, scaler=_unspecified, adder=_unspecified,
                   ref0=_unspecified, ref=_unspecified, defect_scaler=_unspecified,
-                  defect_ref=_unspecified, solve_segments=_unspecified, connected_initial=_unspecified,
+                  defect_ref=_unspecified, continuity_scaler=_unspecified, continuity_ref=_unspecified,
+                  solve_segments=_unspecified, connected_initial=_unspecified,
                   source=_unspecified, input_initial=_unspecified, initial_targets=_unspecified,
                   opt=_unspecified, initial_bounds=_unspecified, final_bounds=_unspecified):
         """
@@ -167,6 +168,12 @@ class Phase(om.Group):
         defect_ref : float or ndarray
             The unit-reference value of the state defect at the collocation nodes of the phase. If
             provided, this value overrides defect_scaler.
+        continuity_scaler : float
+            Constraint scaler used to enforce the continuity mismatch defect between segments when transcription
+            is not compressed.
+        continuity_ref : float
+            Reference unit value of the continuity mismatch defect between segments when transcription is not
+            compressed. Used in place of scaler.
         solve_segments : bool(False)
             If True, a solver will be used to converge the collocation defects within a segment.
             Note that the state continuity defects between segements will still be
@@ -197,7 +204,8 @@ class Phase(om.Group):
                                targets=targets, val=val, fix_initial=fix_initial,
                                fix_final=fix_final, lower=lower, upper=upper, scaler=scaler,
                                adder=adder, ref0=ref0, ref=ref, defect_scaler=defect_scaler,
-                               defect_ref=defect_ref, solve_segments=solve_segments,
+                               defect_ref=defect_ref, continuity_scaler=continuity_scaler,
+                               continuity_ref=continuity_ref, solve_segments=solve_segments,
                                connected_initial=connected_initial, source=source, input_initial=input_initial,
                                initial_targets=initial_targets, opt=opt, initial_bounds=initial_bounds,
                                final_bounds=final_bounds)
@@ -207,6 +215,7 @@ class Phase(om.Group):
                           val=_unspecified, fix_initial=_unspecified, fix_final=_unspecified,
                           lower=_unspecified, upper=_unspecified, scaler=_unspecified, adder=_unspecified,
                           ref0=_unspecified, ref=_unspecified, defect_scaler=_unspecified,
+                          continuity_scaler=_unspecified, continuity_ref=_unspecified,
                           defect_ref=_unspecified, solve_segments=_unspecified, connected_initial=_unspecified,
                           source=_unspecified, input_initial=_unspecified, initial_targets=_unspecified,
                           opt=_unspecified, initial_bounds=_unspecified, final_bounds=_unspecified):
@@ -258,6 +267,12 @@ class Phase(om.Group):
         defect_ref : float or ndarray
             The unit-reference value of the state defect at the collocation nodes of the phase. If
             provided, this value overrides defect_scaler.
+        continuity_scaler : float
+            Constraint scaler used to enforce the continuity mismatch defect between segments when transcription
+            is not compressed.
+        continuity_ref : float
+            Reference unit value of the continuity mismatch defect between segments when transcription is not
+            compressed. Used in place of scaler.
         solve_segments : bool(False)
             If True, a solver will be used to converge the collocation defects within a segment.
             Note that the state continuity defects between segements will still be
@@ -333,6 +348,12 @@ class Phase(om.Group):
         if defect_ref is not _unspecified:
             self.state_options[name]['defect_ref'] = defect_ref
 
+        if continuity_scaler is not _unspecified:
+            self.state_options[name]['continuity_scaler'] = continuity_scaler
+
+        if continuity_ref is not _unspecified:
+            self.state_options[name]['continuity_ref'] = continuity_ref
+
         if solve_segments is not _unspecified:
             self.state_options[name]['solve_segments'] = solve_segments
 
@@ -394,9 +415,10 @@ class Phase(om.Group):
                     rate_targets=_unspecified, rate2_targets=_unspecified, val=_unspecified,
                     shape=_unspecified, lower=_unspecified, upper=_unspecified, scaler=_unspecified,
                     adder=_unspecified, ref0=_unspecified, ref=_unspecified, continuity=_unspecified,
-                    continuity_scaler=_unspecified, rate_continuity=_unspecified,
-                    rate_continuity_scaler=_unspecified, rate2_continuity=_unspecified,
-                    rate2_continuity_scaler=_unspecified):
+                    continuity_scaler=_unspecified, continuity_ref=_unspecified, rate_continuity=_unspecified,
+                    rate_continuity_scaler=_unspecified, rate_continuity_ref=_unspecified,
+                    rate2_continuity=_unspecified, rate2_continuity_scaler=_unspecified,
+                    rate2_continuity_ref=_unspecified):
         """
         Adds a dynamic control variable to be tied to a parameter in the ODE.
 
@@ -457,6 +479,8 @@ class Phase(om.Group):
             Scaler of the continuity constraint. This option is invalid if opt=False.  This
             option is only relevant in the Radau pseudospectral transcription where the continuity
             constraint is nonlinear.  For Gauss-Lobatto the continuity constraint is linear.
+        continuity_ref : bool
+            Reference unit value to be used in place of continuity scaler.
         rate_continuity : bool
             Enforce continuity of control first derivatives  (in dimensionless time) at
             segment boundaries.
@@ -464,12 +488,18 @@ class Phase(om.Group):
         rate_continuity_scaler : float
             Scaler of the rate continuity constraint at segment boundaries.
             This option is invalid if opt=False.
-        rate2_continuity : bool
+        rate_continuity_ref : float or None
+            Reference unit value of the rate continuity constraint at segment boundaries, for use in
+            place of rate_continuity_scaler.
+        rate2_continuity : bool or None
             Enforce continuity of control second derivatives at segment boundaries.
             This option is invalid if opt=False.
-        rate2_continuity_scaler : float
+        rate2_continuity_scaler : float or None
             Scaler of the dimensionless rate continuity constraint at segment boundaries.
             This option is invalid if opt=False.
+        rate2_continuity_ref : float or None
+            Reference unit value of the rate2 continuity constraint at segment boundaries, for use in
+            place of rate_continuity_scaler.
 
         Notes
         -----
@@ -480,19 +510,27 @@ class Phase(om.Group):
             self.control_options[name] = ControlOptionsDictionary()
             self.control_options[name]['name'] = name
 
-        self.set_control_options(name, units, desc, opt, fix_initial, fix_final, targets,
-                                 rate_targets, rate2_targets, val, shape, lower, upper, scaler,
-                                 adder, ref0, ref, continuity, continuity_scaler, rate_continuity,
-                                 rate_continuity_scaler, rate2_continuity, rate2_continuity_scaler)
+        self.set_control_options(name, units=units, desc=desc, opt=opt, fix_initial=fix_initial,
+                                 fix_final=fix_final, targets=targets, rate_targets=rate_targets,
+                                 rate2_targets=rate2_targets, val=val, shape=shape, lower=lower,
+                                 upper=upper, scaler=scaler, adder=adder, ref0=ref0, ref=ref,
+                                 continuity=continuity, continuity_scaler=continuity_scaler,
+                                 continuity_ref=continuity_ref, rate_continuity=rate_continuity,
+                                 rate_continuity_scaler=rate_continuity_scaler,
+                                 rate_continuity_ref=rate_continuity_ref,
+                                 rate2_continuity=rate2_continuity,
+                                 rate2_continuity_scaler=rate2_continuity_scaler,
+                                 rate2_continuity_ref=rate2_continuity_ref)
 
     def set_control_options(self, name, units=_unspecified, desc=_unspecified, opt=_unspecified,
                             fix_initial=_unspecified, fix_final=_unspecified, targets=_unspecified,
                             rate_targets=_unspecified, rate2_targets=_unspecified, val=_unspecified,
                             shape=_unspecified, lower=_unspecified, upper=_unspecified, scaler=_unspecified,
                             adder=_unspecified, ref0=_unspecified, ref=_unspecified, continuity=_unspecified,
-                            continuity_scaler=_unspecified, rate_continuity=_unspecified,
-                            rate_continuity_scaler=_unspecified, rate2_continuity=_unspecified,
-                            rate2_continuity_scaler=_unspecified):
+                            continuity_scaler=_unspecified, continuity_ref=_unspecified,
+                            rate_continuity=_unspecified, rate_continuity_scaler=_unspecified,
+                            rate_continuity_ref=_unspecified, rate2_continuity=_unspecified,
+                            rate2_continuity_scaler=_unspecified, rate2_continuity_ref=_unspecified):
         """
         Set options on an existing dynamic control variable in the phase.
 
@@ -553,6 +591,8 @@ class Phase(om.Group):
             Scaler of the continuity constraint. This option is invalid if opt=False.  This
             option is only relevant in the Radau pseudospectral transcription where the continuity
             constraint is nonlinear.  For Gauss-Lobatto the continuity constraint is linear.
+        continuity_ref : bool
+            Reference unit value to be used in place of continuity scaler.
         rate_continuity : bool
             Enforce continuity of control first derivatives  (in dimensionless time) at
             segment boundaries.
@@ -560,12 +600,18 @@ class Phase(om.Group):
         rate_continuity_scaler : float
             Scaler of the rate continuity constraint at segment boundaries.
             This option is invalid if opt=False.
-        rate2_continuity : bool
+        rate_continuity_ref : float or None
+            Reference unit value of the rate continuity constraint at segment boundaries, for use in
+            place of rate_continuity_scaler.
+        rate2_continuity : bool or None
             Enforce continuity of control second derivatives at segment boundaries.
             This option is invalid if opt=False.
-        rate2_continuity_scaler : float
+        rate2_continuity_scaler : float or None
             Scaler of the dimensionless rate continuity constraint at segment boundaries.
             This option is invalid if opt=False.
+        rate2_continuity_ref : float or None
+            Reference unit value of the rate2 continuity constraint at segment boundaries, for use in
+            place of rate_continuity_scaler.
 
         Notes
         -----
@@ -634,17 +680,26 @@ class Phase(om.Group):
         if continuity_scaler is not _unspecified:
             self.control_options[name]['continuity_scaler'] = continuity_scaler
 
+        if continuity_ref is not _unspecified:
+            self.control_options[name]['continuity_ref'] = continuity_ref
+
         if rate_continuity is not _unspecified:
             self.control_options[name]['rate_continuity'] = rate_continuity
 
         if rate_continuity_scaler is not _unspecified:
             self.control_options[name]['rate_continuity_scaler'] = rate_continuity_scaler
 
+        if rate_continuity_ref is not _unspecified:
+            self.control_options[name]['rate_continuity_ref'] = rate_continuity_ref
+
         if rate2_continuity is not _unspecified:
             self.control_options[name]['rate2_continuity'] = rate2_continuity
 
         if rate2_continuity_scaler is not _unspecified:
             self.control_options[name]['rate2_continuity_scaler'] = rate2_continuity_scaler
+
+        if rate2_continuity_ref is not _unspecified:
+            self.control_options[name]['rate2_continuity_ref'] = rate2_continuity_ref
 
     def add_polynomial_control(self, name, order, desc=_unspecified, val=_unspecified, units=_unspecified,
                                opt=_unspecified, fix_initial=_unspecified, fix_final=_unspecified,

--- a/dymos/phase/test/test_phase.py
+++ b/dymos/phase/test/test_phase.py
@@ -285,6 +285,7 @@ class TestPhaseBase(unittest.TestCase):
         phase.add_state('v', fix_initial=True, fix_final=False)
 
         phase.add_control('theta', continuity=True, rate_continuity=True, opt=True,
+                          rate_continuity_scaler=1.0,
                           units='deg', lower=0.01, upper=179.9, ref=1, ref0=0)
 
         phase.add_parameter('g', opt=True, units='m/s**2', val=9.80665)
@@ -434,19 +435,20 @@ class TestPhaseBase(unittest.TestCase):
         phase = dm.Phase(ode_class=BrachistochroneODE,
                          transcription=dm.GaussLobatto(num_segments=20,
                                                        order=3,
-                                                       compressed=True))
+                                                       compressed=False))
 
         p.model.add_subsystem('phase0', phase)
 
         phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
 
-        phase.add_state('x', fix_initial=True, fix_final=False)
+        phase.add_state('x', fix_initial=True, fix_final=False, continuity_scaler=1.0)
 
-        phase.add_state('y', fix_initial=True, fix_final=False)
+        phase.add_state('y', fix_initial=True, fix_final=False, continuity_ref=1.0)
 
         phase.add_state('v', fix_initial=True, fix_final=False)
 
         phase.add_control('theta', continuity=True, rate_continuity=True, rate2_continuity=True,
+                          rate_continuity_scaler=0.01, rate2_continuity_scaler=0.01,
                           units='deg', lower=0.01, upper=179.9)
 
         phase.add_parameter('g', opt=False, units='m/s**2', val=9.80665)
@@ -502,19 +504,20 @@ class TestPhaseBase(unittest.TestCase):
                 p.driver.declare_coloring()
 
                 phase = dm.Phase(ode_class=BrachistochroneODE,
-                                 transcription=tx(num_segments=5, order=3))
+                                 transcription=tx(num_segments=5, order=3, compressed=False))
 
                 p.model.add_subsystem('phase0', phase)
 
                 phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
 
-                phase.add_state('x', fix_initial=True, fix_final=False)
+                phase.add_state('x', fix_initial=True, fix_final=False, continuity_scaler=1.0)
 
-                phase.add_state('y', fix_initial=True, fix_final=False)
+                phase.add_state('y', fix_initial=True, fix_final=False, continuity_ref=1.0)
 
                 phase.add_state('v', fix_initial=True, fix_final=False)
 
                 phase.add_control('theta', continuity=True, rate_continuity=True, rate2_continuity=True,
+                                  rate_continuity_ref=100., rate2_continuity_scaler=0.01,
                                   units='deg', lower=0.01, upper=179.9)
 
                 phase.add_parameter('g', opt=True, units='m/s**2', val=9.80665)
@@ -549,19 +552,20 @@ class TestPhaseBase(unittest.TestCase):
                 p.driver.declare_coloring()
 
                 phase = dm.Phase(ode_class=BrachistochroneODE,
-                                 transcription=tx(num_segments=5, order=3))
+                                 transcription=tx(num_segments=5, order=3, compressed=False))
 
                 p.model.add_subsystem('phase0', phase)
 
                 phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
 
-                phase.add_state('x', fix_initial=True, fix_final=False)
+                phase.add_state('x', fix_initial=True, fix_final=False, continuity_scaler=1.0)
 
-                phase.add_state('y', fix_initial=True, fix_final=False)
+                phase.add_state('y', fix_initial=True, fix_final=False, continuity_ref=1.0)
 
                 phase.add_state('v', fix_initial=True, fix_final=False)
 
                 phase.add_control('theta', continuity=True, rate_continuity=True, rate2_continuity=True,
+                                  rate_continuity_scaler=0.01, rate2_continuity_ref=1.0,
                                   units='deg', lower=0.01, upper=179.9)
 
                 phase.add_parameter('g', opt=True, units='m/s**2', val=9.80665)

--- a/dymos/transcriptions/common/continuity_comp.py
+++ b/dymos/transcriptions/common/continuity_comp.py
@@ -338,7 +338,9 @@ class GaussLobattoContinuityComp(ContinuityCompBase):
                 # but nonlinear if solve_segments, because its like multiple shooting
                 is_linear = not options['solve_segments']
                 self.add_constraint(name=f'defect_states:{state_name}',
-                                    equals=0.0, scaler=1.0, linear=is_linear)
+                                    scaler=options['continuity_scaler'],
+                                    ref=options['continuity_ref'],
+                                    equals=0.0, linear=is_linear)
 
     def _configure_control_continuity(self):
         control_options = self.options['control_options']
@@ -355,7 +357,9 @@ class GaussLobattoContinuityComp(ContinuityCompBase):
 
             if options['continuity'] and not compressed:
                 self.add_constraint(name=f'defect_controls:{control_name}',
-                                    equals=0.0, scaler=1.0, linear=True)
+                                    scaler=options['continuity_scaler'],
+                                    ref=options['continuity_ref'],
+                                    equals=0.0, linear=True)
 
             #
             # Setup first derivative continuity
@@ -363,8 +367,9 @@ class GaussLobattoContinuityComp(ContinuityCompBase):
 
             if options['rate_continuity']:
                 self.add_constraint(name=f'defect_control_rates:{control_name}_rate',
-                                    equals=0.0, scaler=options['rate_continuity_scaler'],
-                                    linear=False)
+                                    scaler=options['rate_continuity_scaler'],
+                                    ref=options['rate_continuity_ref'],
+                                    equals=0.0, linear=False)
 
             #
             # Setup second derivative continuity
@@ -372,8 +377,9 @@ class GaussLobattoContinuityComp(ContinuityCompBase):
 
             if options['rate2_continuity']:
                 self.add_constraint(name=f'defect_control_rates:{control_name}_rate2',
-                                    equals=0.0, scaler=options['rate2_continuity_scaler'],
-                                    linear=False)
+                                    scaler=options['rate2_continuity_scaler'],
+                                    ref=options['rate2_continuity_ref'],
+                                    equals=0.0, linear=False)
 
 
 class RadauPSContinuityComp(ContinuityCompBase):
@@ -402,7 +408,9 @@ class RadauPSContinuityComp(ContinuityCompBase):
                 is_linear = not options['solve_segments']
 
                 self.add_constraint(name=f'defect_states:{state_name}',
-                                    equals=0.0, scaler=1.0, linear=is_linear)
+                                    scaler=options['continuity_scaler'],
+                                    ref=options['continuity_ref'],
+                                    equals=0.0, linear=is_linear)
 
     def _configure_control_continuity(self):
         control_options = self.options['control_options']
@@ -417,7 +425,9 @@ class RadauPSContinuityComp(ContinuityCompBase):
         for control_name, options in control_options.items():
             if options['continuity']:
                 self.add_constraint(name=f'defect_controls:{control_name}',
-                                    equals=0.0, scaler=1.0, linear=False)
+                                    scaler=options['continuity_scaler'],
+                                    ref=options['continuity_ref'],
+                                    equals=0.0, linear=False)
 
             #
             # Setup first derivative continuity
@@ -425,8 +435,9 @@ class RadauPSContinuityComp(ContinuityCompBase):
 
             if options['rate_continuity']:
                 self.add_constraint(name=f'defect_control_rates:{control_name}_rate',
-                                    equals=0.0, scaler=options['rate_continuity_scaler'],
-                                    linear=False)
+                                    scaler=options['rate_continuity_scaler'],
+                                    ref=options['rate_continuity_ref'],
+                                    equals=0.0, linear=False)
 
             #
             # Setup second derivative continuity
@@ -434,5 +445,6 @@ class RadauPSContinuityComp(ContinuityCompBase):
 
             if options['rate2_continuity']:
                 self.add_constraint(name=f'defect_control_rates:{control_name}_rate2',
-                                    equals=0.0, scaler=options['rate2_continuity_scaler'],
-                                    linear=False)
+                                    scaler=options['rate2_continuity_scaler'],
+                                    ref=options['rate2_continuity_ref'],
+                                    equals=0.0, linear=False)


### PR DESCRIPTION
### Summary

States now have the following options:
- continuity_scaler
- continuity_ref

Which apply when the transcription is not compressed.

Controls now have the following options:
- continuity_scaler
- continuity_ref
- rate_continuity_scaler (previously existed)
- rate_continuity_ref
- rate2_continuity_scaler (previously existed)
- rate2_continuity_ref

Continuity scaling applies to radau controls regardless of compression of the transcription.
Rate scaling now has an option to use a ref value.

### Related Issues

- Resolves #865

### Backwards incompatibilities

None

### New Dependencies

None
