### PR TITLE
Changed default behavior of phase.interp to respect bounds of states and controls

### DIFF
--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -280,6 +280,7 @@ jobs:
         if: env.RUN_BUILD
         env:
           DYMOS_CHECK_PARTIALS: True
+          OPENMDAO_INVALID_DESVAR_BEHAVIOR: "raise"
         shell: bash -l {0}
         run: |
           echo "============================================================="

--- a/dymos/__init__.py
+++ b/dymos/__init__.py
@@ -6,4 +6,4 @@ from .transcriptions.grid_data import GaussLobattoGrid, RadauGrid, UniformGrid
 from .trajectory.trajectory import Trajectory
 from .run_problem import run_problem
 from .load_case import load_case
-from .options import options
+from ._options import options

--- a/dymos/_options.py
+++ b/dymos/_options.py
@@ -16,3 +16,9 @@ options.declare('plots', default='matplotlib', values=['matplotlib', 'bokeh'],
 
 options.declare('notebook_mode', default=False, types=bool,
                 desc='If True, provide notebook-enhanced plots and outputs.')
+
+options.declare('interp_respect_bounds', default=True, types=bool,
+                desc='If True, the default behavior of phase.interp will be to clip the resulting interpolated '
+                     'values to be within the range of the lower and upper bounds of the interpolated variable. '
+                     'This value may be overridden by specifying a non-default value for argument respect_bounds '
+                     'in phase.interpolate.')

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -18,14 +18,13 @@ from .options import ControlOptionsDictionary, ParameterOptionsDictionary, \
     TimeseriesOutputOptionsDictionary
 
 from ..transcriptions.transcription_base import TranscriptionBase
-from ..transcriptions.grid_data import GaussLobattoGrid, RadauGrid, UniformGrid
-from ..transcriptions import ExplicitShooting, GaussLobatto, Radau
 from ..utils.indexing import get_constraint_flat_idxs
 from ..utils.introspection import configure_time_introspection, _configure_constraint_introspection, \
     configure_controls_introspection, configure_parameters_introspection, \
     configure_timeseries_output_introspection, classify_var, configure_timeseries_expr_introspection
 from ..utils.misc import _unspecified
 from ..utils.lgl import lgl
+from .._options import options as dymos_options
 
 
 om_dev_version = openmdao.__version__.endswith('dev')
@@ -2024,7 +2023,7 @@ class Phase(om.Group):
         return res
 
     def interp(self, name=None, ys=None, xs=None, nodes=None, kind='linear', axis=0,
-               respect_bounds=True):
+               respect_bounds=_unspecified):
         """
         Interpolate values onto the given subset of nodes in the phase.
 
@@ -2054,7 +2053,7 @@ class Phase(om.Group):
         axis : int
             Specifies the axis along which interpolation should be performed.  Default is
             the first axis (0).
-        respect_bounds : bool
+        respect_bounds : bool or _unspecified
             If True, and the variable being interpolated has bounds, clip the
             interpolated values to lie within those bounds.
 
@@ -2121,7 +2120,9 @@ class Phase(om.Group):
 
         res = np.atleast_2d(interpfunc(node_locations))
 
-        if respect_bounds and (lower is not None or upper is not None):
+        _respect_bounds = dymos_options['interp_respect_bounds'] if respect_bounds is _unspecified else respect_bounds
+
+        if _respect_bounds and (lower is not None or upper is not None):
             res = np.clip(res, lower, upper)
 
         if res.shape[0] == 1:

--- a/dymos/phase/test/test_phase.py
+++ b/dymos/phase/test/test_phase.py
@@ -252,7 +252,7 @@ class TestPhaseBase(unittest.TestCase):
         p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0
-        p['phase0.t_duration'] = 2.0
+        p['phase0.t_duration'] = 4.0
 
         p['phase0.states:x'] = phase.interp('x', [0, 10])
         p['phase0.states:y'] = phase.interp('y', [10, 5])
@@ -298,7 +298,7 @@ class TestPhaseBase(unittest.TestCase):
         p.setup(check=True)
 
         p['phase0.t_initial'] = 0.0
-        p['phase0.t_duration'] = 2.0
+        p['phase0.t_duration'] = 4.0
 
         p['phase0.states:x'] = phase.interp('x', [0, 10])
         p['phase0.states:y'] = phase.interp('y', [10, 5])

--- a/dymos/trajectory/phase_linkage_comp.py
+++ b/dymos/trajectory/phase_linkage_comp.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import openmdao.api as om
 
-from ..options import options as dymos_options
+from .._options import options as dymos_options
 from ..utils.misc import _unspecified
 
 

--- a/dymos/transcriptions/common/continuity_comp.py
+++ b/dymos/transcriptions/common/continuity_comp.py
@@ -3,7 +3,7 @@ import openmdao.api as om
 
 from ..grid_data import GridData
 from ...utils.misc import get_rate_units
-from ...options import options as dymos_options
+from ..._options import options as dymos_options
 
 
 class ContinuityCompBase(om.ExplicitComponent):

--- a/dymos/transcriptions/common/control_group.py
+++ b/dymos/transcriptions/common/control_group.py
@@ -9,7 +9,7 @@ from ...utils.misc import get_rate_units, CoerceDesvar, reshape_val
 from ...utils.lagrange import lagrange_matrices
 from ...utils.indexing import get_desvar_indices
 from ...utils.constants import INF_BOUND
-from ...options import options as dymos_options
+from ..._options import options as dymos_options
 
 
 class ControlInterpComp(om.ExplicitComponent):

--- a/dymos/transcriptions/common/parameter_comp.py
+++ b/dymos/transcriptions/common/parameter_comp.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from openmdao.core.explicitcomponent import ExplicitComponent
 from ...utils.misc import _unspecified
-from ...options import options as dymos_options
+from ..._options import options as dymos_options
 
 
 class ParameterComp(ExplicitComponent):

--- a/dymos/transcriptions/common/polynomial_control_group.py
+++ b/dymos/transcriptions/common/polynomial_control_group.py
@@ -8,7 +8,7 @@ from ...utils.lagrange import lagrange_matrices
 from ...utils.misc import get_rate_units, reshape_val
 from ...utils.constants import INF_BOUND
 
-from ...options import options as dymos_options
+from ..._options import options as dymos_options
 
 
 class LGLPolynomialControlComp(om.ExplicitComponent):

--- a/dymos/transcriptions/common/time_comp.py
+++ b/dymos/transcriptions/common/time_comp.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import openmdao.api as om
 
-from ...options import options as dymos_options
+from ..._options import options as dymos_options
 
 
 class TimeComp(om.ExplicitComponent):

--- a/dymos/transcriptions/common/timeseries_output_comp.py
+++ b/dymos/transcriptions/common/timeseries_output_comp.py
@@ -1,7 +1,7 @@
 import openmdao.api as om
 
 from ...transcriptions.grid_data import GridData
-from ...options import options as dymos_options
+from ..._options import options as dymos_options
 
 
 class TimeseriesOutputCompBase(om.ExplicitComponent):

--- a/dymos/transcriptions/explicit_shooting/explicit_shooting_timeseries_comp.py
+++ b/dymos/transcriptions/explicit_shooting/explicit_shooting_timeseries_comp.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from openmdao.utils.units import unit_conversion
-from ...options import options as dymos_options
+from ..._options import options as dymos_options
 
 from ..common.timeseries_output_comp import TimeseriesOutputCompBase
 

--- a/dymos/transcriptions/explicit_shooting/ode_integration_comp.py
+++ b/dymos/transcriptions/explicit_shooting/ode_integration_comp.py
@@ -2,7 +2,7 @@ import numpy as np
 import openmdao.api as om
 from scipy.integrate import solve_ivp
 
-from ...options import options as dymos_options
+from ..._options import options as dymos_options
 
 from .ode_evaluation_group import ODEEvaluationGroup
 

--- a/dymos/transcriptions/explicit_shooting/state_rate_collector_comp.py
+++ b/dymos/transcriptions/explicit_shooting/state_rate_collector_comp.py
@@ -3,7 +3,7 @@ import numpy as np
 import openmdao.api as om
 
 from dymos.utils.misc import get_rate_units
-from dymos.options import options as dymos_options
+from ..._options import options as dymos_options
 
 
 class StateRateCollectorComp(om.ExplicitComponent):

--- a/dymos/transcriptions/explicit_shooting/tau_comp.py
+++ b/dymos/transcriptions/explicit_shooting/tau_comp.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import openmdao.api as om
 
-from ...options import options as dymos_options
+from ..._options import options as dymos_options
 
 
 class TauComp(om.ExplicitComponent):

--- a/dymos/transcriptions/explicit_shooting/test/test_explicit_shooting.py
+++ b/dymos/transcriptions/explicit_shooting/test/test_explicit_shooting.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import openmdao.api as om
 import dymos as dm
-import dymos.options as dymos_options
+from dymos import options as dymos_options
 
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs

--- a/dymos/transcriptions/explicit_shooting/test/test_ode_integration_comp.py
+++ b/dymos/transcriptions/explicit_shooting/test/test_ode_integration_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 import openmdao.api as om
 import dymos as dm
-import dymos.options as dymos_options
+from dymos import options as dymos_options
 
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE

--- a/dymos/transcriptions/pseudospectral/components/collocation_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/collocation_comp.py
@@ -5,7 +5,7 @@ import openmdao.api as om
 
 from ...grid_data import GridData
 from ....utils.misc import get_rate_units
-from ....options import options as dymos_options
+from ...._options import options as dymos_options
 
 
 class CollocationComp(om.ExplicitComponent):

--- a/dymos/transcriptions/pseudospectral/components/control_endpoint_defect_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/control_endpoint_defect_comp.py
@@ -1,7 +1,7 @@
 import numpy as np
 import openmdao.api as om
 from ...grid_data import GridData
-from ....options import options as dymos_options
+from ...._options import options as dymos_options
 
 
 class ControlEndpointDefectComp(om.ExplicitComponent):

--- a/dymos/transcriptions/pseudospectral/components/gauss_lobatto_interleave_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/gauss_lobatto_interleave_comp.py
@@ -3,7 +3,7 @@ import openmdao.api as om
 from openmdao.utils.units import unit_conversion
 
 from ...grid_data import GridData
-from ....options import options as dymos_options
+from ...._options import options as dymos_options
 
 
 class GaussLobattoInterleaveComp(om.ExplicitComponent):

--- a/dymos/transcriptions/pseudospectral/components/state_independents.py
+++ b/dymos/transcriptions/pseudospectral/components/state_independents.py
@@ -5,7 +5,7 @@ import numpy as np
 import openmdao.api as om
 
 from ....transcriptions.grid_data import GridData
-from ....options import options as dymos_options
+from ...._options import options as dymos_options
 
 
 class StateIndependentsComp(om.ImplicitComponent):

--- a/dymos/transcriptions/pseudospectral/components/state_interp_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/state_interp_comp.py
@@ -3,7 +3,7 @@ import scipy.sparse as sp
 import openmdao.api as om
 from ...grid_data import GridData
 from ....utils.misc import get_rate_units
-from ....options import options as dymos_options
+from ...._options import options as dymos_options
 
 
 class StateInterpComp(om.ExplicitComponent):

--- a/dymos/transcriptions/solve_ivp/components/state_rate_collector_comp.py
+++ b/dymos/transcriptions/solve_ivp/components/state_rate_collector_comp.py
@@ -1,6 +1,6 @@
 import numpy as np
 from ....utils.misc import get_rate_units
-from ....options import options as dymos_options
+from ...._options import options as dymos_options
 import openmdao.api as om
 
 

--- a/dymos/visualization/test/test_timeseries_plots.py
+++ b/dymos/visualization/test/test_timeseries_plots.py
@@ -75,8 +75,6 @@ class TestTimeSeriesPlotsBasics(unittest.TestCase):
         p['traj0.phase0.controls:theta'] = phase.interp('theta', [5, 100])
         p['traj0.phase0.parameters:g'] = 9.80665
 
-        p.setup()
-
         self.p = p
 
     def test_brachistochrone_timeseries_plots(self):

--- a/dymos/visualization/timeseries_plots.py
+++ b/dymos/visualization/timeseries_plots.py
@@ -10,7 +10,7 @@ import matplotlib.lines as mlines
 import matplotlib.patches as mpatches
 
 import openmdao.api as om
-from dymos.options import options as dymos_options
+from dymos._options import options as dymos_options
 
 
 def _get_phases_node_in_problem_metadata(node, path=""):


### PR DESCRIPTION
### Summary

An upcoming change to OpenMDAO will have it raise an exception if the values of a design variable exceed their bounds.

In dymos, this situation can occur when using the `Phase.interp` method to interpolate a previous solution.

- If argument `respect_bounds` to `Phase.interp` is True and
- If the variable being interpolated is a state or a control and
- if that state or control has lower or upper bounds then
`numpy.clip` will be used to force the interpolated solution to be within acceptable bounds.

This behavior will be controlled globally by `dymos.options['interp_respect_bounds']` which can be set to a "truthy" value to enable this behavior (the default).

### Related Issues

- Resolves #921 

### Backwards incompatibilities

This behavior will result in different initial values coming from `phase.interp` 

### New Dependencies

None
