### PR TITLE
Allow parameter shape to be given as `None`, rather than just `_unspecified`

### DIFF
--- a/dymos/examples/brachistochrone/test/test_brachistochrone_path_constraint.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_path_constraint.py
@@ -40,7 +40,7 @@ class TestBrachistochroneExprPathConstraint(unittest.TestCase):
         phase.add_boundary_constraint('x', loc='final', equals=10.0)
         phase.add_path_constraint('pc = y-x/2-1', lower=0.0)
 
-        phase.add_parameter('g', opt=False, units='m/s**2', val=9.80665, include_timeseries=True)
+        phase.add_parameter('g', opt=False, units='m/s**2', val=9.80665, shape=None, include_timeseries=True)
 
         phase.add_objective('time_phase', loc='final', scaler=10)
 

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -3,7 +3,7 @@ from numbers import Number
 import numpy as np
 
 import openmdao.api as om
-from ..utils.misc import _unspecified
+from ..utils.misc import _unspecified, _none_or_unspecified
 
 
 class ControlOptionsDictionary(om.OptionsDictionary):
@@ -224,7 +224,7 @@ def check_valid_shape(name, value):
         Shape to check, should be a Iterable, Number, list, or tuple.
     """
     if name == 'shape':
-        if value is not _unspecified and not isinstance(value, (Iterable, Number, list, tuple)):
+        if value not in _none_or_unspecified and not isinstance(value, (Iterable, Number, list, tuple)):
             raise ValueError(f"Option '{name}' with value {value} is not valid.")
 
 

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -284,7 +284,7 @@ class ParameterOptionsDictionary(om.OptionsDictionary):
         self.declare(name='val', types=(Iterable, np.ndarray, Number), default=0.0,
                      desc='The default value of the parameter in the phase.')
 
-        self.declare(name='shape', check_valid=check_valid_shape, default=_unspecified,
+        self.declare(name='shape', check_valid=check_valid_shape, default=_unspecified, allow_none=True,
                      desc='The shape of the parameter.')
 
         self.declare(name='lower', types=(Iterable, Number), default=None,


### PR DESCRIPTION
### Summary

The previous parameter introspection update changed parameters so that a shape of `None` is not allowed. This is added back in as dymos can handle this situation just fine.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
