### PR TITLE
Slight changes to scaling in the water rocket example.

### DIFF
--- a/dymos/examples/water_rocket/phases.py
+++ b/dymos/examples/water_rocket/phases.py
@@ -53,14 +53,14 @@ def new_ballistic_ascent_phase(transcription):
         duration_ref=1, units='s')
 
     ballistic_ascent.add_state('r', units='m', rate_source='eom.r_dot', fix_initial=False,
-                               fix_final=False, ref=100.0, defect_ref=100.0)
+                               fix_final=False, ref=1.0, defect_ref=1.0)
     ballistic_ascent.add_state('h', units='m', rate_source='eom.h_dot', targets=['atmos.h'],
-                               fix_initial=False, fix_final=False, ref=100.0, defect_ref=100.0)
+                               fix_initial=False, fix_final=False, ref=1.0)
     ballistic_ascent.add_state('gam', units='deg', rate_source='eom.gam_dot', targets=['eom.gam'],
-                               fix_initial=False, fix_final=True, upper=89, ref=90, defect_ref=90)
+                               fix_initial=False, fix_final=True, upper=89, ref=90)
     ballistic_ascent.add_state('v', units='m/s', rate_source='eom.v_dot',
                                targets=['dynamic_pressure.v', 'eom.v'], fix_initial=False,
-                               fix_final=False, ref=100, defect_ref=100)
+                               fix_final=False, ref=1.)
 
     ballistic_ascent.add_parameter('S', targets=['aero.S'], units='m**2')
     ballistic_ascent.add_parameter('m_empty', targets=['eom.m'], units='kg')
@@ -85,7 +85,7 @@ def new_descent_phase(transcription):
     descent.add_state('v', units='m/s', rate_source='eom.v_dot',
                       targets=['dynamic_pressure.v', 'eom.v'],
                       fix_initial=False, fix_final=False,
-                      ref=100, defect_ref=100)
+                      ref=1)
 
     descent.add_parameter('S', targets=['aero.S'], units='m**2')
     descent.add_parameter('mass', targets=['eom.m'], units='kg')

--- a/dymos/examples/water_rocket/test/test_water_rocket.py
+++ b/dymos/examples/water_rocket/test/test_water_rocket.py
@@ -26,7 +26,7 @@ class TestWaterRocketForDocs(unittest.TestCase):
 
         p.driver = om.pyOptSparseDriver(optimizer='IPOPT', print_results=False)
         p.driver.opt_settings['print_level'] = 0
-        p.driver.opt_settings['max_iter'] = 1000
+        p.driver.opt_settings['max_iter'] = 500
         p.driver.opt_settings['mu_strategy'] = 'monotone'
         p.driver.declare_coloring(tol=1.0E-12)
 
@@ -65,7 +65,7 @@ class TestWaterRocketForDocs(unittest.TestCase):
 
         p.driver = om.pyOptSparseDriver(optimizer='IPOPT')
         p.driver.opt_settings['print_level'] = 0
-        p.driver.opt_settings['max_iter'] = 1000
+        p.driver.opt_settings['max_iter'] = 300
         p.driver.opt_settings['mu_strategy'] = 'monotone'
         p.driver.declare_coloring(tol=1.0E-12)
 


### PR DESCRIPTION
### Summary

The water rocket example was particularly sensitive and slight changes to scaling factors were needed to accommodate the upcoming auto_order update in OpenMDAO.

### Related Issues

- Resolves #968 

### Backwards incompatibilities

None

### New Dependencies

None
