### PR TITLE
Fixed a unnecessary error when linking phases with different units via connection.

### DIFF
--- a/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
@@ -121,8 +121,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
         with self.assertRaises(ValueError) as e:
             p.setup(check=True, force_alloc_complex=True)
 
-        expected_exception = 'Error in linking accel from burn1 to accel in burn2: Linkage units ' \
-                             'were not specified but the units of var_a (DU/TU**2) and var_b ' \
+        expected_exception = 'traj: Linkage units were not specified but the units of var_a (DU/TU**2) and var_b ' \
                              '(km/s**2) are not the same. Units for this linkage constraint must ' \
                              'be specified explicitly.'
 

--- a/dymos/trajectory/test/test_trajectory.py
+++ b/dymos/trajectory/test/test_trajectory.py
@@ -1156,7 +1156,7 @@ class TestInvalidLinkages(unittest.TestCase):
         with self.assertRaises(RuntimeError) as e:
             p.setup(check=True)
 
-        self.assertEqual(str(e.exception), 'Error in linking bar from burn1 to bar in burn2: '
+        self.assertEqual(str(e.exception), 'Error in linking bar from burn1 to bar in burn2. '
                                            'Unable to find variable \'bar\' in phase '
                                            '\'phases.burn1\' or its ODE.')
 
@@ -1602,6 +1602,256 @@ class TestInvalidLinkages(unittest.TestCase):
 
         assert_near_equal(lnk_1_output, lnk_1_manual)
         assert_near_equal(lnk_2_output, lnk_2_manual)
+
+    def test_linkage_units_connected(self):
+        import numpy as np
+        from scipy.interpolate import interp1d
+
+        import openmdao.api as om
+
+        import dymos as dm
+        from dymos.models.atmosphere.atmos_1976 import USatm1976Data
+
+        class CannonballSizeComp(om.ExplicitComponent):
+
+            def setup(self):
+                self.add_input(name='radius', val=1.0, desc='cannonball radius', units='m')
+                self.add_input(name='dens', val=7870., desc='cannonball density', units='kg/m**3')
+
+                self.add_output(name='mass', shape=(1,), desc='cannonball mass', units='kg')
+                self.add_output(name='S', shape=(1,), desc='aerodynamic reference area', units='m**2')
+
+                self.declare_partials(of='mass', wrt='dens')
+                self.declare_partials(of='mass', wrt='radius')
+
+                self.declare_partials(of='S', wrt='radius')
+
+            def compute(self, inputs, outputs):
+                radius = inputs['radius']
+                dens = inputs['dens']
+
+                outputs['mass'] = (4/3.) * dens * np.pi * radius ** 3
+                outputs['S'] = np.pi * radius ** 2
+
+            def compute_partials(self, inputs, partials):
+                radius = inputs['radius']
+                dens = inputs['dens']
+
+                partials['mass', 'dens'] = (4/3.) * np.pi * radius ** 3
+                partials['mass', 'radius'] = 4. * dens * np.pi * radius ** 2
+
+                partials['S', 'radius'] = 2 * np.pi * radius
+
+        class CannonballODE(om.ExplicitComponent):
+
+            def initialize(self):
+                self.options.declare('num_nodes', types=int)
+                self.options.declare('alt_unit', values=('ft', 'm', 'NM'))
+
+            def setup(self):
+                nn = self.options['num_nodes']
+
+                # static parameters
+                self.add_input('m', units='kg')
+                self.add_input('S', units='m**2')
+                # 0.5 good assumption for a sphere
+                self.add_input('CD', 0.5)
+
+                # time varying inputs
+                self.add_input('h', units=self.options['alt_unit'], shape=nn)
+                self.add_input('v', units='m/s', shape=nn)
+                self.add_input('gam', units='rad', shape=nn)
+
+                # state rates
+                self.add_output('v_dot', shape=nn, units='m/s**2', tags=['dymos.state_rate_source:v'])
+                self.add_output('gam_dot', shape=nn, units='rad/s', tags=['dymos.state_rate_source:gam'])
+                self.add_output('h_dot', shape=nn, units=self.options['alt_unit']+'/s', tags=['dymos.state_rate_source:h'])
+                self.add_output('r_dot', shape=nn, units='m/s', tags=['dymos.state_rate_source:r'])
+                self.add_output('ke', shape=nn, units='J')
+
+                self.declare_coloring(wrt='*', method='cs')
+
+                alt_data = USatm1976Data.alt * om.unit_conversion('ft', 'm')[0]
+                rho_data = USatm1976Data.rho * om.unit_conversion('slug/ft**3', 'kg/m**3')[0]
+                self.rho_interp = interp1d(np.array(alt_data, dtype=complex),
+                                           np.array(rho_data, dtype=complex),
+                                           kind='linear')
+
+            def compute(self, inputs, outputs):
+
+                gam = inputs['gam']
+                v = inputs['v']
+                h = inputs['h']
+                m = inputs['m']
+                S = inputs['S']
+                CD = inputs['CD']
+
+                if self.options['alt_unit'] == 'ft':
+                    h = h*0.3048
+                elif self.options['alt_unit'] == 'NM':
+                    h = h*1852
+
+                GRAVITY = 9.80665  # m/s**2
+
+                # handle complex-step gracefully from the interpolant
+                if np.iscomplexobj(h):
+                    rho = self.rho_interp(inputs['h'])
+                else:
+                    rho = self.rho_interp(inputs['h']).real
+
+                q = 0.5*rho*inputs['v']**2
+                qS = q * S
+                D = qS * CD
+                cgam = np.cos(gam)
+                sgam = np.sin(gam)
+                outputs['v_dot'] = - D/m-GRAVITY*sgam
+                outputs['gam_dot'] = -(GRAVITY/v)*cgam
+
+                if self.options['alt_unit'] == 'ft':
+                    outputs['h_dot'] = v*sgam/0.3048
+                elif self.options['alt_unit'] == 'NM':
+                    outputs['h_dot'] = v*sgam/1852
+                outputs['h_dot'] = v*sgam
+
+                outputs['r_dot'] = v*cgam
+                outputs['ke'] = 0.5*m*v**2
+
+        p = om.Problem(model=om.Group())
+
+        p.model.add_subsystem('size_comp', CannonballSizeComp(),
+                              promotes_inputs=['radius', 'dens'])
+        p.model.set_input_defaults('dens', val=7.87, units='g/cm**3')
+        p.model.add_design_var('radius', lower=0.01, upper=0.10,
+                               ref0=0.01, ref=0.10, units='m')
+
+        traj = p.model.add_subsystem('traj', dm.Trajectory())
+
+        transcription = dm.Radau(num_segments=5, order=3, compressed=True)
+
+        start = dm.Phase(ode_class=CannonballODE, transcription=transcription,
+                         ode_init_kwargs={'alt_unit': 'm'})
+
+        start = traj.add_phase('start', start)
+
+        start.set_time_options(fix_initial=True, duration_bounds=(1, 100), duration_ref=100, units='s')
+        start.set_state_options('r', fix_initial=True, fix_final=False)
+        start.set_state_options('h', fix_initial=True, fix_final=False)
+        start.set_state_options('gam', fix_initial=False, fix_final=False)
+        start.set_state_options('v', fix_initial=False, fix_final=False)
+
+        start.add_parameter('S', units='m**2', static_target=True)
+        start.add_parameter('m', units='kg', static_target=True)
+
+        # Limit the muzzle energy
+        start.add_boundary_constraint('ke', loc='initial', upper=400000, lower=0, ref=100000)
+
+        start.add_boundary_constraint('h', loc='final', equals=2, units='m')
+
+        ascent = dm.Phase(ode_class=CannonballODE, transcription=transcription,
+                          ode_init_kwargs={'alt_unit': 'm'})
+
+        ascent = traj.add_phase('ascent', ascent)
+
+        ascent.set_time_options(fix_initial=False, duration_bounds=(1, 100),
+                                duration_ref=100, units='s')
+        ascent.set_state_options('r', fix_initial=False, fix_final=False)
+        ascent.set_state_options('h', fix_initial=False, fix_final=False)
+        ascent.set_state_options('gam', fix_initial=False, fix_final=True)
+        ascent.set_state_options('v', fix_initial=False, fix_final=False)
+
+        ascent.add_parameter('S', units='m**2', static_target=True)
+        ascent.add_parameter('m', units='kg', static_target=True)
+
+        transcription = dm.GaussLobatto(num_segments=5, order=3, compressed=True)
+        descent = dm.Phase(ode_class=CannonballODE, transcription=transcription,
+                           ode_init_kwargs={'alt_unit': 'ft'})
+
+        traj.add_phase('descent', descent)
+
+        descent.set_time_options(initial_bounds=(.5, 100), duration_bounds=(.5, 100),
+                                 duration_ref=100, units='s')
+        descent.add_state('r')
+        descent.add_state('h', fix_initial=False, fix_final=True)
+        descent.add_state('gam', fix_initial=False, fix_final=False)
+        descent.add_state('v', fix_initial=False, fix_final=False)
+
+        descent.add_parameter('S', units='m**2', static_target=True)
+        descent.add_parameter('m', units='kg', static_target=True)
+
+        descent.add_objective('r', loc='final', scaler=-1.0)
+
+        # Add internally-managed design parameters to the trajectory.
+        traj.add_parameter('CD',
+                           targets={'ascent': ['CD'], 'descent': ['CD']},
+                           val=0.5, units=None, opt=False, static_target=True)
+
+        traj.add_parameter('m', units='kg', val=1.0,
+                           targets={'ascent': 'm', 'descent': 'm'}, static_target=True)
+
+        # In this case, by omitting targets, we're connecting these
+        # parameters to parameters with the same name in each phase.
+        traj.add_parameter('S', units='m**2', val=0.005, static_target=True)
+
+        # Link Phases (link time and all state variables)
+        traj.link_phases(phases=['start', 'ascent'], vars=['*'])
+        traj.add_linkage_constraint('ascent', 'descent', 'h', 'h', 'final', 'initial', connected=True)
+        traj.link_phases(phases=['ascent', 'descent'], vars=['time', 'r', 'v', 'gam'])
+
+        # Issue Connections
+        p.model.connect('size_comp.mass', 'traj.parameters:m')
+        p.model.connect('size_comp.S', 'traj.parameters:S')
+
+        # A linear solver at the top level can improve performance.
+        p.model.linear_solver = om.DirectSolver()
+
+        # Finish Problem Setup
+        p.setup()
+
+        #############################################
+        # Set constants and initial guesses
+        #############################################
+        p.set_val('radius', 0.05, units='m')
+        p.set_val('dens', 7.87, units='g/cm**3')
+
+        p.set_val('traj.parameters:CD', 0.5)
+
+        p.set_val('traj.start.t_initial', 0.0)
+        p.set_val('traj.start.t_duration', 10.0)
+
+        p.set_val('traj.ascent.t_initial', 0.0)
+        p.set_val('traj.ascent.t_duration', 10.0)
+
+        p.set_val('traj.start.states:r', ascent.interp('r', [0, 100]))
+        p.set_val('traj.start.states:h', ascent.interp('h', [0, 50]))
+        p.set_val('traj.start.states:v', ascent.interp('v', [200, 150]))
+        p.set_val('traj.start.states:gam', ascent.interp('gam', [25, 0]), units='deg')
+
+        p.set_val('traj.ascent.states:r', ascent.interp('r', [0, 100]))
+        p.set_val('traj.ascent.states:h', ascent.interp('h', [0, 100]))
+        p.set_val('traj.ascent.states:v', ascent.interp('v', [200, 150]))
+        p.set_val('traj.ascent.states:gam', ascent.interp('gam', [25, 0]), units='deg')
+
+        p.set_val('traj.descent.t_initial', 10.0)
+        p.set_val('traj.descent.t_duration', 10.0)
+
+        p.set_val('traj.descent.states:r', descent.interp('r', [100, 200]))
+        p.set_val('traj.descent.states:h', descent.interp('h', [200, 0]))
+        p.set_val('traj.descent.states:v', descent.interp('v', [150, 200]))
+        p.set_val('traj.descent.states:gam', descent.interp('gam', [0, -45]), units='deg')
+
+        #####################################################
+        # Run the optimization and final explicit simulation
+        #####################################################
+        dm.run_problem(p, run_driver=False, simulate=False)
+
+        p.model.list_inputs()
+
+        ascent_h_m = p.get_val('traj.ascent.timeseries.states:h', units='m')[[0, -1], ...]
+        descent_h_m = p.get_val('traj.descent.timeseries.states:h', units='m')[[0, -1], ...]
+
+        lnk_2_manual = - descent_h_m[0, ...] + ascent_h_m[-1, ...]
+
+        assert_near_equal(lnk_2_manual, 0.0)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -515,7 +515,7 @@ class Trajectory(om.Group):
         var_a = linkage_options['var_a']
         var_b = linkage_options['var_b']
 
-        info_str = f'Error in linking {var_a} from {phase_name_a} to {var_b} in {phase_name_b}'
+        info_str = f'{self.pathname}: ' if self.pathname else ''
 
         phase_a = self._get_subsystem(f'phases.{phase_name_a}')
         phase_b = self._get_subsystem(f'phases.{phase_name_b}')
@@ -579,8 +579,9 @@ class Trajectory(om.Group):
                     shapes[i] = meta['shape']
                     units[i] = meta['units']
                 except ValueError as e:
-                    raise RuntimeError(f'{info_str}: Unable to find variable \'{vars[i]}\' in '
-                                       f'phase \'{phases[i].pathname}\' or its ODE.')
+                    raise RuntimeError(f'{info_str}Error in linking {var_a} from {phase_name_a} to {var_b} in '
+                                       f'{phase_name_b}. Unable to find variable \'{vars[i]}\' in phase '
+                                       f'\'{phases[i].pathname}\' or its ODE.')
 
         linkage_options._src_a = sources['a']
         linkage_options._src_b = sources['b']
@@ -592,9 +593,9 @@ class Trajectory(om.Group):
         if linkage_options['units_b'] is _unspecified:
             linkage_options['units_b'] = units['b']
 
-        if (linkage_options['units_a'] != linkage_options['units_b']) and \
+        if not linkage_options['connected'] and (linkage_options['units_a'] != linkage_options['units_b']) and \
                 linkage_options['units'] is _unspecified:
-            raise ValueError(f'{info_str}: Linkage units were not specified but the units of '
+            raise ValueError(f'{info_str}Linkage units were not specified but the units of '
                              f'var_a ({units["a"]}) and var_b ({units["b"]}) are not the same. '
                              f'Units for this linkage constraint must be specified explicitly.')
         else:
@@ -963,7 +964,7 @@ class Trajectory(om.Group):
         if connected:
             invalid_options = []
             for arg in ['lower', 'upper', 'equals', 'scaler', 'adder', 'ref0', 'ref', 'units']:
-                if locals()[arg] is not None:
+                if locals()[arg] is not None and locals()[arg] is not _unspecified:
                     invalid_options.append(arg)
             if locals()['linear']:
                 invalid_options.append('linear')


### PR DESCRIPTION
### Summary

When imposing linkage constraints the units of the linkage must be specified by the user if the two involved variables have different units.  However, in the cast of `connected=True`, OpenMDAO just directly connects the two variables and handles the unit conversion internally.

### Related Issues

- Resolves #869 

### Backwards incompatibilities

None

### New Dependencies

None
