### PR TITLE
Deprecate Trajectory.add_linkage_constraint arguments, sign_a and sign_b

### DIFF
--- a/dymos/trajectory/options.py
+++ b/dymos/trajectory/options.py
@@ -38,7 +38,7 @@ class LinkageOptionsDictionary(om.OptionsDictionary):
                      desc='The multiplier applied to the variable from the second phase in the linkage constraint',
                      deprecation="Option 'sign_b' has been replaced by option 'mult_b'")
         self.declare(name='mult_a', types=Number, default=1.0,
-                     deprecation="Option 'sign_a' has been replaced by option 'mult_a'")
+                     desc='The multiplier applied to the variable from the first phase in the linkage constraint')
         self.declare(name='mult_b', types=Number, default=-1.0,
                      desc='The multiplier applied to the variable from the second phase in the linkage constraint')
 

--- a/dymos/trajectory/options.py
+++ b/dymos/trajectory/options.py
@@ -36,9 +36,9 @@ class LinkageOptionsDictionary(om.OptionsDictionary):
                      deprecation="Option 'sign_a' has been replaced by option 'mult_a'")
         self.declare(name='sign_b', types=Number, default=-1.0,
                      desc='The multiplier applied to the variable from the second phase in the linkage constraint',
-                     deprecation = "Option 'sign_b' has been replaced by option 'mult_b'")
+                     deprecation="Option 'sign_b' has been replaced by option 'mult_b'")
         self.declare(name='mult_a', types=Number, default=1.0,
-                     deprecation = "Option 'sign_a' has been replaced by option 'mult_a'")
+                     deprecation="Option 'sign_a' has been replaced by option 'mult_a'")
         self.declare(name='mult_b', types=Number, default=-1.0,
                      desc='The multiplier applied to the variable from the second phase in the linkage constraint')
 

--- a/dymos/trajectory/options.py
+++ b/dymos/trajectory/options.py
@@ -32,10 +32,15 @@ class LinkageOptionsDictionary(om.OptionsDictionary):
                      desc='location of the second variable in the linkage (\'initial\' or \'final\')')
 
         self.declare(name='sign_a', types=Number, default=1.0,
-                     desc='sign of the first variable in the linkage (\'initial\' or \'final\')')
-
+                     desc='The multiplier applied to the variable from the first phase in the linkage constraint',
+                     deprecation="Option 'sign_a' has been replaced by option 'mult_a'")
         self.declare(name='sign_b', types=Number, default=-1.0,
-                     desc='sign of the second variable in the linkage (\'initial\' or \'final\')')
+                     desc='The multiplier applied to the variable from the second phase in the linkage constraint',
+                     deprecation = "Option 'sign_b' has been replaced by option 'mult_b'")
+        self.declare(name='mult_a', types=Number, default=1.0,
+                     deprecation = "Option 'sign_a' has been replaced by option 'mult_a'")
+        self.declare(name='mult_b', types=Number, default=-1.0,
+                     desc='The multiplier applied to the variable from the second phase in the linkage constraint')
 
         self.declare(name='units_a', default=_unspecified,
                      allow_none=True, desc='units in which the first variable is defined')

--- a/dymos/trajectory/phase_linkage_comp.py
+++ b/dymos/trajectory/phase_linkage_comp.py
@@ -119,10 +119,12 @@ class PhaseLinkageComp(om.ExplicitComponent):
         cs_b = rs if loc_b == 'initial' else size + rs
 
         self.declare_partials(of=output, wrt=input_a, rows=rs, cols=cs_a,
-                              val=lnk['sign_a'] * lnk._conv_a)
+                              val=lnk['mult_a'] * lnk._conv_a)
+                              # val=lnk['sign_a'] * lnk._conv_a)
 
         self.declare_partials(of=output, wrt=input_b, rows=rs, cols=cs_b,
-                              val=lnk['sign_b'] * lnk._conv_b)
+                              val=lnk['mult_b'] * lnk._conv_b)
+                              # val=lnk['sign_b'] * lnk._conv_b)
 
     def compute(self, inputs, outputs):
         """
@@ -142,7 +144,9 @@ class PhaseLinkageComp(om.ExplicitComponent):
             idxs_b = lnk._idxs_b
             output = lnk._output
 
-            a_val = lnk['sign_a'] * (inputs[input_a][idxs_a] + lnk._offset_a) * lnk._conv_a
-            b_val = lnk['sign_b'] * (inputs[input_b][idxs_b] + lnk._offset_b) * lnk._conv_b
+            # a_val = lnk['sign_a'] * (inputs[input_a][idxs_a] + lnk._offset_a) * lnk._conv_a
+            # b_val = lnk['sign_b'] * (inputs[input_b][idxs_b] + lnk._offset_b) * lnk._conv_b
+            a_val = lnk['mult_a'] * (inputs[input_a][idxs_a] + lnk._offset_a) * lnk._conv_a
+            b_val = lnk['mult_b'] * (inputs[input_b][idxs_b] + lnk._offset_b) * lnk._conv_b
 
             outputs[output] = a_val + b_val

--- a/dymos/trajectory/phase_linkage_comp.py
+++ b/dymos/trajectory/phase_linkage_comp.py
@@ -120,11 +120,9 @@ class PhaseLinkageComp(om.ExplicitComponent):
 
         self.declare_partials(of=output, wrt=input_a, rows=rs, cols=cs_a,
                               val=lnk['mult_a'] * lnk._conv_a)
-                              # val=lnk['sign_a'] * lnk._conv_a)
 
         self.declare_partials(of=output, wrt=input_b, rows=rs, cols=cs_b,
                               val=lnk['mult_b'] * lnk._conv_b)
-                              # val=lnk['sign_b'] * lnk._conv_b)
 
     def compute(self, inputs, outputs):
         """

--- a/dymos/trajectory/phase_linkage_comp.py
+++ b/dymos/trajectory/phase_linkage_comp.py
@@ -43,10 +43,10 @@ class PhaseLinkageComp(om.ExplicitComponent):
 
         The resulting linkage equation of constraint is:
 
-        C_linkage = sign_a * vars_a + sign_b * vars_b
+        C_linkage = mult_a * vars_a + mult_b * vars_b
 
-        Constraining this linkage to a value of zero, with the default signs
-        (sign_a = 1, sign_b = -1) will result in the two variables having the same value at the
+        Constraining this linkage to a value of zero, with the default multipliers
+        (mult_a = 1, mult_b = -1) will result in the two variables having the same value at the
         given locations.
 
         Parameters
@@ -142,8 +142,6 @@ class PhaseLinkageComp(om.ExplicitComponent):
             idxs_b = lnk._idxs_b
             output = lnk._output
 
-            # a_val = lnk['sign_a'] * (inputs[input_a][idxs_a] + lnk._offset_a) * lnk._conv_a
-            # b_val = lnk['sign_b'] * (inputs[input_b][idxs_b] + lnk._offset_b) * lnk._conv_b
             a_val = lnk['mult_a'] * (inputs[input_a][idxs_a] + lnk._offset_a) * lnk._conv_a
             b_val = lnk['mult_b'] * (inputs[input_b][idxs_b] + lnk._offset_b) * lnk._conv_b
 

--- a/dymos/trajectory/test/test_trajectory.py
+++ b/dymos/trajectory/test/test_trajectory.py
@@ -1339,6 +1339,52 @@ class TestInvalidLinkages(unittest.TestCase):
 
         self.assertEqual(expected_warning, str(w.warning))
 
+        # Test the deprecation of the linkage constraint options, sign_a and sign_b
+        traj.add_linkage_constraint(phase_a='burn1', phase_b='burn2', var_a='accel', var_b='accel')
+        self.assertEqual(1.0, traj._linkages[('burn1', 'burn2')][('accel', 'accel')]['mult_a'])
+
+        with self.assertWarns(UserWarning) as w:
+            traj.add_linkage_constraint(phase_a='burn1', phase_b='burn2', var_a='accel', var_b='accel',
+                                        sign_a=2.0)
+        self.assertEqual("'sign_a' has been deprecated. Use 'mult_a' instead.", str(w.warning))
+        self.assertEqual(2.0, traj._linkages[('burn1', 'burn2')][('accel', 'accel')]['mult_a'])
+
+        traj.add_linkage_constraint(phase_a='burn1', phase_b='burn2', var_a='accel', var_b='accel',
+                                    mult_a=3.0)
+        self.assertEqual(3.0, traj._linkages[('burn1', 'burn2')][('accel', 'accel')]['mult_a'])
+
+        with self.assertRaises(ValueError) as cm:
+            traj.add_linkage_constraint(phase_a='burn1', phase_b='burn2', var_a='accel', var_b='accel',
+                                        sign_a=2.0, mult_a=3.0)
+        self.assertEqual("Both the deprecated 'sign_a' option and option 'mult_a' were specified."
+                    "Going forward, please use only option mult_a.", str(cm.exception))
+
+        traj.add_linkage_constraint(phase_a='burn1', phase_b='burn2', var_a='accel', var_b='accel')
+        self.assertEqual(-1.0, traj._linkages[('burn1', 'burn2')][('accel', 'accel')]['mult_b'])
+
+        with self.assertWarns(UserWarning) as w:
+            traj.add_linkage_constraint(phase_a='burn1', phase_b='burn2', var_a='accel', var_b='accel',
+                                        sign_b=2.0)
+        self.assertEqual("'sign_b' has been deprecated. Use 'mult_b' instead.", str(w.warning))
+        self.assertEqual(2.0, traj._linkages[('burn1', 'burn2')][('accel', 'accel')]['mult_b'])
+
+        traj.add_linkage_constraint(phase_a='burn1', phase_b='burn2', var_a='accel', var_b='accel',
+                                    mult_b=3.0)
+        self.assertEqual(3.0, traj._linkages[('burn1', 'burn2')][('accel', 'accel')]['mult_b'])
+
+        with self.assertRaises(ValueError) as cm:
+            traj.add_linkage_constraint(phase_a='burn1', phase_b='burn2', var_a='accel', var_b='accel',
+                                        sign_b=2.0, mult_b=3.0)
+        self.assertEqual("Both the deprecated 'sign_b' option and option 'mult_b' were specified."
+                    "Going forward, please use only option mult_b.", str(cm.exception))
+
+
+    def test_linkage_constraint_sign_arg_deprecation(self):
+        traj = dm.Trajectory()
+        with self.assertWarns(UserWarning) as w:
+            traj.add_linkage_constraint(sign_a=2.0)
+
+
     def test_linkage_units(self):
         import numpy as np
         from scipy.interpolate import interp1d

--- a/dymos/trajectory/test/test_trajectory.py
+++ b/dymos/trajectory/test/test_trajectory.py
@@ -1344,8 +1344,7 @@ class TestInvalidLinkages(unittest.TestCase):
         self.assertEqual(1.0, traj._linkages[('burn1', 'burn2')][('accel', 'accel')]['mult_a'])
 
         with self.assertWarns(UserWarning) as w:
-            traj.add_linkage_constraint(phase_a='burn1', phase_b='burn2', var_a='accel', var_b='accel',
-                                        sign_a=2.0)
+            traj.add_linkage_constraint(phase_a='burn1', phase_b='burn2', var_a='accel', var_b='accel', sign_a=2.0)
         self.assertEqual("'sign_a' has been deprecated. Use 'mult_a' instead.", str(w.warning))
         self.assertEqual(2.0, traj._linkages[('burn1', 'burn2')][('accel', 'accel')]['mult_a'])
 
@@ -1363,8 +1362,7 @@ class TestInvalidLinkages(unittest.TestCase):
         self.assertEqual(-1.0, traj._linkages[('burn1', 'burn2')][('accel', 'accel')]['mult_b'])
 
         with self.assertWarns(UserWarning) as w:
-            traj.add_linkage_constraint(phase_a='burn1', phase_b='burn2', var_a='accel', var_b='accel',
-                                        sign_b=2.0)
+            traj.add_linkage_constraint(phase_a='burn1', phase_b='burn2', var_a='accel', var_b='accel', sign_b=2.0)
         self.assertEqual("'sign_b' has been deprecated. Use 'mult_b' instead.", str(w.warning))
         self.assertEqual(2.0, traj._linkages[('burn1', 'burn2')][('accel', 'accel')]['mult_b'])
 

--- a/dymos/trajectory/test/test_trajectory.py
+++ b/dymos/trajectory/test/test_trajectory.py
@@ -1357,7 +1357,7 @@ class TestInvalidLinkages(unittest.TestCase):
             traj.add_linkage_constraint(phase_a='burn1', phase_b='burn2', var_a='accel', var_b='accel',
                                         sign_a=2.0, mult_a=3.0)
         self.assertEqual("Both the deprecated 'sign_a' option and option 'mult_a' were specified."
-                    "Going forward, please use only option mult_a.", str(cm.exception))
+                         "Going forward, please use only option mult_a.", str(cm.exception))
 
         traj.add_linkage_constraint(phase_a='burn1', phase_b='burn2', var_a='accel', var_b='accel')
         self.assertEqual(-1.0, traj._linkages[('burn1', 'burn2')][('accel', 'accel')]['mult_b'])
@@ -1376,14 +1376,7 @@ class TestInvalidLinkages(unittest.TestCase):
             traj.add_linkage_constraint(phase_a='burn1', phase_b='burn2', var_a='accel', var_b='accel',
                                         sign_b=2.0, mult_b=3.0)
         self.assertEqual("Both the deprecated 'sign_b' option and option 'mult_b' were specified."
-                    "Going forward, please use only option mult_b.", str(cm.exception))
-
-
-    def test_linkage_constraint_sign_arg_deprecation(self):
-        traj = dm.Trajectory()
-        with self.assertWarns(UserWarning) as w:
-            traj.add_linkage_constraint(sign_a=2.0)
-
+                         "Going forward, please use only option mult_b.", str(cm.exception))
 
     def test_linkage_units(self):
         import numpy as np

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -4,6 +4,9 @@ from copy import deepcopy
 import itertools
 import sys
 import warnings
+
+from openmdao.utils.om_warnings import warn_deprecation
+
 try:
     from itertools import izip
 except ImportError:
@@ -625,14 +628,18 @@ class Trajectory(om.Group):
                     options = var_dict[var_pair]
                     self.add_linkage_constraint(phase_name_a, phase_name_b, var_a='time',
                                                 var_b='time', loc_a=options['loc_a'],
-                                                loc_b=options['loc_b'], sign_a=options['sign_a'],
-                                                sign_b=options['sign_b'])
+                                                loc_b=options['loc_b'], sign_a=options['mult_a'],
+                                                sign_b=options['mult_b'])
+                                                # loc_b=options['loc_b'], sign_a=options['sign_a'],
+                                                # sign_b=options['sign_b'])
                     for state_name in phase_b.state_options:
                         self.add_linkage_constraint(phase_name_a, phase_name_b, var_a=state_name,
                                                     var_b=state_name, loc_a=options['loc_a'],
                                                     loc_b=options['loc_b'],
-                                                    sign_a=options['sign_a'],
-                                                    sign_b=options['sign_b'])
+                                                    sign_a=options['mult_a'],
+                                                    sign_b=options['mult_b'])
+                                                    # sign_a=options['sign_a'],
+                                                    # sign_b=options['sign_b'])
                     self._linkages[phase_pair].pop(var_pair)
 
     def _is_valid_linkage(self, phase_name_a, phase_name_b, loc_a, loc_b, var_a, var_b, fixed_a, fixed_b):
@@ -869,7 +876,9 @@ class Trajectory(om.Group):
         self.promotes('phases', inputs=['*'], outputs=['*'])
 
     def add_linkage_constraint(self, phase_a, phase_b, var_a, var_b, loc_a='final', loc_b='initial',
-                               sign_a=1.0, sign_b=-1.0, units=_unspecified, lower=None, upper=None,
+                               sign_a=_unspecified, sign_b=_unspecified,
+                               mult_a=_unspecified, mult_b=_unspecified,
+                               units=_unspecified, lower=None, upper=None,
                                equals=None, scaler=None, adder=None, ref0=None, ref=None,
                                linear=False, connected=False):
         """
@@ -934,8 +943,14 @@ class Trajectory(om.Group):
             The location of the variable in the second phase of the linkage constraint (one of
             'initial' or 'final').
         sign_a : float
-            The sign applied to the variable from the first phase in the linkage constraint.
+            The multiplier applied to the variable from the first phase in the linkage constraint. This
+            argument is deprecated in favor of mult_a
         sign_b : float
+            The multiplier applied to the variable from the second phase in the linkage constraint. This
+            argument is deprecated in favor of mult_b
+        mult_a : float
+            The sign applied to the variable from the first phase in the linkage constraint.
+        mult_b : float
             The sign applied to the variable from the second phase in the linkage constraint.
         units : str or None or _unspecified
             Units of the linkage. If _unspecified, dymos will use the units from the variable
@@ -963,6 +978,30 @@ class Trajectory(om.Group):
             If True, this constraint is enforced by direct connection rather than a constraint
             for the optimizer. This is only valid for states and time.
         """
+        if sign_a is not _unspecified:
+            if mult_a is not _unspecified:
+                raise ValueError(
+                    "Both the deprecated 'sign_a' option and option 'mult_a' were specified."
+                    "Going forward, please use only option mult_a.")
+            warn_deprecation("'sign_a' has been deprecated. Use "
+                             "'mult_a' instead.")
+            mult_a = sign_a
+        else:  # sign_a is _unspecified
+            if mult_a is _unspecified:
+                mult_a = 1.0
+
+        if sign_b is not _unspecified:
+            if mult_b is not _unspecified:
+                raise ValueError(
+                    "Both the deprecated 'sign_b' option and option 'mult_b' were specified."
+                    "Going forward, please use only option mult_b.")
+            warn_deprecation("'sign_b' has been deprecated. Use "
+                             "'mult_b' instead.")
+            mult_b = sign_b
+        else:  # sign_a is _unspecified
+            if mult_b is _unspecified:
+                mult_b = -1.0
+
         if connected:
             invalid_options = []
             for arg in ['lower', 'upper', 'equals', 'scaler', 'adder', 'ref0', 'ref', 'units']:
@@ -987,8 +1026,10 @@ class Trajectory(om.Group):
         d['var_b'] = var_b
         d['loc_a'] = loc_a
         d['loc_b'] = loc_b
-        d['sign_a'] = sign_a
-        d['sign_b'] = sign_b
+        # d['sign_a'] = sign_a
+        # d['sign_b'] = sign_b
+        d['mult_a'] = mult_a
+        d['mult_b'] = mult_b
         d['units'] = units
         d['lower'] = lower
         d['upper'] = upper

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -630,16 +630,12 @@ class Trajectory(om.Group):
                                                 var_b='time', loc_a=options['loc_a'],
                                                 loc_b=options['loc_b'], sign_a=options['mult_a'],
                                                 sign_b=options['mult_b'])
-                                                # loc_b=options['loc_b'], sign_a=options['sign_a'],
-                                                # sign_b=options['sign_b'])
                     for state_name in phase_b.state_options:
                         self.add_linkage_constraint(phase_name_a, phase_name_b, var_a=state_name,
                                                     var_b=state_name, loc_a=options['loc_a'],
                                                     loc_b=options['loc_b'],
                                                     sign_a=options['mult_a'],
                                                     sign_b=options['mult_b'])
-                                                    # sign_a=options['sign_a'],
-                                                    # sign_b=options['sign_b'])
                     self._linkages[phase_pair].pop(var_pair)
 
     def _is_valid_linkage(self, phase_name_a, phase_name_b, loc_a, loc_b, var_a, var_b, fixed_a, fixed_b):
@@ -943,15 +939,15 @@ class Trajectory(om.Group):
             The location of the variable in the second phase of the linkage constraint (one of
             'initial' or 'final').
         sign_a : float
-            The multiplier applied to the variable from the first phase in the linkage constraint. This
-            argument is deprecated in favor of mult_a
+            The multiplier applied to the variable from the first phase in the linkage constraint.
+            This argument is deprecated in favor of mult_a.
         sign_b : float
-            The multiplier applied to the variable from the second phase in the linkage constraint. This
-            argument is deprecated in favor of mult_b
+            The multiplier applied to the variable from the second phase in the linkage constraint.
+            This argument is deprecated in favor of mult_b.
         mult_a : float
-            The sign applied to the variable from the first phase in the linkage constraint.
+            The multiplier applied to the variable from the first phase in the linkage constraint.
         mult_b : float
-            The sign applied to the variable from the second phase in the linkage constraint.
+            The multiplier applied to the variable from the second phase in the linkage constraint.
         units : str or None or _unspecified
             Units of the linkage. If _unspecified, dymos will use the units from the variable
             in the first phase of the linkage. Units of the two specified variables must be

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -628,14 +628,14 @@ class Trajectory(om.Group):
                     options = var_dict[var_pair]
                     self.add_linkage_constraint(phase_name_a, phase_name_b, var_a='time',
                                                 var_b='time', loc_a=options['loc_a'],
-                                                loc_b=options['loc_b'], sign_a=options['mult_a'],
-                                                sign_b=options['mult_b'])
+                                                loc_b=options['loc_b'], mult_a=options['mult_a'],
+                                                mult_b=options['mult_b'])
                     for state_name in phase_b.state_options:
                         self.add_linkage_constraint(phase_name_a, phase_name_b, var_a=state_name,
                                                     var_b=state_name, loc_a=options['loc_a'],
                                                     loc_b=options['loc_b'],
-                                                    sign_a=options['mult_a'],
-                                                    sign_b=options['mult_b'])
+                                                    mult_a=options['mult_a'],
+                                                    mult_b=options['mult_b'])
                     self._linkages[phase_pair].pop(var_pair)
 
     def _is_valid_linkage(self, phase_name_a, phase_name_b, loc_a, loc_b, var_a, var_b, fixed_a, fixed_b):
@@ -882,7 +882,7 @@ class Trajectory(om.Group):
 
         Phase linkage constraints are enforced by constraining the following equation:
 
-        sign_a * var_a + sign_b * var_b
+        mult_a * var_a + mult_b * var_b
 
         The resulting value of this equation is constrained.  This can satisfy 'coupling' or
         'linkage' conditions across phase boundaries:  enforcing continuity,
@@ -979,8 +979,7 @@ class Trajectory(om.Group):
                 raise ValueError(
                     "Both the deprecated 'sign_a' option and option 'mult_a' were specified."
                     "Going forward, please use only option mult_a.")
-            warn_deprecation("'sign_a' has been deprecated. Use "
-                             "'mult_a' instead.")
+            warn_deprecation("'sign_a' has been deprecated. Use 'mult_a' instead.")
             mult_a = sign_a
         else:  # sign_a is _unspecified
             if mult_a is _unspecified:
@@ -991,8 +990,7 @@ class Trajectory(om.Group):
                 raise ValueError(
                     "Both the deprecated 'sign_b' option and option 'mult_b' were specified."
                     "Going forward, please use only option mult_b.")
-            warn_deprecation("'sign_b' has been deprecated. Use "
-                             "'mult_b' instead.")
+            warn_deprecation("'sign_b' has been deprecated. Use 'mult_b' instead.")
             mult_b = sign_b
         else:  # sign_a is _unspecified
             if mult_b is _unspecified:
@@ -1022,8 +1020,6 @@ class Trajectory(om.Group):
         d['var_b'] = var_b
         d['loc_a'] = loc_a
         d['loc_b'] = loc_b
-        # d['sign_a'] = sign_a
-        # d['sign_b'] = sign_b
         d['mult_a'] = mult_a
         d['mult_b'] = mult_b
         d['units'] = units


### PR DESCRIPTION
### Summary

Deprecated `Trajectory.add_linkage_constraint` arguments, `sign_a` and `sign_b`, in favor of arguments, `mult_a` and `mult_b`. 

Also fixed the docstrings to note that these arguments act as multipliers, not just signs.

### Related Issues

- Resolves #882 

### Backwards incompatibilities

None

### New Dependencies

None
