### PR TITLE
Fixed dymos.load_case so that it does not load states or controls into AnalyticPhases

### DIFF
--- a/dymos/phase/test/test_analytic_phase.py
+++ b/dymos/phase/test/test_analytic_phase.py
@@ -74,6 +74,7 @@ class SimpleBVPSolution(om.ExplicitComponent):
         outputs['y'] = x ** 4 / 12 - x ** 3 / 6 + c_1 * x + c_2
 
 
+@use_tempdirs
 class TestAnalyticPhaseSimpleResults(unittest.TestCase):
 
     def test_simple_ivp_system(self):

--- a/dymos/phase/test/test_analytic_phase.py
+++ b/dymos/phase/test/test_analytic_phase.py
@@ -239,8 +239,6 @@ class TestAnalyticPhaseSimpleResults(unittest.TestCase):
         assert_near_equal(y, expected(t))
 
 
-
-
 @use_tempdirs
 class TestAnalyticPhaseInvalidOptions(unittest.TestCase):
 


### PR DESCRIPTION
### Summary

In the case of AnalyticPhase, states are not inputs and controls/polynomial_controls are non-existent.  We should not be loading these for analytic phase.

### Related Issues

- Resolves #870

### Backwards incompatibilities

None

### New Dependencies

None
