### PR TITLE
Deprecated SolveIVP transcription.  `simulate` method now uses the ExplicitShooting transcription without derivatives.

### DIFF
--- a/.github/workflows/dymos_docs_workflow.yml
+++ b/.github/workflows/dymos_docs_workflow.yml
@@ -72,7 +72,7 @@ jobs:
           echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Fetch tags
         run: |

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Checkout code
         if: env.RUN_BUILD
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Fetch tags
         if: env.RUN_BUILD

--- a/docs/dymos_book/examples/robertson_problem/robertson_problem.ipynb
+++ b/docs/dymos_book/examples/robertson_problem/robertson_problem.ipynb
@@ -243,7 +243,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Building and running the problem"
+    "## Building and running the problem\n",
+    "\n",
+    "Here we're using the ExplicitShooting transcription in Dymos.\n",
+    "The ExplicitShooting transcription explicit integrates the given ODE using the `solve_ivp` method of [scipy](https://scipy.org/).\n",
+    "\n",
+    "Since this is purely an integration with no controls to be determined, a single call to `run_model` will propagate the solution for us. There's no need to run a driver. Even the typical follow-up call to `traj.simulate` is unnecessary.\n",
+    "\n",
+    "Technically, we could even solve this using a single segment since segment spacing in the explicit shooting transcription determine the density of the control nodes, and there are no controls for this simulation.\n",
+    "Providing more segments in this case (or a higher segment order) increases the number of nodes at which the outputs are provided."
    ]
   },
   {
@@ -265,11 +273,11 @@
     "    # Create a trajectory and add a phase to it\n",
     "    #\n",
     "    traj = p.model.add_subsystem('traj', dm.Trajectory())\n",
+    "    \n",
+    "    tx = dm.ExplicitShooting(num_segments=10, method='LSODA')\n",
     "\n",
     "    phase = traj.add_phase('phase0',\n",
-    "                           dm.Phase(ode_class=RobertsonODE,\n",
-    "                                    transcription=dm.GaussLobatto(num_segments=50)\n",
-    "                                   ))\n",
+    "                           dm.Phase(ode_class=RobertsonODE, transcription=tx))\n",
     "\n",
     "    #\n",
     "    # Set the variables\n",
@@ -311,9 +319,7 @@
     "# just set up the problem, test it elsewhere\n",
     "p = robertson_problem(t_final=40)\n",
     "\n",
-    "p.run_model()\n",
-    "\n",
-    "p_sim = p.model.traj.simulate(method='LSODA')"
+    "p.run_model()"
    ]
   },
   {
@@ -329,7 +335,7 @@
    "source": [
     "from openmdao.utils.assert_utils import assert_near_equal\n",
     "\n",
-    "assert_near_equal(p_sim.get_val('traj.phase0.timeseries.states:x0')[-1], 0.71583161, tolerance=1E-5)"
+    "assert_near_equal(p.get_val('traj.phase0.timeseries.states:x0')[-1], 0.71583161, tolerance=1E-4)"
    ]
   },
   {
@@ -345,7 +351,7 @@
    "source": [
     "from openmdao.utils.assert_utils import assert_near_equal\n",
     "\n",
-    "assert_near_equal(p_sim.get_val('traj.phase0.timeseries.states:y0')[-1], 9.18571144e-06, tolerance=1E-1)"
+    "assert_near_equal(p.get_val('traj.phase0.timeseries.states:y0')[-1], 9.18571144e-06, tolerance=1E-4)"
    ]
   },
   {
@@ -361,7 +367,7 @@
    "source": [
     "from openmdao.utils.assert_utils import assert_near_equal\n",
     "\n",
-    "assert_near_equal(p_sim.get_val('traj.phase0.timeseries.states:z0')[-1], 0.2841592, tolerance=1E-5)"
+    "assert_near_equal(p.get_val('traj.phase0.timeseries.states:z0')[-1], 0.2841592, tolerance=1E-4)"
    ]
   },
   {
@@ -372,12 +378,12 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "t_sim = p_sim.get_val('traj.phase0.timeseries.time')\n",
+    "t = p.get_val('traj.phase0.timeseries.time')\n",
     "\n",
     "states = ['x0', 'y0', 'z0']\n",
     "fig, axes = plt.subplots(len(states), 1)\n",
     "for i, state in enumerate(states):\n",
-    "    axes[i].plot(t_sim, p_sim.get_val(f'traj.phase0.timeseries.states:{state}'), '-')\n",
+    "    axes[i].plot(t, p.get_val(f'traj.phase0.timeseries.states:{state}'), 'o')\n",
     "    axes[i].set_ylabel(state[0])\n",
     "axes[-1].set_xlabel('time (s)')\n",
     "plt.tight_layout()\n",
@@ -396,7 +402,7 @@
    }
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -410,7 +416,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/docs/dymos_book/examples/robertson_problem/robertson_problem.ipynb
+++ b/docs/dymos_book/examples/robertson_problem/robertson_problem.ipynb
@@ -240,6 +240,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -250,7 +251,7 @@
     "\n",
     "Since this is purely an integration with no controls to be determined, a single call to `run_model` will propagate the solution for us. There's no need to run a driver. Even the typical follow-up call to `traj.simulate` is unnecessary.\n",
     "\n",
-    "Technically, we could even solve this using a single segment since segment spacing in the explicit shooting transcription determine the density of the control nodes, and there are no controls for this simulation.\n",
+    "Technically, we could even solve this using a single segment since segment spacing in the explicit shooting transcription determines the density of the control nodes, and there are no controls for this simulation.\n",
     "Providing more segments in this case (or a higher segment order) increases the number of nodes at which the outputs are provided."
    ]
   },

--- a/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
@@ -83,7 +83,7 @@ class TestAircraftCruise(unittest.TestCase):
         p.setup()
 
         p['phase0.t_initial'] = 0.0
-        p['phase0.t_duration'] = 1.515132 * 3600.0
+        p['phase0.t_duration'] = 3600.0
         p['phase0.states:range'] = phase.interp('range', (0, 1296.4))
         p['phase0.states:mass_fuel'] = phase.interp('mass_fuel', (12236.594555, 1))
         p['phase0.states:alt'] = 5.0
@@ -181,7 +181,7 @@ class TestAircraftCruise(unittest.TestCase):
         p.setup()
 
         p['phase0.t_initial'] = 0.0
-        p['phase0.t_duration'] = 1.515132 * 3600.0
+        p['phase0.t_duration'] = 1.0 * 3600.0
         p['phase0.states:range'] = phase.interp('range', (0, 1296.4))
         p['phase0.states:mass_fuel'] = phase.interp('mass_fuel', (12236.594555, 0))
         p['phase0.states:alt'] = 5.0

--- a/dymos/examples/brachistochrone/test/ex_brachistochrone.py
+++ b/dymos/examples/brachistochrone/test/ex_brachistochrone.py
@@ -90,6 +90,6 @@ def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, tran
 
 
 if __name__ == '__main__':
-    p = brachistochrone_min_time(transcription='shooting-gauss-lobatto', num_segments=5, run_driver=True,
-                                 transcription_order=5, compressed=False, optimizer='SNOPT',
+    p = brachistochrone_min_time(transcription='gauss-lobatto', num_segments=5, run_driver=True,
+                                 transcription_order=5, compressed=False, optimizer='IPOPT',
                                  solve_segments=False, force_alloc_complex=True)

--- a/dymos/examples/brachistochrone/test/ex_brachistochrone.py
+++ b/dymos/examples/brachistochrone/test/ex_brachistochrone.py
@@ -1,5 +1,4 @@
 import matplotlib
-import matplotlib.pyplot as plt
 
 import openmdao.api as om
 from openmdao.utils.testing_utils import require_pyoptsparse
@@ -30,6 +29,17 @@ def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, tran
         t = dm.Radau(num_segments=num_segments,
                      order=transcription_order,
                      compressed=compressed)
+    elif transcription == 'shooting-gauss-lobatto':
+        grid = dm.GaussLobattoGrid(num_segments=num_segments,
+                                   nodes_per_seg=transcription_order,
+                                   compressed=compressed)
+        t = dm.ExplicitShooting(grid=grid)
+    elif transcription == 'shooting-radau':
+        grid = dm.RadauGrid(num_segments=num_segments,
+                            nodes_per_seg=transcription_order + 1,
+                            compressed=compressed)
+        t = dm.ExplicitShooting(grid=grid)
+
     traj = dm.Trajectory()
     phase = dm.Phase(ode_class=BrachistochroneODE, transcription=t)
     p.model.add_subsystem('traj0', traj)
@@ -80,6 +90,6 @@ def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, tran
 
 
 if __name__ == '__main__':
-    p = brachistochrone_min_time(transcription='gauss-lobatto', num_segments=5, run_driver=True,
+    p = brachistochrone_min_time(transcription='shooting-gauss-lobatto', num_segments=5, run_driver=True,
                                  transcription_order=5, compressed=False, optimizer='SNOPT',
                                  solve_segments=False, force_alloc_complex=True)

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_subprob_reports.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_subprob_reports.py
@@ -166,8 +166,8 @@ if Version(openmdao_version) > Version("3.18"):
             report_subdirs = sorted([e for e in pathlib.Path(get_reports_dir()).iterdir() if e.is_dir()])
 
             # Test that a report subdir was made
-            # # There is the nominal problem, the simulation problem, and a subproblem for each segment in the simulation.
-            self.assertEqual(len(report_subdirs), 12)
+            # There is the nominal problem, the simulation problem, and a subproblem for the simulation.
+            self.assertEqual(len(report_subdirs), 3)
 
             for subdir in report_subdirs:
                 path = pathlib.Path(subdir).joinpath(self.n2_filename)

--- a/dymos/examples/brachistochrone/test/test_ex_brachistochrone.py
+++ b/dymos/examples/brachistochrone/test/test_ex_brachistochrone.py
@@ -55,8 +55,6 @@ class TestBrachistochroneExample(unittest.TestCase):
                                                         compressed=True)
         self.run_asserts(p)
         self.tearDown()
-        if os.path.exists('ex_brach_radau_compressed.db'):
-            os.remove('ex_brach_radau_compressed.db')
 
     def test_ex_brachistochrone_radau_uncompressed(self):
         ex_brachistochrone.SHOW_PLOTS = True
@@ -64,8 +62,6 @@ class TestBrachistochroneExample(unittest.TestCase):
                                                         compressed=False)
         self.run_asserts(p)
         self.tearDown()
-        if os.path.exists('ex_brach_radau_uncompressed.db'):
-            os.remove('ex_brach_radau_uncompressed.db')
 
     def test_ex_brachistochrone_gl_compressed(self):
         ex_brachistochrone.SHOW_PLOTS = True
@@ -73,8 +69,6 @@ class TestBrachistochroneExample(unittest.TestCase):
                                                         compressed=True)
         self.run_asserts(p)
         self.tearDown()
-        if os.path.exists('ex_brach_gl_compressed.db'):
-            os.remove('ex_brach_gl_compressed.db')
 
     def test_ex_brachistochrone_gl_uncompressed(self):
         ex_brachistochrone.SHOW_PLOTS = True
@@ -82,5 +76,31 @@ class TestBrachistochroneExample(unittest.TestCase):
                                                         compressed=False)
         self.run_asserts(p)
         self.tearDown()
-        if os.path.exists('ex_brach_gl_uncompressed.db'):
-            os.remove('ex_brach_gl_uncompressed.db')
+
+    def test_ex_brachistochrone_shooting_gl_compressed(self):
+        ex_brachistochrone.SHOW_PLOTS = True
+        p = ex_brachistochrone.brachistochrone_min_time(transcription='shooting-gauss-lobatto',
+                                                        compressed=True)
+        self.run_asserts(p)
+        self.tearDown()
+
+    def test_ex_brachistochrone_shooting_gl_uncompressed(self):
+        ex_brachistochrone.SHOW_PLOTS = True
+        p = ex_brachistochrone.brachistochrone_min_time(transcription='shooting-gauss-lobatto',
+                                                        compressed=False)
+        self.run_asserts(p)
+        self.tearDown()
+
+    def test_ex_brachistochrone_shooting_radau_compressed(self):
+        ex_brachistochrone.SHOW_PLOTS = True
+        p = ex_brachistochrone.brachistochrone_min_time(transcription='shooting-radau',
+                                                        compressed=True)
+        self.run_asserts(p)
+        self.tearDown()
+
+    def test_ex_brachistochrone_shooting_radau_uncompressed(self):
+        ex_brachistochrone.SHOW_PLOTS = True
+        p = ex_brachistochrone.brachistochrone_min_time(transcription='shooting-radau',
+                                                        compressed=False)
+        self.run_asserts(p)
+        self.tearDown()

--- a/dymos/examples/brachistochrone/test/test_state_rate_introspection.py
+++ b/dymos/examples/brachistochrone/test/test_state_rate_introspection.py
@@ -239,7 +239,7 @@ class TestIntegrateControl(unittest.TestCase):
         # Define a Dymos Phase object with GaussLobatto Transcription
         #
         phase = dm.Phase(ode_class=BrachistochroneODE,
-                         transcription=transcription(num_segments=10, order=3))
+                         transcription=transcription(num_segments=15, order=3))
 
         traj.add_phase(name='phase0', phase=phase)
 
@@ -304,7 +304,7 @@ class TestIntegrateControl(unittest.TestCase):
         p.set_val('traj.phase0.controls:theta', phase.interp('theta', [0, 100]), units='deg')
 
         # Run the driver to solve the problem
-        dm.run_problem(p, simulate=True, make_plots=False)
+        dm.run_problem(p, simulate=True, make_plots=False, simulate_kwargs={'atol': 1.0E-9, 'rtol': 1.0E-9})
 
         sol = om.CaseReader('dymos_solution.db').get_case('final')
         sim = om.CaseReader('dymos_simulation.db').get_case('final')

--- a/dymos/examples/brachistochrone/test/test_state_rate_introspection.py
+++ b/dymos/examples/brachistochrone/test/test_state_rate_introspection.py
@@ -9,7 +9,7 @@ from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 import dymos as dm
 from dymos.utils.testing_utils import assert_timeseries_near_equal
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
-.
+
 
 @use_tempdirs
 class TestIntegrateControl(unittest.TestCase):

--- a/dymos/examples/brachistochrone/test/test_state_rate_introspection.py
+++ b/dymos/examples/brachistochrone/test/test_state_rate_introspection.py
@@ -9,7 +9,7 @@ from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 import dymos as dm
 from dymos.utils.testing_utils import assert_timeseries_near_equal
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
-
+.
 
 @use_tempdirs
 class TestIntegrateControl(unittest.TestCase):

--- a/dymos/examples/min_time_climb/test/test_min_time_climb_simulate_failure.py
+++ b/dymos/examples/min_time_climb/test/test_min_time_climb_simulate_failure.py
@@ -93,10 +93,10 @@ class TestMinTimeClimbSimulateFailure(unittest.TestCase):
 
         with self.assertRaises(om.AnalysisError) as e:
             dm.run_problem(p, run_driver=False, simulate=True)
-        expected_pattern = r"'traj.phases.phase0.segments.segment_[0-9]' <class SegmentSimulationComp>: Error calling " \
-                           r"compute\(\), solve_ivp failed: Required step size is less than spacing " \
-                           r"between numbers. Dynamics changing too dramatically"
-        self.assertRegex(str(e.exception), expected_pattern)
+        expected_pattern = r"'traj.phases.phase0.integrator' <class ODEIntegrationComp>: Error calling " \
+                           r"compute(), solve_ivp failed: Required step size is less than spacing " \
+                           r"between numbers."
+        self.assertEqual(str(e.exception), expected_pattern)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/examples/robertson_problem/doc/test_doc_robertson_problem.py
+++ b/dymos/examples/robertson_problem/doc/test_doc_robertson_problem.py
@@ -7,7 +7,7 @@ from openmdao.utils.testing_utils import use_tempdirs
 from dymos.examples.robertson_problem.doc.robertson_ode import RobertsonODE
 
 
-matplotlib.use('Agg')
+# matplotlib.use('Agg')
 plt.style.use('ggplot')
 
 
@@ -31,9 +31,8 @@ class TestRobertsonProblemForDocs(unittest.TestCase):
 
         phase = traj.add_phase('phase0',
                                dm.Phase(ode_class=RobertsonODE,
-                                        transcription=dm.GaussLobatto(num_segments=50)
+                                        transcription=dm.ExplicitShooting(num_segments=10, method='LSODA')
                                         ))
-
         #
         # Set the variables
         #
@@ -93,18 +92,16 @@ class TestRobertsonProblemForDocs(unittest.TestCase):
 
         p.run_model()
 
-        p_sim = p.model.traj.simulate(method='LSODA')
+        assert_near_equal(p.get_val('traj.phase0.timeseries.states:x0')[-1], 0.71583161, tolerance=1E-4)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.states:y0')[-1], 9.18571144e-06, tolerance=1E-4)
+        assert_near_equal(p.get_val('traj.phase0.timeseries.states:z0')[-1], 0.2841592, tolerance=1E-4)
 
-        assert_near_equal(p_sim.get_val('traj.phase0.timeseries.states:x0')[-1], 0.71583161, tolerance=1E-5)
-        assert_near_equal(p_sim.get_val('traj.phase0.timeseries.states:y0')[-1], 9.18571144e-06, tolerance=1E-1)
-        assert_near_equal(p_sim.get_val('traj.phase0.timeseries.states:z0')[-1], 0.2841592, tolerance=1E-5)
-
-        t_sim = p_sim.get_val('traj.phase0.timeseries.time')
+        t_sim = p.get_val('traj.phase0.timeseries.time')
 
         states = ['x0', 'y0', 'z0']
         fig, axes = plt.subplots(len(states), 1)
         for i, state in enumerate(states):
-            axes[i].plot(t_sim, p_sim.get_val(f'traj.phase0.timeseries.states:{state}'), '-')
+            axes[i].plot(t_sim, p.get_val(f'traj.phase0.timeseries.states:{state}'), 'o')
             axes[i].set_ylabel(state[0])
         axes[-1].set_xlabel('time (s)')
         plt.tight_layout()

--- a/dymos/phase/__init__.py
+++ b/dymos/phase/__init__.py
@@ -1,2 +1,3 @@
 from .analytic_phase import AnalyticPhase
 from .phase import Phase
+from .simulation_phase import SimulationPhase

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -611,7 +611,7 @@ class SimulateOptionsDictionary(om.OptionsDictionary):
     def __init__(self, read_only=False):
         super(SimulateOptionsDictionary, self).__init__(read_only)
 
-        self.declare('method', values=('RK23', 'RK45', 'DOP853', 'BDF', 'Radau', 'LSODA'), default='RK45',
+        self.declare('method', values=('RK23', 'RK45', 'DOP853', 'BDF', 'Radau', 'LSODA'), default='DOP853',
                      desc='The method used by simulate to propagate the ODE.')
 
         self.declare(name='atol', types=(float, np.array), default=1.0E-6,

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -2282,7 +2282,7 @@ class Phase(om.Group):
         sim_prob.setup(check=True)
 
         # sim_phase.set_val_from_phase(from_phase=self)  # TODO: use this for OpenMDAO >= 3.25.1
-        sim_phase.initialize_values_from_phase(prop=sim_prob, from_phase=self, phase_path=self.pathname)
+        sim_phase.initialize_values_from_phase(prob=sim_prob, from_phase=self)
 
         print(f'\nSimulating phase {self.pathname}')
         sim_prob.run_model()

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -2152,13 +2152,6 @@ class Phase(om.Group):
         sim_phase = SimulationPhase(from_phase=self, times_per_seg=times_per_seg, atol=atol, rtol=rtol,
                                     first_step=first_step, max_step=max_step, reports=reports)
 
-        # Copy over any simulation options from the simulate call.  The fallback will be to
-        # phase.simulate_options, which are copied from the original phase.
-        for key, val in {'method': method, 'atol': atol, 'rtol': rtol, 'first_step': first_step,
-                         'max_step': max_step}.items():
-            if val is not _unspecified:
-                sim_phase.simulate_options[key] = val
-
         return sim_phase
 
     def initialize_values_from_phase(self, prob, from_phase, phase_path='', skip_params=None):

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -2152,7 +2152,7 @@ class Phase(om.Group):
         sim_phase = SimulationPhase(from_phase=self, times_per_seg=times_per_seg, atol=atol, rtol=rtol,
                                     first_step=first_step, max_step=max_step, reports=reports)
 
-        # Copy over any simulation options from the simulate call.  The ffallback will be to
+        # Copy over any simulation options from the simulate call.  The fallback will be to
         # phase.simulate_options, which are copied from the original phase.
         for key, val in {'method': method, 'atol': atol, 'rtol': rtol, 'first_step': first_step,
                          'max_step': max_step}.items():

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -2149,7 +2149,8 @@ class Phase(om.Group):
             times.  This instance has not yet been setup.
         """
         from .simulation_phase import SimulationPhase
-        sim_phase = SimulationPhase(from_phase=self, times_per_seg=times_per_seg, reports=reports)
+        sim_phase = SimulationPhase(from_phase=self, times_per_seg=times_per_seg, atol=atol, rtol=rtol,
+                                    first_step=first_step, max_step=max_step, reports=reports)
 
         # Copy over any simulation options from the simulate call.  The ffallback will be to
         # phase.simulate_options, which are copied from the original phase.

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -2237,30 +2237,6 @@ class Phase(om.Group):
                 prob_path = f'{self.name}.parameters:{name}'
             prob.set_val(prob_path, val)
 
-    def set_val_from_phase(self, from_phase):
-
-        t_initial = from_phase.get_val('t_initial', units=self.time_options['units'])
-        self.set_val('t_initial', t_initial, units=self.time_options['units'])
-
-        t_duration = from_phase.get_val('t_duration', units=self.time_options['units'])
-        self.set_val('t_duration', t_duration, units=self.time_options['units'])
-
-        for name, options in self.state_options.items():
-            val = from_phase.get_val(f'states:{name}', units=options['units'])[0, ...]
-            self.set_val(f'states:{name}', val, units=options['units'])
-
-        for name, options in self.parameter_options.items():
-            val = from_phase.get_val(f'parameters:{name}', units=options['units'])
-            self.set_val(f'parameters:{name}', val, units=options['units'])
-
-        for name, options in self.control_options.items():
-            val = from_phase.get_val(f'controls:{name}', units=options['units'])
-            self.set_val(f'controls:{name}', val, units=options['units'])
-
-        for name, options in self.polynomial_control_options.items():
-            val = from_phase.get_val(f'polynomial_controls:{name}', units=options['units'])
-            self.set_val(f'polynomial_controls:{name}', val, units=options['units'])
-
     def simulate(self, times_per_seg=10, method=_unspecified, atol=_unspecified, rtol=_unspecified,
                  first_step=_unspecified, max_step=_unspecified, record_file=None):
         """
@@ -2304,7 +2280,9 @@ class Phase(om.Group):
             sim_prob.add_recorder(rec)
 
         sim_prob.setup(check=True)
-        sim_phase.set_val_from_phase(from_phase=self)
+
+        # sim_phase.set_val_from_phase(from_phase=self)  # TODO: use this for OpenMDAO >= 3.25.1
+        sim_phase.initialize_values_from_phase(prop=sim_prob, from_phase=self, phase_path=self.pathname)
 
         print(f'\nSimulating phase {self.pathname}')
         sim_prob.run_model()

--- a/dymos/phase/simulation_phase.py
+++ b/dymos/phase/simulation_phase.py
@@ -1,0 +1,223 @@
+import openmdao
+
+from .phase import Phase
+from ..transcriptions.grid_data import GaussLobattoGrid, RadauGrid, UniformGrid
+from ..transcriptions import ExplicitShooting, GaussLobatto, Radau
+
+from ..utils.misc import _unspecified
+
+
+class SimulationPhase(Phase):
+    """
+    A SimulationPhase is a special kind of Phase that may only be used to propagate a trajectory from
+    some initial state and time for some given duration using the provided parameters and controls.
+
+    It does not support optimization, and no derivatives are propagated with the states.
+
+    Parameters
+    ----------
+    from_phase : <Phase> or None
+        A phase instance from which the initialized phase should copy its data.
+    **kwargs : dict
+        Dictionary of optional phase arguments.
+    """
+    def __init__(self, from_phase, times_per_seg=None, method=_unspecified, atol=_unspecified,
+                 rtol=_unspecified, first_step=_unspecified, max_step=_unspecified,
+                 reports=False, **kwargs):
+
+        phase_tx = from_phase.options['transcription']
+        num_seg = phase_tx.grid_data.num_segments
+        seg_order = phase_tx.grid_data.transcription_order
+        seg_ends = phase_tx.grid_data.segment_ends
+        compressed = phase_tx.grid_data.compressed
+
+        _method = method if method is not _unspecified else from_phase.simulate_options['method']
+        _atol = atol if atol is not _unspecified else from_phase.simulate_options['atol']
+        _rtol = rtol if rtol is not _unspecified else from_phase.simulate_options['rtol']
+        _first_step = first_step if first_step is not _unspecified else from_phase.simulate_options['first_step']
+        _max_step = max_step if max_step is not _unspecified else from_phase.simulate_options['max_step']
+
+        if isinstance(phase_tx, GaussLobatto):
+            grid = GaussLobattoGrid(num_segments=num_seg, nodes_per_seg=seg_order, segment_ends=seg_ends,
+                                    compressed=compressed)
+        elif isinstance(phase_tx, Radau):
+            grid = RadauGrid(num_segments=num_seg, nodes_per_seg=seg_order + 1, segment_ends=seg_ends,
+                             compressed=compressed)
+        else:
+            raise RuntimeError(f'Unexpected grid class for {phase_tx.grid_data}. Only phases with GaussLobatto'
+                               f'or Radau grids can be simulated.')
+
+        output_grid = UniformGrid(num_segments=num_seg, nodes_per_seg=times_per_seg, segment_ends=seg_ends,
+                                  compressed=compressed)
+
+        tx = ExplicitShooting(propagate_derivs=False,
+                              subprob_reports=reports,
+                              grid=grid,
+                              output_grid=output_grid,
+                              method=_method,
+                              atol=_atol,
+                              rtol=_rtol,
+                              first_step=_first_step,
+                              max_step=_max_step)
+
+        super().__init__(from_phase=from_phase, transcription=tx, ode_class=from_phase.options['ode_class'],
+                         ode_init_kwargs=from_phase.options['ode_init_kwargs'])
+
+        # Remove invalid options
+        for state_name, options in self.state_options.items():
+            options['fix_final'] = False  # ExplicitShooting will raise if `fix_final` is True for any states.
+
+        # Remove all but the default timeseries object
+        self._timeseries = {ts_name: ts_options for ts_name, ts_options in self._timeseries.items()
+                            if ts_name == 'timeseries'}
+
+    def add_boundary_constraint(self, name, loc, constraint_name=None, units=None,
+                                shape=None, indices=None, lower=None, upper=None, equals=None,
+                                scaler=None, adder=None, ref=None, ref0=None, linear=False, flat_indices=False):
+        r"""
+        Add a boundary constraint to a variable in the phase.
+
+        Parameters
+        ----------
+        name : str
+            Name of the variable to constrain. May also provide an expression to be evaluated and constrained.
+            If a single variable and the name is not a state, control, or 'time',
+            then this is assumed to be the path of the variable to be constrained in the ODE.
+            If an expression, it must be provided in the form of an equation with a left- and right-hand side.
+        loc : str
+            The location of the boundary constraint ('initial' or 'final').
+        constraint_name : str or None
+            The name of the boundary constraint. By default, this is 'var_constraint' if name is a single variable,
+             or the left-hand side of the equation if name is an expression.
+        units : str or None
+            The units in which the boundary constraint is to be applied.  If None, use the
+            units associated with the constrained output.  If provided, must be compatible with
+            the variables units.
+        shape : tuple, list, ndarray, or None
+            The shape of the variable being boundary-constrained.  This can be inferred
+            automatically for time, states, controls, and parameters, but is required
+            if the constrained variable is an output of the ODE system.
+        indices : tuple, list, ndarray, slice, or None
+            The indices of the output variable to be boundary constrained at either the initial or final time in the
+            phase. When the variable is multi-dimensional, this should be a list of lists, one for each dimension,
+            containing the indices to be constrained.  Note the behavior of indices changes depending on the value
+            of the flat_indices option.
+        lower : float or ndarray, optional
+            Lower boundary for the variable.
+        upper : float or ndarray, optional
+            Upper boundary for the variable.
+        equals : float or ndarray, optional
+            Equality constraint value for the variable.
+        scaler : float or ndarray, optional
+            Value to multiply the model value to get the scaled value. Scaler
+            is second in precedence.
+        adder : float or ndarray, optional
+            Value to add to the model value to get the scaled value. Adder
+            is first in precedence.
+        ref : float or ndarray, optional
+            Value of response variable that scales to 1.0 in the driver.
+        ref0 : float or ndarray, optional
+            Value of response variable that scales to 0.0 in the driver.
+        linear : bool
+            Set to True if constraint is linear. Setting this to True when the constraint is not a linear function
+            of the design variables will result in a failure of the optimization.
+        flat_indices : bool
+            If True, treat indices as flattened C-ordered indices of elements to constrain. Otherwise,
+            indices should be a tuple or list giving the elements to constrain at each point in time.
+        """
+        raise NotImplementedError('SimulationPhase does not support boundary constraints.')
+
+    def add_path_constraint(self, name, constraint_name=None, units=None, shape=None, indices=None,
+                            lower=None, upper=None, equals=None, scaler=None, adder=None, ref=None,
+                            ref0=None, linear=False, flat_indices=False):
+        r"""
+        Add a path constraint to a variable in the phase.
+
+        Parameters
+        ----------
+        name : str
+            Name of the variable to constrain. May also provide an expression to be evaluated and constrained.
+            If a single variable and the name is not a state, control, or 'time',
+            then this is assumed to be the path of the variable to be constrained in the ODE.
+            If an expression, it must be provided in the form of an equation with a left- and right-hand side.
+        constraint_name : str or None
+            The name of the path constraint. By default, this is 'var_constraint' if name is a single variable,
+             or the left-hand side of the equation if name is an expression.
+        units : str or None
+            The units in which the boundary constraint is to be applied.  If None, use the
+            units associated with the constrained output.  If provided, must be compatible with
+            the variables units.
+        shape : tuple, list, ndarray, or None
+            The shape of the variable being boundary-constrained.  This can be inferred
+            automatically for time, states, controls, and parameters, but is required
+            if the constrained variable is an output of the ODE system.
+        indices : tuple, list, ndarray, or None
+            The indices of the output variable to be constrained at each point in time in the phase.
+            When the variable is multi-dimensional, this should be a list of lists, one for each dimension,
+            containing the indices to be constrained.  Note the behavior of indices changes depending on the value
+            of the flat_indices option.
+        lower : float or ndarray, optional
+            Lower boundary for the variable.
+        upper : float or ndarray, optional
+            Upper boundary for the variable.
+        equals : float or ndarray, optional
+            Equality constraint value for the variable.
+        scaler : float or ndarray, optional
+            Value to multiply the model value to get the scaled value. Scaler
+            is second in precedence.
+        adder : float or ndarray, optional
+            Value to add to the model value to get the scaled value. Adder
+            is first in precedence.
+        ref : float or ndarray, optional
+            Value of response variable that scales to 1.0 in the driver.
+        ref0 : float or ndarray, optional
+            Value of response variable that scales to 0.0 in the driver.
+        linear : bool
+            Set to True if constraint is linear. If set to True and the constrained output is not a linear function
+            of the design variables, the optimization will fail.
+        flat_indices : bool
+            If True, treat indices as flattened C-ordered indices of elements to constrain at each given point in time.
+            Otherwise, indices should be a tuple or list giving the elements to constrain at each point in time.
+        """
+        raise NotImplementedError('SimulationPhase does not support path constraints.')
+
+    def add_objective(self, name, loc='final', index=None, shape=(1,), units=None, ref=None, ref0=None,
+                      adder=None, scaler=None, parallel_deriv_color=None):
+        """
+        Add an objective in the phase.
+
+        If name is not a state, control, control rate, or 'time', then this is assumed to be the
+        path of the variable to be constrained in the RHS.
+
+        Parameters
+        ----------
+        name : str
+            Name of the objective variable.  This should be one of the integration variable, a state or control
+            variable, the path to an output from the top level of the RHS, or an expression to be evaluated.
+            If an expression, it must be provided in the form of an equation with a left- and right-hand side.
+        loc : str
+            Where in the phase the objective is to be evaluated.  Valid
+            options are 'initial' and 'final'.  The default is 'final'.
+        index : int, optional
+            If variable is an array at each point in time, this indicates which index is to be
+            used as the objective, assuming C-ordered flattening.
+        shape : int, optional
+            The shape of the objective variable, at a point in time.
+        units : str, optional
+            The units of the objective function.  If None, use the units associated with the target.
+            If provided, must be compatible with the target units.
+        ref : float or ndarray, optional
+            Value of response variable that scales to 1.0 in the driver.
+        ref0 : float or ndarray, optional
+            Value of response variable that scales to 0.0 in the driver.
+        adder : float or ndarray, optional
+            Value to add to the model value to get the scaled value. Adder
+            is first in precedence.
+        scaler : float or ndarray, optional
+            Value to multiply the model value to get the scaled value. Scaler
+            is second in precedence.
+        parallel_deriv_color : str
+            If specified, this design var will be grouped for parallel derivative
+            calculations with other variables sharing the same parallel_deriv_color.
+        """
+        raise NotImplementedError('SimulationPhase does not support optimization objectives.')

--- a/dymos/phase/simulation_phase.py
+++ b/dymos/phase/simulation_phase.py
@@ -9,15 +9,30 @@ from ..utils.misc import _unspecified
 
 class SimulationPhase(Phase):
     """
-    A SimulationPhase is a special kind of Phase that may only be used to propagate a trajectory from
-    some initial state and time for some given duration using the provided parameters and controls.
+    A special phase class for performing simulation of an ODE without derivatives.
 
-    It does not support optimization, and no derivatives are propagated with the states.
+    Note: For the arguments which accept _unspecified, any argument not provided will be overridden
+    by the simulation_options of the phase specified by `from_phase`.
 
     Parameters
     ----------
     from_phase : <Phase> or None
         A phase instance from which the initialized phase should copy its data.
+    times_per_seg : int
+        The number of output points per segment, uniformly distributed.
+    method : str or _unspecified
+        A valid scipy.solve_ivp method for integration.
+    atol : float or _unspecified
+        Absolute error tolerance of the integration.
+    rtol : float or _unspecified
+        Relative error tolerance of the integration.
+    first_step : float or _unspecified
+        Initial step size of the integration.
+    max_step : float or _unspecified
+        Maximum step size of the integration.
+    reports : float or _unspecified
+        If True, generate reports for the subproblem used in integration.
+
     **kwargs : dict
         Dictionary of optional phase arguments.
     """
@@ -76,8 +91,7 @@ class SimulationPhase(Phase):
 
     def set_val_from_phase(self, from_phase):
         """
-        Set the necessary values to simulate the phase based on time, state, control, and parameter values
-        from the given phase.
+        Set the necessary values to simulate the phase based on variables in the given phase.
 
         Parameters
         ----------

--- a/dymos/phase/simulation_phase.py
+++ b/dymos/phase/simulation_phase.py
@@ -43,8 +43,11 @@ class SimulationPhase(Phase):
         elif isinstance(phase_tx, Radau):
             grid = RadauGrid(num_segments=num_seg, nodes_per_seg=seg_order + 1, segment_ends=seg_ends,
                              compressed=compressed)
+        elif isinstance(phase_tx.grid_data, GaussLobattoGrid) or \
+                isinstance(phase_tx.grid_data, RadauGrid):
+            grid = phase_tx.grid_data
         else:
-            raise RuntimeError(f'Unexpected grid class for {phase_tx.grid_data}. Only phases with GaussLobatto'
+            raise RuntimeError(f'Unexpected grid class for {phase_tx.grid_data}. Only phases with GaussLobatto '
                                f'or Radau grids can be simulated.')
 
         output_grid = UniformGrid(num_segments=num_seg, nodes_per_seg=times_per_seg, segment_ends=seg_ends,

--- a/dymos/phase/simulation_phase.py
+++ b/dymos/phase/simulation_phase.py
@@ -65,8 +65,11 @@ class SimulationPhase(Phase):
             raise RuntimeError(f'Unexpected grid class for {phase_tx.grid_data}. Only phases with GaussLobatto '
                                f'or Radau grids can be simulated.')
 
-        output_grid = UniformGrid(num_segments=num_seg, nodes_per_seg=times_per_seg, segment_ends=seg_ends,
-                                  compressed=compressed)
+        if times_per_seg is None:
+            output_grid = None
+        else:
+            output_grid = UniformGrid(num_segments=num_seg, nodes_per_seg=times_per_seg, segment_ends=seg_ends,
+                                      compressed=compressed)
 
         tx = ExplicitShooting(propagate_derivs=False,
                               subprob_reports=reports,

--- a/dymos/phase/test/test_time_targets.py
+++ b/dymos/phase/test/test_time_targets.py
@@ -185,7 +185,7 @@ class TestPhaseTimeTargets(unittest.TestCase):
 
                 exp_out = p.model._get_subsystem('phase0').simulate()
 
-                time_comp = exp_out.model.phase0._get_subsystem(f'time')
+                time_comp = exp_out.model.phase0._get_subsystem('time')
                 integrator_comp = exp_out.model.phase0._get_subsystem(f'integrator')
                 ode = exp_out.model.phase0._get_subsystem(f'ode')
                 timeseries_comp = exp_out.model.phase0._get_subsystem(f'timeseries')
@@ -237,7 +237,7 @@ class TestPhaseTimeTargets(unittest.TestCase):
 
                 exp_out = p.model.phase0.simulate()
 
-                time_comp = exp_out.model.phase0._get_subsystem(f'time')
+                time_comp = exp_out.model.phase0._get_subsystem('time')
                 integrator_comp = exp_out.model.phase0._get_subsystem(f'integrator')
                 ode = exp_out.model.phase0._get_subsystem(f'ode')
                 timeseries_comp = exp_out.model.phase0._get_subsystem(f'timeseries')
@@ -325,7 +325,7 @@ class TestPhaseTimeTargets(unittest.TestCase):
 
         exp_out = p.model._get_subsystem('phase0').simulate()
 
-        time_comp = exp_out.model.phase0._get_subsystem(f'time')
+        time_comp = exp_out.model.phase0._get_subsystem('time')
         integrator_comp = exp_out.model.phase0._get_subsystem(f'integrator')
         ode = exp_out.model.phase0._get_subsystem(f'ode')
         timeseries_comp = exp_out.model.phase0._get_subsystem(f'timeseries')
@@ -375,7 +375,7 @@ class TestPhaseTimeTargets(unittest.TestCase):
 
         exp_out = p.model._get_subsystem('phase0').simulate()
 
-        time_comp = exp_out.model.phase0._get_subsystem(f'time')
+        time_comp = exp_out.model.phase0._get_subsystem('time')
         integrator_comp = exp_out.model.phase0._get_subsystem(f'integrator')
         ode = exp_out.model.phase0._get_subsystem(f'ode')
         timeseries_comp = exp_out.model.phase0._get_subsystem(f'timeseries')

--- a/dymos/phase/test/test_time_targets.py
+++ b/dymos/phase/test/test_time_targets.py
@@ -188,11 +188,11 @@ class TestPhaseTimeTargets(unittest.TestCase):
                 integrator_comp = exp_out.model.phase0._get_subsystem(f'integrator')
                 ode = exp_out.model.phase0._get_subsystem(f'ode')
                 timeseries_comp = exp_out.model.phase0._get_subsystem(f'timeseries')
-                
+
                 time_comp_t_initial = time_comp.get_val('t_initial')
                 integrator_comp_t_initial = integrator_comp.get_val('t_initial')
                 ode_t_initial = ode.get_val('t_initial')
-                
+
                 time_comp_t_duration = time_comp.get_val('t_duration')
                 integrator_comp_t_duration = integrator_comp.get_val('t_duration')
                 ode_t_duration = ode.get_val('t_duration')
@@ -206,9 +206,8 @@ class TestPhaseTimeTargets(unittest.TestCase):
                 assert_near_equal(time_comp_t_duration, p['phase0.t_duration'])
                 assert_near_equal(integrator_comp_t_duration, p['phase0.t_duration'])
                 assert_near_equal(ode_t_duration, p['phase0.t_duration'])
-                
+
                 assert_near_equal(ode_time_phase.ravel(), timeseries_time_phase.ravel())
-                
 
     def test_radau(self):
         for time_name in ('time', 'elapsed_time'):
@@ -241,11 +240,11 @@ class TestPhaseTimeTargets(unittest.TestCase):
                 integrator_comp = exp_out.model.phase0._get_subsystem(f'integrator')
                 ode = exp_out.model.phase0._get_subsystem(f'ode')
                 timeseries_comp = exp_out.model.phase0._get_subsystem(f'timeseries')
-                
+
                 time_comp_t_initial = time_comp.get_val('t_initial')
                 integrator_comp_t_initial = integrator_comp.get_val('t_initial')
                 ode_t_initial = ode.get_val('t_initial')
-                
+
                 time_comp_t_duration = time_comp.get_val('t_duration')
                 integrator_comp_t_duration = integrator_comp.get_val('t_duration')
                 ode_t_duration = ode.get_val('t_duration')
@@ -259,7 +258,7 @@ class TestPhaseTimeTargets(unittest.TestCase):
                 assert_near_equal(time_comp_t_duration, p['phase0.t_duration'])
                 assert_near_equal(integrator_comp_t_duration, p['phase0.t_duration'])
                 assert_near_equal(ode_t_duration, p['phase0.t_duration'])
-                
+
                 assert_near_equal(ode_time_phase.ravel(), timeseries_time_phase.ravel())
 
     def test_explicit_shooting(self):
@@ -329,11 +328,11 @@ class TestPhaseTimeTargets(unittest.TestCase):
         integrator_comp = exp_out.model.phase0._get_subsystem(f'integrator')
         ode = exp_out.model.phase0._get_subsystem(f'ode')
         timeseries_comp = exp_out.model.phase0._get_subsystem(f'timeseries')
-        
+
         time_comp_t_initial = time_comp.get_val('t_initial')
         integrator_comp_t_initial = integrator_comp.get_val('t_initial')
         ode_t_initial = ode.get_val('t_initial')
-        
+
         time_comp_t_duration = time_comp.get_val('t_duration')
         integrator_comp_t_duration = integrator_comp.get_val('t_duration')
         ode_t_duration = ode.get_val('t_duration')
@@ -347,7 +346,7 @@ class TestPhaseTimeTargets(unittest.TestCase):
         assert_near_equal(time_comp_t_duration, p['phase0.t_duration'])
         assert_near_equal(integrator_comp_t_duration, p['phase0.t_duration'])
         assert_near_equal(ode_t_duration, p['phase0.t_duration'])
-        
+
         assert_near_equal(ode_time_phase.ravel(), timeseries_time_phase.ravel())
 
     def test_radau_targets_are_inputs(self):
@@ -360,12 +359,8 @@ class TestPhaseTimeTargets(unittest.TestCase):
         gd = p.model.phase0.options['transcription'].grid_data
 
         time_all = p['phase0.t']
-        time_segends = np.reshape(time_all[gd.subset_node_indices['segment_ends']],
-                                  newshape=(gd.num_segments, 2))
 
         time_phase_all = p['phase0.t_phase']
-        time_phase_segends = np.reshape(time_phase_all[gd.subset_node_indices['segment_ends']],
-                                        newshape=(gd.num_segments, 2))
 
         assert_near_equal(p['phase0.rhs_all.time_phase'][-1], 1.8016, tolerance=1.0E-3)
 
@@ -383,11 +378,11 @@ class TestPhaseTimeTargets(unittest.TestCase):
         integrator_comp = exp_out.model.phase0._get_subsystem(f'integrator')
         ode = exp_out.model.phase0._get_subsystem(f'ode')
         timeseries_comp = exp_out.model.phase0._get_subsystem(f'timeseries')
-        
+
         time_comp_t_initial = time_comp.get_val('t_initial')
         integrator_comp_t_initial = integrator_comp.get_val('t_initial')
         ode_t_initial = ode.get_val('t_initial')
-        
+
         time_comp_t_duration = time_comp.get_val('t_duration')
         integrator_comp_t_duration = integrator_comp.get_val('t_duration')
         ode_t_duration = ode.get_val('t_duration')
@@ -401,7 +396,7 @@ class TestPhaseTimeTargets(unittest.TestCase):
         assert_near_equal(time_comp_t_duration, p['phase0.t_duration'])
         assert_near_equal(integrator_comp_t_duration, p['phase0.t_duration'])
         assert_near_equal(ode_t_duration, p['phase0.t_duration'])
-        
+
         assert_near_equal(ode_time_phase.ravel(), timeseries_time_phase.ravel())
 
 

--- a/dymos/phase/test/test_time_targets.py
+++ b/dymos/phase/test/test_time_targets.py
@@ -92,6 +92,7 @@ class _BrachistochroneTestODE(om.ExplicitComponent):
         jacobian['check', 'theta'] = -v * cos_theta / sin_theta**2
 
 
+@use_tempdirs
 class TestPhaseTimeTargets(unittest.TestCase):
 
     def _make_problem(self, transcription, num_seg, transcription_order=3, input_initial=False,

--- a/dymos/test/test_run_problem.py
+++ b/dymos/test/test_run_problem.py
@@ -104,7 +104,7 @@ class TestRunProblem(unittest.TestCase):
             p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
             p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
         elif optimizer == 'IPOPT':
-            p.driver.opt_settings['print_level'] = 5
+            p.driver.opt_settings['print_level'] = 0
             p.driver.opt_settings['max_iter'] = 200
             p.driver.opt_settings['linear_solver'] = 'mumps'
             p.driver.opt_settings['mu_strategy'] = 'monotone'

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -1273,8 +1273,7 @@ class Trajectory(om.Group):
             sim_prob.set_val(sim_prob_prom_path, self.get_val(f'parameters:{name}'))
 
         for phase_name, phs in sim_traj._phases.items():
-            phs.initialize_values_from_phase(sim_prob, self._phases[phase_name],
-                                             phase_path=traj_name)
+            phs.set_val_from_phase(from_phase=self._phases[phase_name])
 
         print(f'\nSimulating trajectory {self.pathname}')
         sim_prob.run_model(case_prefix=case_prefix, reset_iter_counts=reset_iter_counts)

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -1273,7 +1273,11 @@ class Trajectory(om.Group):
             sim_prob.set_val(sim_prob_prom_path, self.get_val(f'parameters:{name}'))
 
         for phase_name, phs in sim_traj._phases.items():
-            phs.set_val_from_phase(from_phase=self._phases[phase_name])
+            # TODO: use the following method once OpenMDAO >= 3.25.1
+            # phs.set_val_from_phase(from_phase=self._phases[phase_name])
+            phs.initialize_values_from_phase(prob=sim_prob,
+                                             from_phase=self._phases[phase_name],
+                                             phase_path=traj_name)
 
         print(f'\nSimulating trajectory {self.pathname}')
         sim_prob.run_model(case_prefix=case_prefix, reset_iter_counts=reset_iter_counts)

--- a/dymos/transcriptions/explicit_shooting/explicit_shooting.py
+++ b/dymos/transcriptions/explicit_shooting/explicit_shooting.py
@@ -75,8 +75,6 @@ class ExplicitShooting(TranscriptionBase):
                              default=None, desc='Number of integration steps in each segment',
                              deprecation='Option `num_steps_per_segment is deprecated. ExplicitShooting now uses '
                                          'adaptive-step methods.')
-        self.options.declare('subprob_reports', default=False,
-                             desc='Controls the reports made when running the subproblems for ExplicitShooting')
 
         # Deprecated options previously inherited from transcription base.
         self.options.declare('num_segments', types=int, desc='Number of segments',

--- a/dymos/transcriptions/explicit_shooting/explicit_shooting.py
+++ b/dymos/transcriptions/explicit_shooting/explicit_shooting.py
@@ -77,44 +77,23 @@ class ExplicitShooting(TranscriptionBase):
                                          'adaptive-step methods.')
 
         # Deprecated options previously inherited from transcription base.
-        self.options.declare('num_segments', types=int, desc='Number of segments',
-                             deprecation='Option `num_segments` of ExplicitShooting is deprecated. Please provide '
-                                         '`grid` as an instance of dymos.GaussLobattoGrid or '
-                                         'dymos.RadauGrid instead.')
+        self.options.declare('num_segments', types=int, desc='Number of segments')
         self.options.declare('segment_ends', default=None, types=(Sequence, np.ndarray),
                              allow_none=True, desc='Locations of segment ends or None for equally '
-                             'spaced segments',
-                             deprecation='Option `segment_ends` of ExplicitShooting is deprecated. Please provide '
-                                         '`grid` as an instance of dymos.GaussLobattoGrid or '
-                                         'dymos.RadauGrid instead.')
+                             'spaced segments')
         self.options.declare('order', default=3, types=(int, Sequence, np.ndarray),
                              desc='Order of the state transcription. The order of the control '
-                                  'transcription is `order - 1`.',
-                             deprecation='Option `order` of ExplicitShooting is deprecated. Please provide '
-                                         '`grid` as an instance of dymos.GaussLobattoGrid or '
-                                         'dymos.RadauGrid instead.')
+                                  'transcription is `order - 1`.')
         self.options.declare('compressed', default=True, types=bool,
                              desc='Use compressed transcription, meaning state and control values'
                                   'at segment boundaries are not duplicated on input.  This '
                                   'implicitly enforces value continuity between segments but in '
-                                  'some cases may make the problem more difficult to solve.',
-                             deprecation='Option `compressed`` of ExplicitShooting is deprecated. Please provide '
-                                         '`grid` as an instance of dymos.GaussLobattoGrid or '
-                                         'dymos.RadauGrid instead.')
+                                  'some cases may make the problem more difficult to solve.')
 
     def init_grid(self):
         """
         Setup the GridData object for the Transcription.
         """
-        # Don't show the deprecation warning unless the user actually used the deprecated options:
-        dep_options = {'order': None, 'segment_ends': None, 'compressed': None}
-
-        for option in dep_options:
-            show_warn_save = self.options._dict[option]['deprecation'][2]
-            self.options._dict[option]['deprecation'][2] = False
-            dep_options[option] = self.options[option]
-            self.options._dict[option]['deprecation'][2] = show_warn_save
-
         if self.options['grid'] in ('gauss-lobatto', None):
             self.options['grid'] = GaussLobattoGrid(num_segments=self.options['num_segments'],
                                                     nodes_per_seg=self.options['order'],

--- a/dymos/transcriptions/explicit_shooting/ode_evaluation_group.py
+++ b/dymos/transcriptions/explicit_shooting/ode_evaluation_group.py
@@ -367,7 +367,7 @@ class ODEEvaluationGroup(om.Group):
         t_name = self._time_options['name']
 
         if var == t_name:
-            rate_path = 'time'
+            rate_path = t_name
         elif var == f'{t_name}_phase':
             rate_path = f'{t_name}_phase'
         elif self._state_options is not None and var in self._state_options:

--- a/dymos/transcriptions/explicit_shooting/ode_integration_comp.py
+++ b/dymos/transcriptions/explicit_shooting/ode_integration_comp.py
@@ -798,6 +798,9 @@ class ODEIntegrationComp(om.ExplicitComponent):
                 sol = solve_ivp(self._f_primal, t_span=t_span_seg, t_eval=t_eval_seg, y0=y0, args=(theta,),
                                 method=method, first_step=first_step, max_step=max_step, atol=atol, rtol=rtol)
 
+            if not sol.success:
+                raise om.AnalysisError(f'solve_ivp failed: {sol.message}')
+
             x_out[row_seg_i:row_seg_i+nnps[i], :] = sol.y.T[:, :n_x]  # Save solution to the output nodes
             t_out[row_seg_i:row_seg_i + nnps[i], 0] = sol.t
             y0 = sol.y.T[-1, :]  # Set initial y for the next segment

--- a/dymos/transcriptions/explicit_shooting/ode_integration_comp.py
+++ b/dymos/transcriptions/explicit_shooting/ode_integration_comp.py
@@ -664,8 +664,8 @@ class ODEIntegrationComp(om.ExplicitComponent):
         ----------
         t : float
             The current value of the integration variable.
-        y : np.array
-            The augmented state vector.
+        x : np.array
+            The primal state vector.
         theta : np.array
             The ODE parameter vector. The first two elements are t_initial and t_duration.
 
@@ -674,9 +674,12 @@ class ODEIntegrationComp(om.ExplicitComponent):
         y_dot : np.array
             The rates associated with each state in the augmented state vector (primal and tangent states).
         """
-        x_dot, _, _, _ = self.eval_ode(x, t, theta, eval_solution=True, eval_derivs=False)
+        n_x = self.x_size
+        _x = x.reshape((1, n_x))
 
-        return x_dot
+        x_dot, _, _, _ = self.eval_ode(_x, t, theta, eval_solution=True, eval_derivs=False)
+
+        return x_dot.ravel()
 
     def _propagate(self, inputs, propagate_derivs=None, x_out=None, t_out=None, dx_dz_out=None,
                    dt_dz_out=None):

--- a/dymos/transcriptions/explicit_shooting/tau_comp.py
+++ b/dymos/transcriptions/explicit_shooting/tau_comp.py
@@ -38,13 +38,14 @@ class TauComp(om.ExplicitComponent):
         """
         vec_size = self.options['vec_size']
         time_units = self.options['time_units']
+        dstau_dt_units = None if time_units is None else f'1/{time_units}'
 
         self.add_input('t_initial', val=0.0, units=time_units)
         self.add_input('t_duration', val=1.0, units=time_units)
         self.add_input('t', shape=(vec_size,), units=time_units)
         self.add_output('ptau', units=None, shape=(vec_size,))
         self.add_output('stau', units=None, shape=(vec_size,))
-        self.add_output('dstau_dt', units=f'1/{time_units}', val=1.0)
+        self.add_output('dstau_dt', units=dstau_dt_units, val=1.0)
         self.add_output('t_phase', units=time_units, shape=(vec_size,))
         # self.add_discrete_output('segment_index', val=0)
 

--- a/dymos/transcriptions/explicit_shooting/vandermonde_control_interp_comp.py
+++ b/dymos/transcriptions/explicit_shooting/vandermonde_control_interp_comp.py
@@ -2,6 +2,7 @@ import numpy as np
 import openmdao.api as om
 
 from ...utils.lgl import lgl
+from ...utils.misc import get_rate_units
 
 
 class VandermondeControlInterpComp(om.ExplicitComponent):
@@ -126,12 +127,14 @@ class VandermondeControlInterpComp(om.ExplicitComponent):
             output_name = f'control_values:{control_name}'
             rate_name = f'control_rates:{control_name}_rate'
             rate2_name = f'control_rates:{control_name}_rate2'
+            rate_units = get_rate_units(units, self._time_units)
+            rate2_units = get_rate_units(units, self._time_units, deriv=2)
             uhat_shape = (num_uhat_nodes,) + shape
             output_shape = (vec_size,) + shape
             self.add_input(input_name, shape=uhat_shape, units=units)
             self.add_output(output_name, shape=output_shape, units=units)
-            self.add_output(rate_name, shape=output_shape, units=units)
-            self.add_output(rate2_name, shape=output_shape, units=units)
+            self.add_output(rate_name, shape=output_shape, units=rate_units)
+            self.add_output(rate2_name, shape=output_shape, units=rate2_units)
             self._control_io_names[control_name] = (input_name, output_name, rate_name, rate2_name)
             self.declare_partials(of=output_name, wrt=input_name)
             self.declare_partials(of=output_name, wrt='stau', rows=ar, cols=ar)
@@ -154,12 +157,14 @@ class VandermondeControlInterpComp(om.ExplicitComponent):
             output_name = f'polynomial_control_values:{pc_name}'
             rate_name = f'polynomial_control_rates:{pc_name}_rate'
             rate2_name = f'polynomial_control_rates:{pc_name}_rate2'
+            rate_units = get_rate_units(units, self._time_units)
+            rate2_units = get_rate_units(units, self._time_units, deriv=2)
             input_shape = (order + 1,) + shape
             output_shape = (vec_size,) + shape
             self.add_input(input_name, shape=input_shape, units=units)
             self.add_output(output_name, shape=output_shape, units=units)
-            self.add_output(rate_name, shape=output_shape, units=units)
-            self.add_output(rate2_name, shape=output_shape, units=units)
+            self.add_output(rate_name, shape=output_shape, units=rate_units)
+            self.add_output(rate2_name, shape=output_shape, units=rate2_units)
             self._control_io_names[pc_name] = (input_name, output_name, rate_name, rate2_name)
             self.declare_partials(of=output_name, wrt=input_name)
             self.declare_partials(of=output_name, wrt='ptau', rows=ar, cols=ar)

--- a/dymos/transcriptions/grid_data.py
+++ b/dymos/transcriptions/grid_data.py
@@ -322,10 +322,9 @@ class GridData(object):
         if isinstance(transcription_order, str):
             self.transcription_order = num_segments * [transcription_order]
         elif np.ndim(transcription_order) == 0:  # scalar
-            transcription_order = np.ones(num_segments, int) * transcription_order
-            self.transcription_order = np.asarray(transcription_order, dtype=int)
-        elif np.ndim(transcription_order) == 1:
-            self.transcription_order = np.ones(num_segments, int) * transcription_order[0]
+            self.transcription_order = np.ones(num_segments, int) * transcription_order
+        elif np.size(transcription_order) == 1:  # length-1 array
+            self.transcription_order = np.ones(num_segments, int) * np.asarray(transcription_order)[0]
         else:
             self.transcription_order = np.asarray(transcription_order, dtype=int)
 

--- a/dymos/transcriptions/grid_data.py
+++ b/dymos/transcriptions/grid_data.py
@@ -583,7 +583,7 @@ class GaussLobattoGrid(GridData):
     """
     def __init__(self, num_segments, nodes_per_seg, segment_ends=None, compressed=False):
         super().__init__(num_segments=num_segments, transcription='gauss-lobatto',
-                         transcription_order=np.asarray(nodes_per_seg, dtype=int)-1,
+                         transcription_order=np.asarray(nodes_per_seg, dtype=int),
                          segment_ends=segment_ends, compressed=compressed)
 
 

--- a/dymos/transcriptions/grid_data.py
+++ b/dymos/transcriptions/grid_data.py
@@ -321,9 +321,11 @@ class GridData(object):
         # Make sure transcription_order is a vector
         if isinstance(transcription_order, str):
             self.transcription_order = num_segments * [transcription_order]
-        elif np.isscalar(transcription_order):
+        elif np.ndim(transcription_order) == 0:  # scalar
             transcription_order = np.ones(num_segments, int) * transcription_order
             self.transcription_order = np.asarray(transcription_order, dtype=int)
+        elif np.ndim(transcription_order) == 1:
+            self.transcription_order = np.ones(num_segments, int) * transcription_order[0]
         else:
             self.transcription_order = np.asarray(transcription_order, dtype=int)
 

--- a/dymos/transcriptions/pseudospectral/components/pseudospectral_timeseries_output_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/pseudospectral_timeseries_output_comp.py
@@ -66,7 +66,7 @@ class PseudospectralTimeseriesOutputComp(TimeseriesOutputCompBase):
             istau_segi = igd.node_stau[i1:i2]
 
             # The indices of the output grid that fall within this segment of the input grid
-            if ogd is igd:
+            if ogd is igd and output_subset == 'all':
                 optau_segi = iptau_segi
             else:
                 ptau_hi = igd.segment_ends[iseg+1]

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -32,6 +32,10 @@ class SolveIVP(TranscriptionBase):
         Dictionary of optional arguments.
     """
     def __init__(self, grid_data=None, **kwargs):
+        om.issue_warning('The SolveIVP transcription is deprecated. The simulate methods in Dymos now use a '
+                         'the ExplicitShooting transcription without derivative propagation to achieve the same'
+                         'functionality. SolveIVP will be removed in a future version of Dymos.',
+                         category=DeprecationWarning)
         super(SolveIVP, self).__init__(**kwargs)
         self.grid_data = grid_data
         self._rhs_source = 'ode'

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -32,7 +32,7 @@ class SolveIVP(TranscriptionBase):
         Dictionary of optional arguments.
     """
     def __init__(self, grid_data=None, **kwargs):
-        om.issue_warning('The SolveIVP transcription is deprecated. The simulate methods in Dymos now use a '
+        om.issue_warning('The SolveIVP transcription is deprecated. The simulate methods in Dymos now uses '
                          'the ExplicitShooting transcription without derivative propagation to achieve the same'
                          'functionality. SolveIVP will be removed in a future version of Dymos.',
                          category=om.OMDeprecationWarning)

--- a/dymos/transcriptions/solve_ivp/solve_ivp.py
+++ b/dymos/transcriptions/solve_ivp/solve_ivp.py
@@ -35,7 +35,7 @@ class SolveIVP(TranscriptionBase):
         om.issue_warning('The SolveIVP transcription is deprecated. The simulate methods in Dymos now use a '
                          'the ExplicitShooting transcription without derivative propagation to achieve the same'
                          'functionality. SolveIVP will be removed in a future version of Dymos.',
-                         category=DeprecationWarning)
+                         category=om.OMDeprecationWarning)
         super(SolveIVP, self).__init__(**kwargs)
         self.grid_data = grid_data
         self._rhs_source = 'ode'

--- a/dymos/visualization/linkage/test/linkage_report_ui_test.py
+++ b/dymos/visualization/linkage/test/linkage_report_ui_test.py
@@ -255,7 +255,7 @@ class dymos_linkage_gui_test_case(_GuiTestCase):
 
         p.driver = om.pyOptSparseDriver()
         p.driver.options['optimizer'] = 'IPOPT'
-        p.driver.opt_settings['print_level'] = 5
+        p.driver.opt_settings['print_level'] = 0
         p.driver.opt_settings['derivative_test'] = 'first-order'
 
         p.driver.declare_coloring()

--- a/dymos/visualization/timeseries_plots.py
+++ b/dymos/visualization/timeseries_plots.py
@@ -58,7 +58,7 @@ def _mpl_timeseries_plots(time_units, var_units, phase_names, phases_node_path,
     backend_save = plt.get_backend()
     plt.switch_backend('Agg')
     # use a colormap with 20 values
-    cm = matplotlib.colormaps.get_cmap('tab20')
+    cm = matplotlib.cm.get_cmap('tab20')
     plotfiles = []
 
     for var_name, var_unit in var_units.items():

--- a/dymos/visualization/timeseries_plots.py
+++ b/dymos/visualization/timeseries_plots.py
@@ -4,6 +4,7 @@ import pathlib
 
 import numpy as np
 
+import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.lines as mlines
 import matplotlib.patches as mpatches
@@ -57,7 +58,7 @@ def _mpl_timeseries_plots(time_units, var_units, phase_names, phases_node_path,
     backend_save = plt.get_backend()
     plt.switch_backend('Agg')
     # use a colormap with 20 values
-    cm = plt.cm.get_cmap('tab20')
+    cm = matplotlib.colormaps.get_cmap('tab20')
     plotfiles = []
 
     for var_name, var_unit in var_units.items():

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ The software has two primary objectives:
     packages=find_packages(),
     python_requires=">=3.8",
     install_requires=[
-        'openmdao>=3.24.0',
+        'openmdao>=3.17.0',
         'numpy',
         'scipy'
     ],

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ The software has two primary objectives:
     packages=find_packages(),
     python_requires=">=3.8",
     install_requires=[
-        'openmdao>=3.17.0',
+        'openmdao>=3.24.0',
         'numpy',
         'scipy'
     ],


### PR DESCRIPTION
### Summary

SolveIVP transcription is now deprecated.
Added SimulationPhase which is returned by `phase.get_simulation_phase`.
- does not support optimization
- currently only supports a single default `timeseries`

Changes to ExplicitShooting
- `num_segments`, `order`, `compressed`, `segment_ends` are no longer deprecated.  This makes the interface to create the transcription the same as the others. If using these options rather than `grid`, it will use a `GaussLobattoGrid` by default.
- fixed a units bug in the related VandermondeControlInterpComp

Changes to grid_data
- grid_data now treats `transcription_order` argument the same whether it is a scalar or a length-1 array.

### Related Issues

- Resolves #889 
- Resolves #895 

### Backwards incompatibilities

None

### New Dependencies

None
