### PR TITLE
Trajectory.simulate method specification bug

### DIFF
--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -2151,8 +2151,9 @@ class Phase(om.Group):
             times.  This instance has not yet been setup.
         """
         from .simulation_phase import SimulationPhase
-        sim_phase = SimulationPhase(from_phase=self, times_per_seg=times_per_seg, atol=atol, rtol=rtol,
-                                    first_step=first_step, max_step=max_step, reports=reports)
+        sim_phase = SimulationPhase(from_phase=self, times_per_seg=times_per_seg, method=method,
+                                    atol=atol, rtol=rtol, first_step=first_step, max_step=max_step,
+                                    reports=reports)
 
         return sim_phase
 


### PR DESCRIPTION
### Summary

when traj.simulate is called with the method specified as follows, the method parameter was unused and therefor DOP853 was always used regardless of what was passed in as the method parameters. This is a small fix to make sure the selected method is actually used.

```python
traj.simulate(times_per_seg=50, method='RK45')
```

### Related Issues

- Resolves #932 

### Backwards incompatibilities

None

### New Dependencies

None
