### PR TITLE
Bug report template no longer assumes entire example section is code.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,7 +16,6 @@ body:
     attributes:
       label: Example
       description: Please provide an example of the code that triggers the unexpected behavior. If possible, we would appreciate a minimal test case that reproduces the issue. Alternatively, link to a file in another repository where the issue is demonstrated.
-      render: python
     validations:
       required: true
   - type: input


### PR DESCRIPTION
### Summary

The bug report template previously assumed the entire example section was python code which led to distracting formatting.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
