### PR TITLE
Fix for openmdao warning messages.

### DIFF
--- a/dymos/transcriptions/explicit_shooting/ode_evaluation_group.py
+++ b/dymos/transcriptions/explicit_shooting/ode_evaluation_group.py
@@ -216,6 +216,7 @@ class ODEEvaluationGroup(om.Group):
 
             if options['static_target']:
                 src_idxs = None
+                shape = None
             else:
                 src_rows = np.zeros(vec_size, dtype=int)
                 src_idxs = om.slicer[src_rows, ...]
@@ -223,7 +224,7 @@ class ODEEvaluationGroup(om.Group):
             # Promote targets from the ODE
             for tgt in targets:
                 self.promotes('ode', inputs=[(tgt, var_name)], src_indices=src_idxs,
-                              src_shape=options['shape'])
+                              src_shape=shape)
             if targets:
                 self.set_input_defaults(name=var_name,
                                         val=np.ones(shape),


### PR DESCRIPTION
### Summary

OpenMDAO's `promotes` method now warns if you specify a src_shape when src_indices is None.  This occurs when we have a static target in dymos and run with simultate=True. Solution is to also set src_shape to None.

### Related Issues

- Resolves #949

### Backwards incompatibilities

None

### New Dependencies

None
