### PR TITLE
Updated baseline test to use Numpy version 1.22.4

### DIFF
--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -259,14 +259,14 @@ jobs:
           echo "============================================================="
           echo "Check installed versions of Python, Numpy and Scipy"
           echo "============================================================="
-          python -c "import sys; assert str(sys.version).startswith(str(${{ matrix.PY }})), \
-                    f'Python version {sys.version} is not the requested version (${{ matrix.PY }})'"
+          python -c "ver='${{ matrix.PY }}'; import sys; assert str(sys.version).startswith(ver), \
+                    f'Python version {sys.version} is not the requested version ({ver})'"
 
-          python -c "import numpy; assert str(numpy.__version__).startswith(str(${{ matrix.NUMPY }})), \
-                    f'Numpy version {numpy.__version__} is not the requested version (${{ matrix.NUMPY }})'"
+          python -c "ver='${{ matrix.NUMPY }}'; import numpy; assert str(numpy.__version__).startswith(ver), \
+                    f'Numpy version {numpy.__version__} is not the requested version ({ver})'"
 
-          python -c "import scipy; assert str(scipy.__version__).startswith(str(${{ matrix.SCIPY }})), \
-                    f'Scipy version {scipy.__version__} is not the requested version (${{ matrix.SCIPY }})'"
+          python -c "ver='${{ matrix.SCIPY }}'; import scipy; assert str(scipy.__version__).startswith(ver), \
+                    f'Scipy version {scipy.__version__} is not the requested version ({ver})'"
 
       - name: 'Upload environment artifact'
         uses: actions/upload-artifact@v3

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -29,7 +29,7 @@ jobs:
           # baseline versions
           - NAME: baseline
             PY: '3.10'
-            NUMPY: 1.22
+            NUMPY: 1.22.4
             SCIPY: 1.7
             PETSc: 3.17
             PYOPTSPARSE: 'v2.9.3'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from setuptools import find_packages, setup
 optional_dependencies = {
     'docs': [
         'matplotlib',
-        'pandas<2.1',
         'bokeh',
         'jupyter',
         'jupyter-book==0.14',

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools import find_packages, setup
 optional_dependencies = {
     'docs': [
         'matplotlib',
+        'pandas<2.1',
         'bokeh',
         'jupyter',
         'jupyter-book==0.14',


### PR DESCRIPTION
### Summary

The latest version of `pandas`  requires a minimum Numpy version of 1.22.4 (see [release notes](https://pandas.pydata.org/pandas-docs/version/2.1.0/whatsnew/v2.1.0.html#whatsnew-210-api-breaking)).

The baseline job in the test workflow was asking for Numpy 1.22 and getting 1.22.3.  This PR changes the workflow to specify [1.22.4](https://numpy.org/doc/stable/release/1.22.4-notes.html), which is the latest maintenance patch of 1.22, released [May 20, 2022](https://pypi.org/project/numpy/1.22.4/).

The version check was updated to handle the additional patch level on the version string.

### Related Issues

- Resolves #974

### Backwards incompatibilities

None

### New Dependencies

None
