### PR TITLE
Parameter flow added to linkage report diagram

### DIFF
--- a/dymos/visualization/linkage/js/DmLinkageMatrixCell.js
+++ b/dymos/visualization/linkage/js/DmLinkageMatrixCell.js
@@ -66,6 +66,7 @@ class DmLinkageMatrixCell extends MatrixCell {
             case "group":
                 return new DmLinkageGroupCell(color, this.id);
             case "connected_variable":
+            case "connected_parameter":
                 return new DmLinkageConnectedCell(color, this.id);
             case "variable":
                 return new DmLinkageVariableCell(color, this.id);

--- a/dymos/visualization/linkage/js/DmLinkageMatrixCell.js
+++ b/dymos/visualization/linkage/js/DmLinkageMatrixCell.js
@@ -35,21 +35,15 @@ class DmLinkageMatrixCell extends MatrixCell {
      */
     color() {
         const clr = DmLinkageStyle.color;
-
         if (this.onDiagonal()) {
-            if (this.obj.isTrajectoryParameter() && this.obj.paramOpt === false) {
-                return clr.falseParamOpt;
+            if ('warningLevel' in this.obj) {
+                const level = this.obj.warningLevel(clr);
+                return level.color;
             }
-            if (this.obj.isParameter()) {
-                if ('isFixed' in this.obj && this.obj.isFixed()) {
-                    return this.obj.isLinked()? clr.fixedLinkedVariableCell : clr.variableCell;
-                }
+            else {
+                if (this.obj.draw.minimized) return clr.collapsed;
+                return clr.variableCell;
             }
-            if ('isFixed' in this.obj && this.obj.isFixed()) {
-                return this.obj.isLinked()? clr.fixedLinkedVariableCell : clr.fixedUnlinkedVariableCell;
-            }
-            if (this.obj.draw.minimized) return clr.collapsed;
-            return clr.variableCell;
         }
 
         return clr.linkageCell;

--- a/dymos/visualization/linkage/js/DmLinkageMatrixCell.js
+++ b/dymos/visualization/linkage/js/DmLinkageMatrixCell.js
@@ -57,8 +57,11 @@ class DmLinkageMatrixCell extends MatrixCell {
 
     /** Choose a renderer based on our SymbolType. */
     _newRenderer() {
-        const renderer = super._newRenderer();
-        if (renderer) return renderer;
+
+        if (! this.inUpperTriangle()) {
+            const renderer = super._newRenderer();
+            if (renderer) return renderer;
+        }
 
         const color = this.color();
 

--- a/dymos/visualization/linkage/js/DmLinkageMatrixCell.js
+++ b/dymos/visualization/linkage/js/DmLinkageMatrixCell.js
@@ -68,6 +68,7 @@ class DmLinkageMatrixCell extends MatrixCell {
             case "connected_parameter":
                 return new DmLinkageConnectedCell(color, this.id);
             case "variable":
+            case "filter":
                 return new DmLinkageVariableCell(color, this.id);
             case "condition":
                 return new DmLinkageConditionCell(color, this.id);

--- a/dymos/visualization/linkage/js/DmLinkageMatrixCell.js
+++ b/dymos/visualization/linkage/js/DmLinkageMatrixCell.js
@@ -37,6 +37,12 @@ class DmLinkageMatrixCell extends MatrixCell {
         const clr = DmLinkageStyle.color;
 
         if (this.onDiagonal()) {
+            if (this.obj.isTrajectoryParameter() && this.obj.paramOpt === false) {
+                return clr.falseParamOpt;
+            }
+            if (this.obj.isParameter()) {
+                return clr.variableCell;
+            }
             if ('isFixed' in this.obj && this.obj.isFixed()) {
                 return this.obj.isLinked()? clr.fixedLinkedVariableCell : clr.fixedUnlinkedVariableCell;
             }

--- a/dymos/visualization/linkage/js/DmLinkageMatrixCell.js
+++ b/dymos/visualization/linkage/js/DmLinkageMatrixCell.js
@@ -41,7 +41,9 @@ class DmLinkageMatrixCell extends MatrixCell {
                 return clr.falseParamOpt;
             }
             if (this.obj.isParameter()) {
-                return clr.variableCell;
+                if ('isFixed' in this.obj && this.obj.isFixed()) {
+                    return this.obj.isLinked()? clr.fixedLinkedVariableCell : clr.variableCell;
+                }
             }
             if ('isFixed' in this.obj && this.obj.isFixed()) {
                 return this.obj.isLinked()? clr.fixedLinkedVariableCell : clr.fixedUnlinkedVariableCell;

--- a/dymos/visualization/linkage/js/DmLinkageModelData.js
+++ b/dymos/visualization/linkage/js/DmLinkageModelData.js
@@ -6,6 +6,7 @@ class DmLinkageModelData extends ModelData {
     /** Do some discovery in the tree and rearrange & enhance where necessary. */
     constructor(modelJSON) {
         super(modelJSON);
+        console.log(this.tree)
     }
 
     /**

--- a/dymos/visualization/linkage/js/DmLinkageModelData.js
+++ b/dymos/visualization/linkage/js/DmLinkageModelData.js
@@ -6,7 +6,6 @@ class DmLinkageModelData extends ModelData {
     /** Do some discovery in the tree and rearrange & enhance where necessary. */
     constructor(modelJSON) {
         super(modelJSON);
-        console.log(this.tree)
     }
 
     /**

--- a/dymos/visualization/linkage/js/DmLinkageStyle.js
+++ b/dymos/visualization/linkage/js/DmLinkageStyle.js
@@ -17,7 +17,8 @@ class DmLinkageStyle extends Style {
         'group': '#ccc',
         'phase': '#ccc',
         'initial': '#bbb',
-        'final': '#999'
+        'final': '#999',
+        'params': '#ddd'
     };
 
     /**
@@ -48,6 +49,11 @@ class DmLinkageStyle extends Style {
                 'cursor': 'pointer',
                 'fill': DmLinkageStyle.color.phase,
                 'fill-opacity': '.8',
+            },
+            "#tree > g[class*='params'] > rect": {
+                'cursor': 'pointer',
+                'fill-opacity': '.8',
+                'fill': DmLinkageStyle.color.params,
             },
             "#tree > g[class*='initial'] > rect": {
                 'cursor': 'pointer',
@@ -80,7 +86,7 @@ class DmLinkageStyle extends Style {
         if (node.draw.minimized) return 'minimized';
 
         switch (node.type) {
-            case 'variable': return node.parent.name; // Either 'initial' or 'final'
+            case 'variable': return node.parent.name; // One of 'initial', 'final', or 'params'
             case 'condition': return node.name;
             case 'phase': return 'phase';
             case 'root': return 'root'

--- a/dymos/visualization/linkage/js/DmLinkageStyle.js
+++ b/dymos/visualization/linkage/js/DmLinkageStyle.js
@@ -11,6 +11,7 @@ class DmLinkageStyle extends Style {
         'variableCell': 'black',
         'fixedLinkedVariableCell': 'red',
         'fixedUnlinkedVariableCell': '#ffc000',
+        'falseParamOpt': '#ffc000',
         'linkageCell': '#00b051',
         'fixedLinkageCell': '#ffc000',
         'root': '#ccc',

--- a/dymos/visualization/linkage/js/DmLinkageSymbolType.js
+++ b/dymos/visualization/linkage/js/DmLinkageSymbolType.js
@@ -27,7 +27,7 @@ class DmLinkageSymbolType extends SymbolType {
         if (cell.srcObj.isFilter() || cell.tgtObj.isFilter()) {
             this.name = 'filter';
         }
-        else if (cell.srcObj.isConnected() && cell.srcObj === cell.tgtObj) {
+        else if (cell.srcObj.isConnected() && cell.srcObj !== cell.tgtObj ) {
             if (cell.srcObj.isParameter()) {
                 this.name = 'connected_parameter';
             }

--- a/dymos/visualization/linkage/js/DmLinkageSymbolType.js
+++ b/dymos/visualization/linkage/js/DmLinkageSymbolType.js
@@ -28,7 +28,12 @@ class DmLinkageSymbolType extends SymbolType {
             this.name = 'filter';
         }
         else if (cell.srcObj.isConnected() && cell.srcObj === cell.tgtObj) {
-            this.name = 'connected_variable';
+            if (cell.srcObj.isParameter()) {
+                this.name = 'connected_parameter';
+            }
+            else {
+                this.name = 'connected_variable';
+            }
         }
         else {
             this.name = cell.srcObj.type;

--- a/dymos/visualization/linkage/js/DmLinkageTreeNode.js
+++ b/dymos/visualization/linkage/js/DmLinkageTreeNode.js
@@ -42,6 +42,12 @@ class DmLinkageTreeNode extends FilterCapableNode {
 
     isVariable() { return this.type == 'variable'; }
 
+    isTrajectory() { return this.type == 'root'; }
+
+    isParameter() { return this.isVariable() && this.class == 'parameter'; }
+
+    isTrajectoryParameter() { return this.isParameter() && this.parent.parent.isTrajectory(); }
+
     isInputOrOutput() { return this.isVariable(); }
 
     isGroup() { return super.isGroup() || this.isRoot(); }
@@ -50,7 +56,7 @@ class DmLinkageTreeNode extends FilterCapableNode {
 
     isLinked() { return this.linked; }
 
-    isConnected() { return this.isVariable && this.connected == true; }
+    isConnected() { return this.isVariable() && this.connected == true; }
 
     /** In the matrix grid, draw a box around variables that share the same boxAncestor() */
     boxAncestor(level = 2) {

--- a/dymos/visualization/linkage/js/DmLinkageTreeNode.js
+++ b/dymos/visualization/linkage/js/DmLinkageTreeNode.js
@@ -114,7 +114,21 @@ class DmLinkageTreeNode extends FilterCapableNode {
         return { 'color': clr, 'priority': priority };
     }
 
-    isConnected() { return this.isVariable() && this.connected == true; }
+    /**
+     * Determine if this node or any children are connected.
+     * @returns True if a connection is found.
+     */
+    isConnected() {
+        if (this.isVariable()) return this.connected;
+
+        if (this.hasChildren()) {
+            for (const child of this.children) {
+                if (child.isConnected()) return true;
+            }
+        }
+
+        return false;
+    }
 
     /** In the matrix grid, draw a box around variables that share the same boxAncestor() */
     boxAncestor(level = 2) {

--- a/dymos/visualization/linkage/js/DmLinkageTreeNode.js
+++ b/dymos/visualization/linkage/js/DmLinkageTreeNode.js
@@ -61,7 +61,6 @@ class DmLinkageTreeNode extends FilterCapableNode {
     /** In the matrix grid, draw a box around variables that share the same boxAncestor() */
     boxAncestor(level = 2) {
         if (level == 1) { // Return condition reference
-            if (this.isVariable() && this.parent.isPhase()) return this;
             if (this.isVariable()) return this.parent;
             if (this.isCondition()) return this;
         }

--- a/dymos/visualization/linkage/js/DmLinkageTreeNode.js
+++ b/dymos/visualization/linkage/js/DmLinkageTreeNode.js
@@ -55,10 +55,12 @@ class DmLinkageTreeNode extends FilterCapableNode {
     /** In the matrix grid, draw a box around variables that share the same boxAncestor() */
     boxAncestor(level = 2) {
         if (level == 1) { // Return condition reference
+            if (this.isVariable() && this.parent.isPhase()) return this;
             if (this.isVariable()) return this.parent;
             if (this.isCondition()) return this;
         }
         else if (level == 2) { // Return phase reference
+            if (this.isVariable() && this.parent.isPhase()) return this.parent;
             if (this.isVariable()) return this.parent.parent;
             if (this.isCondition()) return this.parent;
         }

--- a/dymos/visualization/linkage/js/DmLinkageTreeNode.js
+++ b/dymos/visualization/linkage/js/DmLinkageTreeNode.js
@@ -23,6 +23,9 @@ class DmLinkageTreeNode extends FilterCapableNode {
 
     }
 
+    /** Temp fix to gen code reference */
+    get absPathName() { return this.path; }
+
     /** Use a single filter instead of separate inputs and outputs */
     addFilterChild(attribNames) {
         if (this.isCondition()) {

--- a/dymos/visualization/linkage/js/DmLinkageTreeNode.js
+++ b/dymos/visualization/linkage/js/DmLinkageTreeNode.js
@@ -8,6 +8,10 @@ class DmLinkageTreeNode extends FilterCapableNode {
     constructor(origNode, attribNames, parent) {
         super(origNode, attribNames, parent);
 
+        if ((this.isPhase() || this.isCondition()) && this.name == 'params' ) {
+            this.draw.minimized = true;
+        }
+
         if (parent) { // Retain "highest warning" cell color when collapsed
             // Only applies to trajectory parameters:
             if (this.paramOpt == false) parent.paramOpt = false;
@@ -123,7 +127,7 @@ class DmLinkageTreeNode extends FilterCapableNode {
 
         if (this.hasChildren()) {
             for (const child of this.children) {
-                if (child.isConnected()) return true;
+                if ('isConnected' in child && child.isConnected()) return true;
             }
         }
 

--- a/dymos/visualization/linkage/js/DmLinkageTreeNode.js
+++ b/dymos/visualization/linkage/js/DmLinkageTreeNode.js
@@ -107,7 +107,6 @@ class DmLinkageTreeNode extends FilterCapableNode {
                 if ('warningLevel' in child) {
                     const level = child.warningLevel(colors);
                     if (level.priority > priority) {
-                        console.log("changing color")
                         clr = level.color;
                         priority = level.priority;
                     }

--- a/dymos/visualization/linkage/report.py
+++ b/dymos/visualization/linkage/report.py
@@ -294,7 +294,7 @@ def _is_ignored_conn(name)->bool:
     return re.match(r'.*timeseries.*', name) or re.match(r'.*_auto_ivc.*', name)
 
 
-def _var_ref_from_path(tree, path:str):
+def _var_ref_from_path(tree, path: str):
     """ Find a reference into the tree from a path string. """
     tokens = re.split(r'\.', path)
 
@@ -311,10 +311,11 @@ def _var_ref_from_path(tree, path:str):
 
     return refpath
 
-def _get_fixed_val(tree, path:str)->bool:
+
+def _get_fixed_val(tree, path: str)->bool:
     """ Get the value of the fixed property for the specified path. """
     ref = _var_ref_from_path(tree, path)
-    fixed = False if (ref is None or not 'fixed' in ref) else ref['fixed']
+    fixed = False if (ref is None or 'fixed' not in ref) else ref['fixed']
 
     return fixed
 

--- a/dymos/visualization/linkage/report.py
+++ b/dymos/visualization/linkage/report.py
@@ -91,10 +91,10 @@ def _is_fixed(var_name: str, class_name: str, phase, loc: str):
     return bool(fixed)
 
 
-def _tree_var(var_name, phase, loc = None, var_name_prefix=""):
+def _tree_var(var_name, phase, loc=None, var_name_prefix=""):
     """
     Create a dict to represent a variable in the tree.
-    
+
     Parameters
     ----------
     var_name : str
@@ -113,7 +113,7 @@ def _tree_var(var_name, phase, loc = None, var_name_prefix=""):
     """
     class_name = str(phase.classify_var(var_name))
     opt = phase.parameter_options[var_name]['opt'] if class_name == 'parameter' else None
-    
+
     return {
         'name': f"{var_name_prefix}{var_name}",
         'type': 'variable',
@@ -204,7 +204,7 @@ def _trajectory_to_dict(traj):
         # Parameters
         for param_name, param in phase.parameter_options.items():
             params_children[param_name] = _tree_var(param_name, phase)
-    
+
     return model_data
 
 
@@ -251,7 +251,8 @@ def _linkages_to_list(traj, model_data):
                 if skip is False:
                     tree_var.append(phase_cbn[loc[i]][CBN][var_pair[i]])
 
-            if skip is True: continue
+            if skip is True:
+                continue
 
             tree_var[0]['linked'] = tree_var[1]['linked'] = True
             tree_var[0]['connected'] = tree_var[1]['connected'] = options['connected']
@@ -286,9 +287,11 @@ def _is_param_conn(name)->bool:
     """ Determine if the specified connection involves a parameter. """
     return re.match(r'.*param_comp.*', name) and not re.match(r'.*parameter_vals.*', name)
 
+
 def _is_ignored_conn(name)->bool:
     """ Determine if an connection endpoint should be ignored for this diagram. """
     return re.match(r'.*timeseries.*', name) or re.match(r'.*_auto_ivc.*', name)
+
 
 def _var_ref_from_path(tree, path):
     """ Find a reference into the tree from a path string. """
@@ -300,6 +303,7 @@ def _var_ref_from_path(tree, path):
 
     return refpath
 
+
 def _parameter_connections(traj, model_data):
     """ Find all parameter-to-parameter connections. """
     allconn = traj._problem_meta['model_ref']()._conn_global_abs_in2out
@@ -307,8 +311,9 @@ def _parameter_connections(traj, model_data):
     param_conns = []
 
     for tgt, src in allconn.items():
-        if not (_is_ignored_conn(src) or _is_ignored_conn(tgt)) and \
-            (_is_param_conn(src) or _is_param_conn(tgt)):
+        is_ignored = (_is_ignored_conn(src) or _is_ignored_conn(tgt))
+        is_param_conn = (_is_param_conn(src) or _is_param_conn(tgt))
+        if not is_ignored and is_param_conn:
             src_path = _conn_name_to_path(src)
             src_fixed = _var_ref_from_path(tree, src_path)['fixed']
             tgt_path = _conn_name_to_path(tgt)

--- a/dymos/visualization/linkage/report.py
+++ b/dymos/visualization/linkage/report.py
@@ -270,15 +270,16 @@ def _linkages_to_list(traj, model_data):
 def _conn_name_to_path(name):
     """ Convert the full name of the connection to a format the diagram uses. """
     tokens = re.split(r'\W+', name)
-    if tokens[1] == 'param_comp':
-        return f'params.{tokens.pop()}'
+    if len(tokens) > 0:
+        if tokens[1] == 'param_comp':
+            return f'params.{tokens.pop()}'
 
-    # Example: traj.linkages.v1_to_vr:alpha -> v1_to_vr.alpha
-    if tokens[1] == 'linkages':
-        return f'{tokens[2]}.{tokens[3]}'
+        # Example: traj.linkages.v1_to_vr:alpha -> v1_to_vr.alpha
+        if tokens[1] == 'linkages':
+            return f'{tokens[2]}.{tokens[3]}'
 
-    if tokens[3] == 'param_comp':
-        return f'{tokens[2]}.params.{tokens.pop()}'
+        if len(tokens) > 3 and tokens[3] == 'param_comp':
+            return f'{tokens[2]}.params.{tokens.pop()}'
 
     return name
 

--- a/dymos/visualization/linkage/report.py
+++ b/dymos/visualization/linkage/report.py
@@ -33,8 +33,6 @@ def create_linkage_report(traj, output_file: str = _default_linkage_report_filen
     model_data = _trajectory_to_dict(traj)
     model_data['connections_list'] = _linkages_to_list(traj, model_data)
     model_data['connections_list'].extend(_parameter_connections(traj, model_data))
-    for c in model_data['connections_list']:
-        print(f"{c['src']}({c['src_fixed']}) -> {c['tgt']}({c['tgt_fixed']})")
 
     _convert_dicts_to_lists(model_data['tree'], show_all_vars)
 

--- a/dymos/visualization/linkage/report.py
+++ b/dymos/visualization/linkage/report.py
@@ -294,7 +294,7 @@ def _is_ignored_conn(name)->bool:
     return re.match(r'.*timeseries.*', name) or re.match(r'.*_auto_ivc.*', name)
 
 
-def _var_ref_from_path(tree, path):
+def _var_ref_from_path(tree, path:str):
     """ Find a reference into the tree from a path string. """
     tokens = re.split(r'\.', path)
 
@@ -311,6 +311,13 @@ def _var_ref_from_path(tree, path):
 
     return refpath
 
+def _get_fixed_val(tree, path:str)->bool:
+    """ Get the value of the fixed property for the specified path. """
+    ref = _var_ref_from_path(tree, path)
+    fixed = False if (ref is None or not 'fixed' in ref) else ref['fixed']
+
+    return fixed
+
 
 def _parameter_connections(traj, model_data):
     """ Find all parameter-to-parameter connections. """
@@ -323,14 +330,12 @@ def _parameter_connections(traj, model_data):
         is_param_conn = (_is_param_conn(src) or _is_param_conn(tgt))
         if not is_ignored and is_param_conn:
             src_path = _conn_name_to_path(src)
-            src_fixed = _var_ref_from_path(tree, src_path)['fixed']
             tgt_path = _conn_name_to_path(tgt)
-            tgt_fixed = _var_ref_from_path(tree, tgt_path)['fixed']
             param_conns.append({
                 'src': src_path,
-                'src_fixed': src_fixed if src_fixed is not None else False,
+                'src_fixed': _get_fixed_val(tree, src_path),
                 'tgt': tgt_path,
-                'tgt_fixed': tgt_fixed if tgt_fixed is not None else False
+                'tgt_fixed': _get_fixed_val(tree, tgt_path)
             })
 
     return param_conns

--- a/dymos/visualization/linkage/report.py
+++ b/dymos/visualization/linkage/report.py
@@ -297,6 +297,10 @@ def _is_ignored_conn(name)->bool:
 def _var_ref_from_path(tree, path):
     """ Find a reference into the tree from a path string. """
     tokens = re.split(r'\.', path)
+
+    if (len(tokens) < 2):
+        return None
+
     refpath = tree
 
     for t in tokens:
@@ -321,9 +325,9 @@ def _parameter_connections(traj, model_data):
             tgt_fixed = _var_ref_from_path(tree, tgt_path)['fixed']
             param_conns.append({
                 'src': src_path,
-                'src_fixed': src_fixed,
+                'src_fixed': src_fixed if src_fixed is not None else False,
                 'tgt': tgt_path,
-                'tgt_fixed': tgt_fixed
+                'tgt_fixed': tgt_fixed if tgt_fixed is not None else False
             })
 
     return param_conns

--- a/dymos/visualization/linkage/report.py
+++ b/dymos/visualization/linkage/report.py
@@ -303,8 +303,11 @@ def _var_ref_from_path(tree, path):
 
     refpath = tree
 
-    for t in tokens:
-        refpath = refpath[CBN][t]
+    try:
+        for t in tokens:
+            refpath = refpath[CBN][t]
+    except (KeyError):
+        return None
 
     return refpath
 

--- a/dymos/visualization/linkage/test/linkage_report_ui_test.py
+++ b/dymos/visualization/linkage/test/linkage_report_ui_test.py
@@ -78,7 +78,7 @@ gui_test_script = [
     {
         "desc": "Hover on matrix cell and check arrow count",
         "test": "hoverArrow",
-        "selector": "g#n2elements rect#cellShape_node_10.vMid",
+        "selector": "g#n2elements rect#cellShape_node_41.vMid",
         "arrowCount": 2
     },
     {
@@ -90,7 +90,7 @@ gui_test_script = [
     {
         "desc": "Hover on matrix cell and check arrow count",
         "test": "hoverArrow",
-        "selector": "g#n2elements rect#cellShape_node_55.vMid",
+        "selector": "g#n2elements rect#cellShape_node_128.vMid",
         "arrowCount": 1
     },
     {"test": "root"},
@@ -103,8 +103,8 @@ gui_test_script = [
     {
         "desc": "Hover over collapsed matrix cell and check arrow count",
         "test": "hoverArrow",
-        "selector": "g#n2elements rect#cellShape_node_1.gMid",
-        "arrowCount": 6
+        "selector": "g#n2elements rect#cellShape_node_18.gMid",
+        "arrowCount": 19
     },
     {
         "desc": "Right-click on model tree element to uncollapse",
@@ -117,20 +117,20 @@ gui_test_script = [
         "desc": "Check the number of cells in the matrix grid",
         "test": "count",
         "selector": "g#n2elements > g.n2cell",
-        "count": 53
+        "count": 168
     },
     {
         "desc": "Perform a search on states:v",
         "test": "search",
         "searchString": "states:v",
-        "diagElementCount": 14
+        "diagElementCount": 25
     },
     {"test": "root"},
     {
         "desc": "Check that home button works after search",
         "test": "count",
         "selector": "g#n2elements > g.n2cell",
-        "count": 53
+        "count": 168
     },
     {
         "desc": "Expand toolbar connections menu",
@@ -147,7 +147,7 @@ gui_test_script = [
         "desc": "Check number of arrows",
         "test": "count",
         "selector": "g#n2arrows > g",
-        "count": 30
+        "count": 126
     },
     {
         "desc": "Expand toolbar connections menu",
@@ -227,7 +227,7 @@ gui_test_script = [
         "desc": "Check the number of cells in the matrix grid",
         "test": "count",
         "selector": "g#n2elements > g.n2cell",
-        "count": 49
+        "count": 164
     },
 
 ]
@@ -401,7 +401,8 @@ class dymos_linkage_gui_test_case(_GuiTestCase):
         # Less common "final value of r must be the match at ends of two phases".
         traj.add_linkage_constraint(phase_a='rto', var_a='r', loc_a='final',
                                     phase_b='climb', var_b='r', loc_b='final',
-                                    ref=1000, connected=True)
+                                    ref=1000,
+                                    connected=False)
 
         # Define the constraints and objective for the optimal control problem
         rto.add_boundary_constraint('v', loc='final', upper=0.001, ref=100, linear=True)


### PR DESCRIPTION
### Summary

There are new nodes labeled "params" in the diagram which contains the parameters for the trajectory and each phase. The trajectory parameters node is at the same level as the phases, and the phase parameters appear at the same level as the initial/final conditions.

The only intentional difference between this implementation and the issue description is that the parameters start out minimized due to the large number of them in some models. If one of a parent's child nodes was yellow, the collapsed parent will be yellow; however if a different child was red, the parent will be red.

Here is the report with the trajectory parameters and those in `rotate` manually expanded:
![image](https://user-images.githubusercontent.com/12797795/203411970-e3e09e5f-b538-4564-89ea-f9b70edbba75.png)


### Related Issues

- Resolves #837 

### Backwards incompatibilities

None

### New Dependencies

None
