### PR TITLE
Fixed url in _config.yml so that documentation examples can open at the Google colab.

### DIFF
--- a/docs/dymos_book/_config.yml
+++ b/docs/dymos_book/_config.yml
@@ -26,7 +26,7 @@ bibtex_bibfiles:
 # Information about where the book exists on the web
 repository:
   url: https://github.com/OpenMDAO/dymos  # Online location of your book
-  path_to_book: docs  # Optional path to your book, relative to the repository root
+  path_to_book: docs/dymos_book  # Optional path to your book, relative to the repository root
   branch: master  # Which branch of the repository should be used when creating links (optional)
 
 # Add GitHub buttons to your book


### PR DESCRIPTION
### Summary

This fixes a pathing issue when attempting to open the examples in the docs at the Google Colab.

### Related Issues

- Resolves #867 

### Backwards incompatibilities

None

### New Dependencies

None
