### PR TITLE
raise an exception if the initial time of a phase is unreachable

### DIFF
--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -2552,3 +2552,36 @@ class Phase(om.Group):
             all_flat_idxs.update(flat_idxs)
 
         return all_flat_idxs
+
+    def _is_fixed(self, var_name, var_type, loc):
+        """
+        Determine whether a variable is fixed or not.
+
+        Parameters
+        ----------
+        var_name : str
+            Identifier of the variable as known to the phase.
+        var_type : str
+            The type of variable.
+        loc : str
+            Either 'initial' or 'final' for non-parameters.
+
+        Returns
+        -------
+        bool
+            True if the variable is fixed, otherwise False.
+        """
+        if var_type == 't':
+            return self.is_time_fixed(loc)
+        elif var_type == 'state':
+            return self.is_state_fixed(var_name, loc)
+        elif var_type in {'input_control', 'indep_control'}:
+            return self.is_control_fixed(var_name, loc)
+        elif var_type in {'input_polynomial_control', 'indep_polynomial_control'}:
+            return self.is_polynomial_control_fixed(var_name, loc)
+        elif var_type in {'control_rate', 'control_rate2'}:
+            return self.is_control_rate_fixed(var_name, loc)
+        elif var_type == 'parameter':
+            return not self.parameter_options[var_name]['opt']
+
+        return False  # No way to know so we allow these to go through

--- a/dymos/run_problem.py
+++ b/dymos/run_problem.py
@@ -81,6 +81,9 @@ def run_problem(problem, refine_method='hp', refine_iteration_limit=0, run_drive
     if restart is not None:
         load_case(problem, case)
 
+    for traj in problem.model.system_iter(include_self=True, recurse=True, typ=Trajectory):
+        traj._check_phase_graph()
+
     if run_driver:
         failed = _refine_iter(problem, refine_iteration_limit, refine_method, case_prefix=case_prefix,
                               reset_iter_counts=reset_iter_counts)

--- a/dymos/test/test_pycodestyle.py
+++ b/dymos/test/test_pycodestyle.py
@@ -53,21 +53,23 @@ class TestPyCodeStyle(unittest.TestCase):
                                                ])
         style.options.max_line_length = 130
 
-        report = style.check_files(pyfiles)
+        # the report writes most failures to stdout which is swallowed by testflo by
+        # default, so temporarily replace stdout with a StringIO so we can include the failure
+        # descriptions in the failure message.
+        from io import StringIO
+        save_out = sys.stdout
+        save_err = sys.stderr
+        try:
+            sys.stdout = buff_out = StringIO()
+            sys.stdout = buff_err = StringIO()
+            report = style.check_files(pyfiles)
+        finally:
+            sys.stdout = save_out
+            sys.stderr = save_err
+            fails = buff_out.getvalue()
+            fails += '\n' + buff_err.getvalue()
 
         if report.total_errors > 0:
-            # the report just writes the failures to stdout which is swallowed by testflo by
-            # default, so temporarily replace stdout with a StringIO so we can include the failure
-            # descriptions in the failure message.
-            from io import StringIO
-            save = sys.stdout
-            try:
-                sys.stdout = buff = StringIO()
-                report.get_file_results()
-            finally:
-                sys.stdout = save
-                fails = buff.getvalue()
-
             self.fail(f"Found {report.total_errors} pycodestyle errors:\n{fails}")
 
 

--- a/dymos/test/test_pycodestyle.py
+++ b/dymos/test/test_pycodestyle.py
@@ -56,7 +56,19 @@ class TestPyCodeStyle(unittest.TestCase):
         report = style.check_files(pyfiles)
 
         if report.total_errors > 0:
-            self.fail(f"Found {report.total_errors} pycodestyle errors")
+            # the report just writes the failures to stdout which is swallowed by testflo by
+            # default, so temporarily replace stdout with a StringIO so we can include the failure
+            # descriptions in the failure message.
+            from io import StringIO
+            save = sys.stdout
+            try:
+                sys.stdout = buff = StringIO()
+                report.get_file_results()
+            finally:
+                sys.stdout = save
+                fails = buff.getvalue()
+
+            self.fail(f"Found {report.total_errors} pycodestyle errors:\n{fails}")
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/trajectory/test/test_t_initial_bounds.py
+++ b/dymos/trajectory/test/test_t_initial_bounds.py
@@ -1,0 +1,295 @@
+import unittest
+
+import numpy as np
+import openmdao.api as om
+import dymos as dm
+
+from openmdao.utils.testing_utils import use_tempdirs
+
+
+def make_phases(traj, time_option_kwargs):
+    for pname, kwargs in time_option_kwargs.items():
+        phase = dm.Phase(ode_class=OscillatorODE, transcription=dm.Radau(num_segments=10))
+        traj.add_phase(pname, phase)
+
+        phase.set_time_options(**kwargs)
+
+        # Tell Dymos the states to be propagated using the given ODE.
+        phase.add_state('v', rate_source='v_dot', targets=['v'], units='m/s')
+        phase.add_state('x', rate_source='v', targets=['x'], units='m')
+
+        # The spring constant, damping coefficient, and mass are inputs to the system
+        # that are constant throughout the phase.
+        phase.add_parameter('k', units='N/m', targets=['k'])
+        phase.add_parameter('c', units='N*s/m', targets=['c'])
+        phase.add_parameter('m', units='kg', targets=['m'])
+
+    # Since we're using an optimization driver, an objective is required.  We'll minimize
+    # the final time in this case.
+    phase.add_objective('time', loc='final')
+
+
+def connect_phases(traj, conns):
+    for src, tgts in conns:
+        for tgt in tgts:
+            traj.link_phases((src, tgt), vars=['time'])
+
+
+class OscillatorODE(om.ExplicitComponent):
+    """
+    A Dymos ODE for a damped harmonic oscillator.
+    """
+
+    def initialize(self):
+        self.options.declare('num_nodes', types=int)
+
+    def setup(self):
+        nn = self.options['num_nodes']
+
+        # Inputs
+        self.add_input('x', shape=(nn,), desc='displacement', units='m')
+        self.add_input('v', shape=(nn,), desc='velocity', units='m/s')
+        self.add_input('k', shape=(nn,), desc='spring constant', units='N/m')
+        self.add_input('c', shape=(nn,), desc='damping coefficient', units='N*s/m')
+        self.add_input('m', shape=(nn,), desc='mass', units='kg')
+
+        self.add_output('v_dot', val=np.ones(nn), desc='rate of change of velocity', units='m/s**2')
+
+        arange = np.arange(self.options['num_nodes'], dtype=int)
+        self.declare_partials(of='*', wrt='*', rows=arange, cols=arange)
+
+    def compute(self, inputs, outputs):
+        x = inputs['x']
+        v = inputs['v']
+        k = inputs['k']
+        c = inputs['c']
+        m = inputs['m']
+
+        f_spring = -k * x
+        f_damper = -c * v
+
+        outputs['v_dot'] = (f_spring + f_damper) / m
+
+    def compute_partials(self, inputs, jacobian):
+        x = inputs['x']
+        v = inputs['v']
+        k = inputs['k']
+        c = inputs['c']
+        m = inputs['m']
+
+        jacobian['v_dot', 'x'] = -k / m
+        jacobian['v_dot', 'v'] = -c / m
+        jacobian['v_dot', 'k'] = -x / m
+        jacobian['v_dot', 'c'] = -v / m
+        jacobian['v_dot', 'm'] = -1. / (m * m) * (-k * x - c * v)
+
+
+@use_tempdirs
+class Test_t_initialBounds(unittest.TestCase):
+    def try_model(self, probname, kwargs, conns):
+        prob = om.Problem(name=probname)
+        prob.driver = om.ScipyOptimizeDriver()
+        traj = prob.model.add_subsystem('traj', dm.Trajectory())
+
+        make_phases(traj, kwargs)
+        connect_phases(traj, conns)
+
+        prob.setup(force_alloc_complex=True)
+
+        prob.run_driver()
+
+    def test_phase_link_cycle(self):
+        nphases = 3
+
+        kwargs = {}
+        conns = []
+        for i in range(nphases):
+            pname = f'phase{i}'
+            kwargs[pname] = dct = {}
+            dct['fix_initial'] = True
+            dct['fix_duration'] = False
+            dct['initial_val'] = 5. * i if i < nphases - 1 else 5. * (i - 1)
+
+            if i > 0:
+                conns.append((f'phase{i-1}', [pname]))
+
+        conns.append((pname, ['phase0']))
+
+        with self.assertRaises(Exception) as cm:
+            self.try_model('phase_link_cycle', kwargs, conns)
+
+        msg = ("\nCollected errors for problem 'phase_link_cycle':\n"
+               "   'traj' <class Trajectory>: The following cycles were found in the phase "
+               "linkage graph: [['phase0', 'phase1', 'phase2']].")
+        self.assertEqual(cm.exception.args[0], msg)
+
+    def test_all_fixed(self):
+        nphases = 3
+
+        kwargs = {}
+        conns = []
+        for i in range(nphases):
+            pname = f'phase{i}'
+            kwargs[pname] = dct = {}
+            dct['fix_initial'] = True
+            dct['fix_duration'] = False
+            dct['initial_val'] = 5. * i if i < nphases - 1 else 5. * (i - 1)
+            dct['duration_bounds'] = (5. * i, 5 * (i + 1))
+
+            if i > 0:
+                conns.append((f'phase{i-1}', [pname]))
+
+        with self.assertRaises(Exception) as cm:
+            self.try_model('all_fixed', kwargs, conns)
+
+        msg = ("\nCollected errors for problem 'all_fixed':\n"
+               "   'traj' <class Trajectory>: Fixed t_initial of 5.0 is outside of allowed "
+               "bounds (10.0, 15.0) for phase 'phase2'.")
+        self.assertEquals(cm.exception.args[0], msg)
+
+    def test_odd_fixed(self):
+        nphases = 4
+
+        kwargs = {}
+        conns = []
+        for i in range(nphases):
+            pname = f'phase{i}'
+            kwargs[pname] = dct = {}
+            dct['fix_initial'] = i % 2 != 0
+            dct['fix_duration'] = False
+            dct['initial_val'] = 5. * i if i < nphases - 1 else 5. * (i-1)
+            dct['duration_bounds'] = (5. * i, 5 * (i + 1))
+
+            if i > 0:
+                conns.append((f'phase{i - 1}', [pname]))
+
+        msg = ("\nCollected errors for problem 'odd_fixed':\n"
+               "   'traj' <class Trajectory>: Fixed t_initial of 10.0 is outside of allowed "
+               "bounds (20.0, 30.0) for phase 'phase3'.")
+
+        with self.assertRaises(Exception) as cm:
+            self.try_model('odd_fixed', kwargs, conns)
+
+        self.assertEqual(cm.exception.args[0], msg)
+
+    def test_even_fixed(self):
+        nphases = 5
+
+        kwargs = {}
+        conns = []
+        for i in range(nphases):
+            pname = f'phase{i}'
+            kwargs[pname] = dct = {}
+            dct['fix_initial'] = i % 2 == 0
+            dct['fix_duration'] = False
+            dct['initial_val'] = 5. * i
+            dct['duration_bounds'] = (5. * i, 5 * (i + 1))
+
+            if i > 0:
+                conns.append((f'phase{i - 1}', [pname]))
+
+        with self.assertRaises(Exception) as cm:
+            self.try_model('even_fixed', kwargs, conns)
+
+        msg = ("\nCollected errors for problem 'even_fixed':\n   'traj' <class Trajectory>: "
+               "Fixed t_initial of 20.0 is outside of allowed bounds (35.0, 45.0) for phase "
+               "'phase4'.")
+
+        self.assertEqual(cm.exception.args[0], msg)
+
+    def test_branching_all_fixed(self):
+        nphases = 3  # number of phases in trunk and each branch
+        nbranches = 2
+
+        kwargs = {}
+        conns = []
+        branches = [f'br{i}' for i in range(nbranches)]
+
+        # trunk phases
+        for i in range(nphases):
+            pname = f'phase{i}'
+            kwargs[pname] = dct = {}
+            dct['fix_initial'] = True
+            dct['fix_duration'] = False
+            dct['initial_val'] = 5.*i
+            dct['duration_bounds'] = (5, 10)
+
+            if i > 0:
+                conns.append((f'phase{i-1}', [pname]))
+
+        last_trunk_phase = pname
+        last_t_min = dct['initial_val'] + dct['duration_bounds'][0]
+
+        for br in branches:
+            for i in range(nphases):
+                pname = f'{br}_phase{i}'
+                kwargs[pname] = dct = {}
+                dct['fix_initial'] = True
+                dct['fix_duration'] = False
+                dct['initial_val'] = last_t_min + 5.*(i-1)
+                dct['duration_bounds'] = (5, 10)
+
+                if i > 0:
+                    conns.append((f'{br}_phase{i-1}', [pname]))
+
+            # connect branch to trunk
+            conns.append((last_trunk_phase, [f'{br}_phase0']))
+
+        with self.assertRaises(Exception) as cm:
+            self.try_model('branching_all_fixed', kwargs, conns)
+
+        msg = ("\nCollected errors for problem 'branching_all_fixed':\n"
+               "   'traj' <class Trajectory>: Fixed t_initial of 10.0 is outside of allowed bounds "
+               "(15.0, 20.0) for phase 'br1_phase0'.\n"
+               "Fixed t_initial of 10.0 is outside of allowed bounds (15.0, 20.0) for phase "
+               "'br0_phase0'.")
+        self.assertEquals(cm.exception.args[0], msg)
+
+    def test_branching_odd_fixed(self):
+        nphases = 3  # number of phases in trunk and each branch
+        nbranches = 2
+        nbrphases = 4
+
+        kwargs = {}
+        conns = []
+        branches = [f'br{i}' for i in range(nbranches)]
+
+        # trunk phases
+        for i in range(nphases):
+            pname = f'phase{i}'
+            kwargs[pname] = dct = {}
+            dct['fix_initial'] = i % 2 != 0
+            dct['fix_duration'] = False
+            dct['initial_val'] = 5.*i
+            dct['duration_bounds'] = (5, 10)
+
+            if i > 0:
+                conns.append((f'phase{i-1}', [pname]))
+
+        last_trunk_phase = pname
+        last_t_min = dct['initial_val'] + dct['duration_bounds'][0]
+
+        for br in branches:
+            for i in range(nbrphases):
+                pname = f'{br}_phase{i}'
+                kwargs[pname] = dct = {}
+                dct['fix_initial'] = i % 2 != 0
+                dct['fix_duration'] = False
+                dct['initial_val'] = last_t_min + 15.*i
+                dct['duration_bounds'] = (5, 10)
+
+                if i > 0:
+                    conns.append((f'{br}_phase{i-1}', [pname]))
+
+            # connect branch to trunk
+            conns.append((last_trunk_phase, [f'{br}_phase0']))
+
+        with self.assertRaises(Exception) as cm:
+            self.try_model('branching_odd_fixed', kwargs, conns)
+
+        msg = ("\nCollected errors for problem 'branching_odd_fixed':\n"
+               "   'traj' <class Trajectory>: Fixed t_initial of 60.0 is outside of allowed bounds "
+               "(40.0, 50.0) for phase 'br1_phase3'.\n"
+               "Fixed t_initial of 60.0 is outside of allowed bounds (40.0, 50.0) for phase "
+               "'br0_phase3'.")
+        self.assertEquals(cm.exception.args[0], msg)

--- a/dymos/trajectory/test/test_t_initial_bounds.py
+++ b/dymos/trajectory/test/test_t_initial_bounds.py
@@ -96,7 +96,7 @@ class Test_t_initialBounds(unittest.TestCase):
 
         prob.setup(force_alloc_complex=True)
 
-        prob.run_driver()
+        dm.run_problem(prob)
 
     def test_phase_link_cycle(self):
         nphases = 3
@@ -118,8 +118,7 @@ class Test_t_initialBounds(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             self.try_model('phase_link_cycle', kwargs, conns)
 
-        msg = ("\nCollected errors for problem 'phase_link_cycle':\n"
-               "   'traj' <class Trajectory>: The following cycles were found in the phase "
+        msg = ("'traj' <class Trajectory>: The following cycles were found in the phase "
                "linkage graph: [['phase0', 'phase1', 'phase2']].")
         self.assertEqual(cm.exception.args[0], msg)
 
@@ -142,8 +141,7 @@ class Test_t_initialBounds(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             self.try_model('all_fixed', kwargs, conns)
 
-        msg = ("\nCollected errors for problem 'all_fixed':\n"
-               "   'traj' <class Trajectory>: Fixed t_initial of 5.0 is outside of allowed "
+        msg = ("'traj' <class Trajectory>: Fixed t_initial of 5.0 is outside of allowed "
                "bounds (10.0, 15.0) for phase 'phase2'.")
         self.assertEquals(cm.exception.args[0], msg)
 
@@ -163,8 +161,7 @@ class Test_t_initialBounds(unittest.TestCase):
             if i > 0:
                 conns.append((f'phase{i - 1}', [pname]))
 
-        msg = ("\nCollected errors for problem 'odd_fixed':\n"
-               "   'traj' <class Trajectory>: Fixed t_initial of 10.0 is outside of allowed "
+        msg = ("'traj' <class Trajectory>: Fixed t_initial of 10.0 is outside of allowed "
                "bounds (20.0, 30.0) for phase 'phase3'.")
 
         with self.assertRaises(Exception) as cm:
@@ -191,7 +188,7 @@ class Test_t_initialBounds(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             self.try_model('even_fixed', kwargs, conns)
 
-        msg = ("\nCollected errors for problem 'even_fixed':\n   'traj' <class Trajectory>: "
+        msg = ("'traj' <class Trajectory>: "
                "Fixed t_initial of 20.0 is outside of allowed bounds (35.0, 45.0) for phase "
                "'phase4'.")
 
@@ -238,8 +235,7 @@ class Test_t_initialBounds(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             self.try_model('branching_all_fixed', kwargs, conns)
 
-        msg = ("\nCollected errors for problem 'branching_all_fixed':\n"
-               "   'traj' <class Trajectory>: Fixed t_initial of 10.0 is outside of allowed bounds "
+        msg = ("'traj' <class Trajectory>: Fixed t_initial of 10.0 is outside of allowed bounds "
                "(15.0, 20.0) for phase 'br1_phase0'.\n"
                "Fixed t_initial of 10.0 is outside of allowed bounds (15.0, 20.0) for phase "
                "'br0_phase0'.")
@@ -287,8 +283,7 @@ class Test_t_initialBounds(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             self.try_model('branching_odd_fixed', kwargs, conns)
 
-        msg = ("\nCollected errors for problem 'branching_odd_fixed':\n"
-               "   'traj' <class Trajectory>: Fixed t_initial of 60.0 is outside of allowed bounds "
+        msg = ("'traj' <class Trajectory>: Fixed t_initial of 60.0 is outside of allowed bounds "
                "(40.0, 50.0) for phase 'br1_phase3'.\n"
                "Fixed t_initial of 60.0 is outside of allowed bounds (40.0, 50.0) for phase "
                "'br0_phase3'.")

--- a/dymos/trajectory/test/test_t_initial_bounds.py
+++ b/dymos/trajectory/test/test_t_initial_bounds.py
@@ -144,7 +144,8 @@ class Test_t_initialBounds(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             self.try_model('pair_fixed_t_initial_below', kwargs, conns)
 
-        msg = ("'traj' <class Trajectory>: Fixed t_initial of 5.0 is outside of allowed bounds (10.0, 15.0) for phase 'phase1'.")
+        msg = ("'traj' <class Trajectory>: Fixed t_initial of 5.0 is outside of allowed bounds "
+               "(10.0, 15.0) for phase 'phase1'.")
         self.assertEquals(cm.exception.args[0], msg)
 
     def test_pair_fixed_t_initial_above(self):
@@ -169,7 +170,8 @@ class Test_t_initialBounds(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             self.try_model('pair_fixed_t_initial_above', kwargs, conns)
 
-        msg = ("'traj' <class Trajectory>: Fixed t_initial of 99.0 is outside of allowed bounds (10.0, 15.0) for phase 'phase1'.")
+        msg = ("'traj' <class Trajectory>: Fixed t_initial of 99.0 is outside of allowed bounds "
+               "(10.0, 15.0) for phase 'phase1'.")
         self.assertEquals(cm.exception.args[0], msg)
 
     def test_pair_t_initial_bounds_below(self):
@@ -190,7 +192,8 @@ class Test_t_initialBounds(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             self.try_model('pair_t_initial_bounds_below', kwargs, conns)
 
-        msg = ("'traj' <class Trajectory>: t_initial bounds of (5.0, 7.0) do not overlap with allowed bounds (8.0, 17.0) for phase 'phase1'.")
+        msg = ("'traj' <class Trajectory>: t_initial bounds of (5.0, 7.0) do not overlap with "
+               "allowed bounds (8.0, 17.0) for phase 'phase1'.")
         self.assertEquals(cm.exception.args[0], msg)
 
     def test_pair_t_initial_bounds_above(self):
@@ -211,7 +214,8 @@ class Test_t_initialBounds(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             self.try_model('pair_t_initial_bounds_above', kwargs, conns)
 
-        msg = ("'traj' <class Trajectory>: t_initial bounds of (20.0, 22.0) do not overlap with allowed bounds (8.0, 17.0) for phase 'phase1'.")
+        msg = ("'traj' <class Trajectory>: t_initial bounds of (20.0, 22.0) do not overlap with "
+               "allowed bounds (8.0, 17.0) for phase 'phase1'.")
         self.assertEquals(cm.exception.args[0], msg)
 
     def test_pair_no_duration_bounds(self):
@@ -272,7 +276,8 @@ class Test_t_initialBounds(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             self.try_model('all_t_initial_bounds', kwargs, conns)
 
-        msg = ("'traj' <class Trajectory>: t_initial bounds of (99.0, 104.0) do not overlap with allowed bounds (10.0, 20.0) for phase 'phase2'.")
+        msg = ("'traj' <class Trajectory>: t_initial bounds of (99.0, 104.0) do not overlap with "
+               "allowed bounds (10.0, 20.0) for phase 'phase2'.")
         self.assertEquals(cm.exception.args[0], msg)
 
     def test_odd_fixed_t_initial(self):
@@ -316,7 +321,8 @@ class Test_t_initialBounds(unittest.TestCase):
             if i > 0:
                 conns.append((f'phase{i - 1}', [pname]))
 
-        msg = ("'traj' <class Trajectory>: t_initial bounds of (99.0, 104.0) do not overlap with allowed bounds (20.0, 35.0) for phase 'phase3'.")
+        msg = ("'traj' <class Trajectory>: t_initial bounds of (99.0, 104.0) do not overlap with "
+               "allowed bounds (20.0, 35.0) for phase 'phase3'.")
 
         with self.assertRaises(Exception) as cm:
             self.try_model('odd_t_initial_bounds', kwargs, conns)
@@ -365,13 +371,13 @@ class Test_t_initialBounds(unittest.TestCase):
             if i > 0:
                 conns.append((f'phase{i - 1}', [pname]))
 
-        msg = ("'traj' <class Trajectory>: t_initial bounds of (99.0, 104.0) do not overlap with allowed bounds (5.0, 20.0) for phase 'phase2'.")
+        msg = ("'traj' <class Trajectory>: t_initial bounds of (99.0, 104.0) do not overlap with "
+               "allowed bounds (5.0, 20.0) for phase 'phase2'.")
 
         with self.assertRaises(Exception) as cm:
             self.try_model('even_t_initial_bounds', kwargs, conns)
 
         self.assertEqual(cm.exception.args[0], msg)
-
 
     def test_branching_all_fixed_t_initial(self):
         nphases = 3  # number of phases in trunk and each branch
@@ -463,8 +469,10 @@ class Test_t_initialBounds(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             self.try_model('branching_all_t_initial_bounds', kwargs, conns)
 
-        msg = ("'traj' <class Trajectory>: t_initial bounds of (0.0, 5) do not overlap with allowed bounds (20.0, 30.0) for phase 'br0_phase1'.\n"
-               "t_initial bounds of (0.0, 5) do not overlap with allowed bounds (20.0, 30.0) for phase 'br1_phase1'.")
+        msg = ("'traj' <class Trajectory>: t_initial bounds of (0.0, 5) do not overlap with "
+               "allowed bounds (20.0, 30.0) for phase 'br0_phase1'.\n"
+               "t_initial bounds of (0.0, 5) do not overlap with allowed bounds (20.0, 30.0) "
+               "for phase 'br1_phase1'.")
         self.assertEquals(cm.exception.args[0], msg)
 
     def test_branching_odd_fixed_t_initial(self):

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -838,7 +838,7 @@ class Trajectory(om.Group):
     def _check_phase_graph(self):
 
         # determine if we have any fixed t_initial that are outside of allowed bounds
-        def get_final_bounds(node_name, node_data, old_tmin=-INF_BOUND, old_tmax=INF_BOUND):
+        def get_final_tbounds(node_name, node_data, old_tmin=-INF_BOUND, old_tmax=INF_BOUND):
             t_initial = node_data['t_initial']
             fixed_t_initial = node_data['fixed']
             duration_min, duration_max = node_data['duration_bounds']
@@ -912,7 +912,8 @@ class Trajectory(om.Group):
             stack = [(start_name, -INF_BOUND, INF_BOUND)]
             while stack:
                 src, oldlb, oldub = stack.pop()
-                lb, ub, errs = get_final_bounds(src, node_data[src], old_tmin=oldlb, old_tmax=oldub)
+                lb, ub, errs = get_final_tbounds(src, node_data[src],
+                                                 old_tmin=oldlb, old_tmax=oldub)
                 # print(f"{src}: olb: {oldlb}, oub: {oldub} lb: {lb}, ub: {ub}, "
                 #       f"t_initial: {node_data[src]['t_initial']}, errs: {errs}")
                 if errs:

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -617,26 +617,25 @@ class Trajectory(om.Group):
             a phase boundary.
 
         """
-        linkages_copy = deepcopy(self._linkages)
-        for phase_pair, var_dict in linkages_copy.items():
+        for phase_pair, var_dict in self._linkages.items():
             phase_name_a, phase_name_b = phase_pair
 
             phase_b = self._get_subsystem(f'phases.{phase_name_b}')
 
-            for var_pair in var_dict.keys():
-                if tuple(var_pair) == ('*', '*'):
-                    options = var_dict[var_pair]
-                    self.add_linkage_constraint(phase_name_a, phase_name_b, var_a='time',
-                                                var_b='time', loc_a=options['loc_a'],
-                                                loc_b=options['loc_b'], mult_a=options['mult_a'],
+            var_pair = ('*', '*')
+            if var_pair in var_dict:
+                options = var_dict[var_pair]
+                self.add_linkage_constraint(phase_name_a, phase_name_b, var_a='time',
+                                            var_b='time', loc_a=options['loc_a'],
+                                            loc_b=options['loc_b'], mult_a=options['mult_a'],
+                                            mult_b=options['mult_b'])
+                for state_name in phase_b.state_options:
+                    self.add_linkage_constraint(phase_name_a, phase_name_b, var_a=state_name,
+                                                var_b=state_name, loc_a=options['loc_a'],
+                                                loc_b=options['loc_b'],
+                                                mult_a=options['mult_a'],
                                                 mult_b=options['mult_b'])
-                    for state_name in phase_b.state_options:
-                        self.add_linkage_constraint(phase_name_a, phase_name_b, var_a=state_name,
-                                                    var_b=state_name, loc_a=options['loc_a'],
-                                                    loc_b=options['loc_b'],
-                                                    mult_a=options['mult_a'],
-                                                    mult_b=options['mult_b'])
-                    self._linkages[phase_pair].pop(var_pair)
+                self._linkages[phase_pair].pop(var_pair)
 
     def _is_valid_linkage(self, phase_name_a, phase_name_b, loc_a, loc_b, var_a, var_b, fixed_a, fixed_b):
         """
@@ -1115,7 +1114,8 @@ class Trajectory(om.Group):
                 self.add_linkage_constraint(phase_a=phase_name_a, phase_b=phase_name_b,
                                             var_a=var, var_b=var, loc_a=loc_a, loc_b=loc_b,
                                             connected=connected, units=units,
-                                            scaler=scaler, adder=adder, ref0=ref0, ref=ref, linear=linear)
+                                            scaler=scaler, adder=adder, ref0=ref0, ref=ref,
+                                            linear=linear)
 
     def _constraint_report(self, outstream=sys.stdout):
         if self.options['sim_mode']:

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -870,9 +870,10 @@ class Trajectory(om.Group):
                 initial_max = INF_BOUND if initial_max is None else initial_max
 
                 # check for overlap of incoming bounds on t and initial_bounds
-                if not (old_tmin <= initial_min <= old_tmax or old_tmin <= initial_max <= old_tmax
-                        or initial_min <= old_tmin <= initial_max
-                        or initial_min <= old_tmax <= initial_max):
+                if not (old_tmin <= initial_min <= old_tmax or
+                        old_tmin <= initial_max <= old_tmax or
+                        initial_min <= old_tmin <= initial_max or
+                        initial_min <= old_tmax <= initial_max):
                     errs.append(f"t_initial bounds of ({initial_min}, {initial_max}) do not overlap"
                                 f" with allowed bounds {(old_tmin, old_tmax)} for phase "
                                 f"'{phase_name}'.")

--- a/dymos/visualization/linkage/report.py
+++ b/dymos/visualization/linkage/report.py
@@ -159,7 +159,7 @@ def _trajectory_to_dict(traj):
             'type': 'variable',
             'class': 'parameter',
             'fixed': False,
-            'paramOpt': traj.parameter_options[param_name]['opt'],
+            'paramOpt': param['opt'],
             'connected': True
         }
 
@@ -375,14 +375,12 @@ def _run_linkage_report(prob):
     """ Function invoked by the reports system """
 
     # Find all Trajectory objects in the Problem. Usually, there's only one
-    for sysname, sysinfo in prob.model._subsystems_allprocs.items():
-        if isinstance(sysinfo.system, dm.Trajectory):
-            traj = sysinfo.system
-            # Only create a report for a trajectory with linkages
-            if traj._linkages:
-                report_filename = f'{sysname}_{_default_linkage_report_filename}'
-                report_path = str(Path(prob.get_reports_dir()) / report_filename)
-                create_linkage_report(traj, report_path)
+    for traj in prob.model.system_iter(include_self=True, recurse=True, typ=dm.Trajectory):
+        # Only create a report for a trajectory with linkages
+        if traj._linkages:
+            report_filename = f'{traj.pathname}_{_default_linkage_report_filename}'
+            report_path = str(Path(prob.get_reports_dir()) / report_filename)
+            create_linkage_report(traj, report_path)
 
 
 def _linkage_report_register():


### PR DESCRIPTION
### Summary

- If a fixed t_initial value is unreachable based on upstream duration_bounds, we now raise an exception.
- Also added a check for cycles in the phase linkage graph.
- Updated the pycodestyle test to include the actual failures in the failure message instead of just writing them to stdout, which normally isn't displayed when running testflo.

### Related Issues

- Resolves #883

### Backwards incompatibilities

None

### New Dependencies

None
