### PR TITLE
Fixed an issue where control rate values are showing up in timeseries outputs by default.

### DIFF
--- a/dymos/examples/brachistochrone/test/test_brachistochrone_vector_boundary_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_vector_boundary_constraints.py
@@ -65,49 +65,6 @@ class TestBrachistochroneVectorBoundaryConstraints(unittest.TestCase):
 
         assert_near_equal(p.get_val('phase0.t')[-1], 1.8016, tolerance=1.0E-3)
 
-        # Plot results
-        if SHOW_PLOTS:
-            p.run_driver()
-            exp_out = phase.simulate(times_per_seg=10)
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution')
-
-            x_imp = p.get_val('phase0.timeseries.pos')[:, 0]
-            y_imp = p.get_val('phase0.timeseries.pos')[:, 1]
-
-            x_exp = exp_out.get_val('phase0.timeseries.pos')[:, 0]
-            y_exp = exp_out.get_val('phase0.timeseries.pos')[:, 1]
-
-            ax.plot(x_imp, y_imp, 'ro', label='implicit')
-            ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-            ax.set_xlabel('x (m)')
-            ax.set_ylabel('y (m)')
-            ax.grid(True)
-            ax.legend(loc='upper right')
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution')
-
-            x_imp = p.get_val('phase0.timeseries.time')
-            y_imp = p.get_val('phase0.timeseries.theta_rate2')
-
-            x_exp = exp_out.get_val('phase0.timeseries.time')
-            y_exp = exp_out.get_val('phase0.timeseries.theta_rate2')
-
-            ax.plot(x_imp, y_imp, 'ro', label='implicit')
-            ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-            ax.set_xlabel('time (s)')
-            ax.set_ylabel('theta rate2 (rad/s**2)')
-            ax.grid(True)
-            ax.legend(loc='lower right')
-
-            plt.show()
-
-        return p
-
     def test_brachistochrone_vector_boundary_constraints_radau_full_indices(self):
 
         p = om.Problem(model=om.Group())
@@ -153,49 +110,6 @@ class TestBrachistochroneVectorBoundaryConstraints(unittest.TestCase):
 
         assert_near_equal(p.get_val('phase0.t')[-1], 1.8016, tolerance=1.0E-3)
 
-        # Plot results
-        if SHOW_PLOTS:
-            p.run_driver()
-            exp_out = phase.simulate(times_per_seg=10)
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution')
-
-            x_imp = p.get_val('phase0.timeseries.pos')[:, 0]
-            y_imp = p.get_val('phase0.timeseries.pos')[:, 1]
-
-            x_exp = exp_out.get_val('phase0.timeseries.pos')[:, 0]
-            y_exp = exp_out.get_val('phase0.timeseries.pos')[:, 1]
-
-            ax.plot(x_imp, y_imp, 'ro', label='implicit')
-            ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-            ax.set_xlabel('x (m)')
-            ax.set_ylabel('y (m)')
-            ax.grid(True)
-            ax.legend(loc='upper right')
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution')
-
-            x_imp = p.get_val('phase0.timeseries.time')
-            y_imp = p.get_val('phase0.timeseries.theta_rate2')
-
-            x_exp = exp_out.get_val('phase0.timeseries.time')
-            y_exp = exp_out.get_val('phase0.timeseries.theta_rate2')
-
-            ax.plot(x_imp, y_imp, 'ro', label='implicit')
-            ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-            ax.set_xlabel('time (s)')
-            ax.set_ylabel('theta rate2 (rad/s**2)')
-            ax.grid(True)
-            ax.legend(loc='lower right')
-
-            plt.show()
-
-        return p
-
     def test_brachistochrone_vector_boundary_constraints_radau_partial_indices(self):
 
         p = om.Problem(model=om.Group())
@@ -238,49 +152,6 @@ class TestBrachistochroneVectorBoundaryConstraints(unittest.TestCase):
         p.run_driver()
 
         assert_near_equal(p.get_val('phase0.t')[-1], 1.8016, tolerance=1.0E-3)
-
-        # Plot results
-        if SHOW_PLOTS:
-            p.run_driver()
-            exp_out = phase.simulate(times_per_seg=20)
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution')
-
-            x_imp = p.get_val('phase0.timeseries.pos')[:, 0]
-            y_imp = p.get_val('phase0.timeseries.pos')[:, 1]
-
-            x_exp = exp_out.get_val('phase0.timeseries.pos')[:, 0]
-            y_exp = exp_out.get_val('phase0.timeseries.pos')[:, 1]
-
-            ax.plot(x_imp, y_imp, 'ro', label='implicit')
-            ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-            ax.set_xlabel('x (m)')
-            ax.set_ylabel('y (m)')
-            ax.grid(True)
-            ax.legend(loc='upper right')
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution')
-
-            x_imp = p.get_val('phase0.timeseries.time')
-            y_imp = p.get_val('phase0.timeseries.theta_rate2')
-
-            x_exp = exp_out.get_val('phase0.timeseries.time')
-            y_exp = exp_out.get_val('phase0.timeseries.theta_rate2')
-
-            ax.plot(x_imp, y_imp, 'ro', label='implicit')
-            ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-            ax.set_xlabel('time (s)')
-            ax.set_ylabel('theta rate2 (rad/s**2)')
-            ax.grid(True)
-            ax.legend(loc='lower right')
-
-            plt.show()
-
-        return p
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
@@ -13,10 +13,6 @@ from dymos.examples.brachistochrone.brachistochrone_vector_states_ode \
     import BrachistochroneVectorStatesODE
 
 
-SHOW_PLOTS = True
-plt.switch_backend('Agg')
-
-
 @use_tempdirs
 class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
 
@@ -69,71 +65,6 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         assert_near_equal(np.min(p.get_val('phase0.timeseries.pos')[:, 1]), 5.0,
                           tolerance=1.0E-3)
 
-        # Plot results
-        if SHOW_PLOTS:
-            exp_out = phase.simulate(times_per_seg=10)
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution')
-
-            x_imp = p.get_val('phase0.timeseries.pos')[:, 0]
-            y_imp = p.get_val('phase0.timeseries.pos')[:, 1]
-
-            x_exp = exp_out.get_val('phase0.timeseries.pos')[:, 0]
-            y_exp = exp_out.get_val('phase0.timeseries.pos')[:, 1]
-
-            ax.plot(x_imp, y_imp, 'ro', label='implicit')
-            ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-            ax.set_xlabel('x (m)')
-            ax.set_ylabel('y (m)')
-            ax.grid(True)
-            ax.legend(loc='upper right')
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution\nVelocity')
-
-            t_imp = p.get_val('phase0.timeseries.time')
-            t_exp = exp_out.get_val('phase0.timeseries.time')
-
-            xdot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 0]
-            ydot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 1]
-
-            xdot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 0]
-            ydot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 1]
-
-            ax.plot(t_imp, xdot_imp, 'bo', label='implicit')
-            ax.plot(t_exp, xdot_exp, 'b-', label='explicit')
-
-            ax.plot(t_imp, ydot_imp, 'ro', label='implicit')
-            ax.plot(t_exp, ydot_exp, 'r-', label='explicit')
-
-            ax.set_xlabel('t (s)')
-            ax.set_ylabel('v (m/s)')
-            ax.grid(True)
-            ax.legend(loc='upper right')
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution')
-
-            x_imp = p.get_val('phase0.timeseries.time')
-            y_imp = p.get_val('phase0.timeseries.theta_rate2')
-
-            x_exp = exp_out.get_val('phase0.timeseries.time')
-            y_exp = exp_out.get_val('phase0.timeseries.theta_rate2')
-
-            ax.plot(x_imp, y_imp, 'ro', label='implicit')
-            ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-            ax.set_xlabel('time (s)')
-            ax.set_ylabel('theta rate2 (rad/s**2)')
-            ax.grid(True)
-            ax.legend(loc='lower right')
-
-            plt.show()
-
-        return p
-
     def test_brachistochrone_vector_ode_path_constraints_radau_partial_indices(self):
 
         p = om.Problem(model=om.Group())
@@ -180,71 +111,6 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         assert_near_equal(np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
                           -4,
                           tolerance=1.0E-2)
-
-        # Plot results
-        if SHOW_PLOTS:
-            exp_out = phase.simulate(times_per_seg=20)
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution')
-
-            x_imp = p.get_val('phase0.timeseries.pos')[:, 0]
-            y_imp = p.get_val('phase0.timeseries.pos')[:, 1]
-
-            x_exp = exp_out.get_val('phase0.timeseries.pos')[:, 0]
-            y_exp = exp_out.get_val('phase0.timeseries.pos')[:, 1]
-
-            ax.plot(x_imp, y_imp, 'ro', label='implicit')
-            ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-            ax.set_xlabel('x (m)')
-            ax.set_ylabel('y (m)')
-            ax.grid(True)
-            ax.legend(loc='upper right')
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution\nVelocity')
-
-            t_imp = p.get_val('phase0.timeseries.time')
-            t_exp = exp_out.get_val('phase0.timeseries.time')
-
-            xdot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 0]
-            ydot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 1]
-
-            xdot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 0]
-            ydot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 1]
-
-            ax.plot(t_imp, xdot_imp, 'bo', label='implicit')
-            ax.plot(t_exp, xdot_exp, 'b-', label='explicit')
-
-            ax.plot(t_imp, ydot_imp, 'ro', label='implicit')
-            ax.plot(t_exp, ydot_exp, 'r-', label='explicit')
-
-            ax.set_xlabel('t (s)')
-            ax.set_ylabel('v (m/s)')
-            ax.grid(True)
-            ax.legend(loc='upper right')
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution')
-
-            x_imp = p.get_val('phase0.timeseries.time')
-            y_imp = p.get_val('phase0.timeseries.theta_rate2')
-
-            x_exp = exp_out.get_val('phase0.timeseries.time')
-            y_exp = exp_out.get_val('phase0.timeseries.theta_rate2')
-
-            ax.plot(x_imp, y_imp, 'ro', label='implicit')
-            ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-            ax.set_xlabel('time (s)')
-            ax.set_ylabel('theta rate2 (rad/s**2)')
-            ax.grid(True)
-            ax.legend(loc='lower right')
-
-            plt.show()
-
-        return p
 
     def test_brachistochrone_vector_ode_path_constraints_radau_no_indices(self):
 
@@ -294,71 +160,6 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
                           -4,
                           tolerance=1.0E-2)
 
-        # Plot results
-        if SHOW_PLOTS:
-            exp_out = phase.simulate(times_per_seg=50)
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution')
-
-            x_imp = p.get_val('phase0.timeseries.pos')[:, 0]
-            y_imp = p.get_val('phase0.timeseries.pos')[:, 1]
-
-            x_exp = exp_out.get_val('phase0.timeseries.pos')[:, 0]
-            y_exp = exp_out.get_val('phase0.timeseries.pos')[:, 1]
-
-            ax.plot(x_imp, y_imp, 'ro', label='implicit')
-            ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-            ax.set_xlabel('x (m)')
-            ax.set_ylabel('y (m)')
-            ax.grid(True)
-            ax.legend(loc='upper right')
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution\nVelocity')
-
-            t_imp = p.get_val('phase0.timeseries.time')
-            t_exp = exp_out.get_val('phase0.timeseries.time')
-
-            xdot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 0]
-            ydot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 1]
-
-            xdot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 0]
-            ydot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 1]
-
-            ax.plot(t_imp, xdot_imp, 'bo', label='implicit')
-            ax.plot(t_exp, xdot_exp, 'b-', label='explicit')
-
-            ax.plot(t_imp, ydot_imp, 'ro', label='implicit')
-            ax.plot(t_exp, ydot_exp, 'r-', label='explicit')
-
-            ax.set_xlabel('t (s)')
-            ax.set_ylabel('v (m/s)')
-            ax.grid(True)
-            ax.legend(loc='upper right')
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution')
-
-            x_imp = p.get_val('phase0.timeseries.time')
-            y_imp = p.get_val('phase0.timeseries.theta_rate2')
-
-            x_exp = exp_out.get_val('phase0.timeseries.time')
-            y_exp = exp_out.get_val('phase0.timeseries.theta_rate2')
-
-            ax.plot(x_imp, y_imp, 'ro', label='implicit')
-            ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-            ax.set_xlabel('time (s)')
-            ax.set_ylabel('theta rate2 (rad/s**2)')
-            ax.grid(True)
-            ax.legend(loc='lower right')
-
-            plt.show()
-
-        return p
-
     def test_brachistochrone_vector_state_path_constraints_gl_partial_indices(self):
 
         p = om.Problem(model=om.Group())
@@ -406,71 +207,6 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         assert_near_equal(np.min(p.get_val('phase0.timeseries.pos')[:, 1]),
                           5,
                           tolerance=1.0E-2)
-
-        # Plot results
-        if SHOW_PLOTS:
-            exp_out = phase.simulate(times_per_seg=20)
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution')
-
-            x_imp = p.get_val('phase0.timeseries.pos')[:, 0]
-            y_imp = p.get_val('phase0.timeseries.pos')[:, 1]
-
-            x_exp = exp_out.get_val('phase0.timeseries.pos')[:, 0]
-            y_exp = exp_out.get_val('phase0.timeseries.pos')[:, 1]
-
-            ax.plot(x_imp, y_imp, 'ro', label='implicit')
-            ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-            ax.set_xlabel('x (m)')
-            ax.set_ylabel('y (m)')
-            ax.grid(True)
-            ax.legend(loc='upper right')
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution\nVelocity')
-
-            t_imp = p.get_val('phase0.timeseries.time')
-            t_exp = exp_out.get_val('phase0.timeseries.time')
-
-            xdot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 0]
-            ydot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 1]
-
-            xdot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 0]
-            ydot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 1]
-
-            ax.plot(t_imp, xdot_imp, 'bo', label='implicit')
-            ax.plot(t_exp, xdot_exp, 'b-', label='explicit')
-
-            ax.plot(t_imp, ydot_imp, 'ro', label='implicit')
-            ax.plot(t_exp, ydot_exp, 'r-', label='explicit')
-
-            ax.set_xlabel('t (s)')
-            ax.set_ylabel('v (m/s)')
-            ax.grid(True)
-            ax.legend(loc='upper right')
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution')
-
-            x_imp = p.get_val('phase0.timeseries.time')
-            y_imp = p.get_val('phase0.timeseries.theta_rate2')
-
-            x_exp = exp_out.get_val('phase0.timeseries.time')
-            y_exp = exp_out.get_val('phase0.timeseries.theta_rate2')
-
-            ax.plot(x_imp, y_imp, 'ro', label='implicit')
-            ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-            ax.set_xlabel('time (s)')
-            ax.set_ylabel('theta rate2 (rad/s**2)')
-            ax.grid(True)
-            ax.legend(loc='lower right')
-
-            plt.show()
-
-        return p
 
     def test_brachistochrone_vector_ode_path_constraints_gl_partial_indices(self):
 
@@ -523,71 +259,6 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         assert_near_equal(np.min(p.get_val('phase0.timeseries.pos_dot')[:, 1]), -4.0,
                           tolerance=1.0E-3)
 
-        # Plot results
-        if SHOW_PLOTS:
-            exp_out = phase.simulate(times_per_seg=20)
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution')
-
-            x_imp = p.get_val('phase0.timeseries.pos')[:, 0]
-            y_imp = p.get_val('phase0.timeseries.pos')[:, 1]
-
-            x_exp = exp_out.get_val('phase0.timeseries.pos')[:, 0]
-            y_exp = exp_out.get_val('phase0.timeseries.pos')[:, 1]
-
-            ax.plot(x_imp, y_imp, 'ro', label='implicit')
-            ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-            ax.set_xlabel('x (m)')
-            ax.set_ylabel('y (m)')
-            ax.grid(True)
-            ax.legend(loc='upper right')
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution\nVelocity')
-
-            t_imp = p.get_val('phase0.timeseries.time')
-            t_exp = exp_out.get_val('phase0.timeseries.time')
-
-            xdot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 0]
-            ydot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 1]
-
-            xdot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 0]
-            ydot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 1]
-
-            ax.plot(t_imp, xdot_imp, 'bo', label='implicit')
-            ax.plot(t_exp, xdot_exp, 'b-', label='explicit')
-
-            ax.plot(t_imp, ydot_imp, 'ro', label='implicit')
-            ax.plot(t_exp, ydot_exp, 'r-', label='explicit')
-
-            ax.set_xlabel('t (s)')
-            ax.set_ylabel('v (m/s)')
-            ax.grid(True)
-            ax.legend(loc='upper right')
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution')
-
-            x_imp = p.get_val('phase0.timeseries.time')
-            y_imp = p.get_val('phase0.timeseries.theta_rate2')
-
-            x_exp = exp_out.get_val('phase0.timeseries.time')
-            y_exp = exp_out.get_val('phase0.timeseries.theta_rate2')
-
-            ax.plot(x_imp, y_imp, 'ro', label='implicit')
-            ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-            ax.set_xlabel('time (s)')
-            ax.set_ylabel('theta rate2 (rad/s**2)')
-            ax.grid(True)
-            ax.legend(loc='lower right')
-
-            plt.show()
-
-        return p
-
     def test_brachistochrone_vector_ode_path_constraints_gl_no_indices(self):
 
         p = om.Problem(model=om.Group())
@@ -636,71 +307,6 @@ class TestBrachistochroneVectorPathConstraints(unittest.TestCase):
         assert_near_equal(np.min(p.get_val('phase0.timeseries.pos_dot')[:, -1]),
                           -4,
                           tolerance=1.0E-2)
-
-        # Plot results
-        if SHOW_PLOTS:
-            exp_out = phase.simulate(times_per_seg=20)
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution')
-
-            x_imp = p.get_val('phase0.timeseries.pos')[:, 0]
-            y_imp = p.get_val('phase0.timeseries.pos')[:, 1]
-
-            x_exp = exp_out.get_val('phase0.timeseries.pos')[:, 0]
-            y_exp = exp_out.get_val('phase0.timeseries.pos')[:, 1]
-
-            ax.plot(x_imp, y_imp, 'ro', label='implicit')
-            ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-            ax.set_xlabel('x (m)')
-            ax.set_ylabel('y (m)')
-            ax.grid(True)
-            ax.legend(loc='upper right')
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution\nVelocity')
-
-            t_imp = p.get_val('phase0.timeseries.time')
-            t_exp = exp_out.get_val('phase0.timeseries.time')
-
-            xdot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 0]
-            ydot_imp = p.get_val('phase0.timeseries.pos_dot')[:, 1]
-
-            xdot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 0]
-            ydot_exp = exp_out.get_val('phase0.timeseries.pos_dot')[:, 1]
-
-            ax.plot(t_imp, xdot_imp, 'bo', label='implicit')
-            ax.plot(t_exp, xdot_exp, 'b-', label='explicit')
-
-            ax.plot(t_imp, ydot_imp, 'ro', label='implicit')
-            ax.plot(t_exp, ydot_exp, 'r-', label='explicit')
-
-            ax.set_xlabel('t (s)')
-            ax.set_ylabel('v (m/s)')
-            ax.grid(True)
-            ax.legend(loc='upper right')
-
-            fig, ax = plt.subplots()
-            fig.suptitle('Brachistochrone Solution')
-
-            x_imp = p.get_val('phase0.timeseries.time')
-            y_imp = p.get_val('phase0.timeseries.theta_rate2')
-
-            x_exp = exp_out.get_val('phase0.timeseries.time')
-            y_exp = exp_out.get_val('phase0.timeseries.theta_rate2')
-
-            ax.plot(x_imp, y_imp, 'ro', label='implicit')
-            ax.plot(x_exp, y_exp, 'b-', label='explicit')
-
-            ax.set_xlabel('time (s)')
-            ax.set_ylabel('theta rate2 (rad/s**2)')
-            ax.grid(True)
-            ax.legend(loc='lower right')
-
-            plt.show()
-
-        return p
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/examples/brachistochrone/test/test_ex_brachistochrone.py
+++ b/dymos/examples/brachistochrone/test/test_ex_brachistochrone.py
@@ -49,6 +49,9 @@ class TestBrachistochroneExample(unittest.TestCase):
 
         assert_almost_equal(thetaf, 100.12, decimal=0)
 
+        outputs = [op[1]['prom_name'] for op in p.model.list_outputs(out_stream=None)]
+        self.assertNotIn('traj0.phase0.timeseries.theta_rate', outputs)
+
     def test_ex_brachistochrone_radau_compressed(self):
         ex_brachistochrone.SHOW_PLOTS = True
         p = ex_brachistochrone.brachistochrone_min_time(transcription='radau-ps',

--- a/dymos/examples/brachistochrone/test/test_ex_brachistochrone.py
+++ b/dymos/examples/brachistochrone/test/test_ex_brachistochrone.py
@@ -49,7 +49,7 @@ class TestBrachistochroneExample(unittest.TestCase):
 
         assert_almost_equal(thetaf, 100.12, decimal=0)
 
-        outputs = [op[1]['prom_name'] for op in p.model.list_outputs(out_stream=None)]
+        outputs = [op[1]['prom_name'] for op in p.model.list_outputs(out_stream=None, prom_name=True)]
         self.assertNotIn('traj0.phase0.timeseries.theta_rate', outputs)
 
     def test_ex_brachistochrone_radau_compressed(self):

--- a/dymos/examples/brachistochrone/test/test_state_rate_introspection.py
+++ b/dymos/examples/brachistochrone/test/test_state_rate_introspection.py
@@ -278,6 +278,10 @@ class TestIntegrateControl(unittest.TestCase):
                                     loc_a='initial', loc_b='initial',
                                     units='rad/s')
 
+        # Note we have to add theta_rate to the timeseries outputs here because
+        # linkages get boundary values from that output.
+        phase.add_timeseries_output('theta_rate')
+
         # Minimize final time.
         phase.add_objective('time', loc='final')
 
@@ -621,6 +625,10 @@ class TestIntegratePolynomialControl(unittest.TestCase):
                                     var_a='int_theta_dot', var_b='theta_rate',
                                     loc_a='initial', loc_b='initial',
                                     units='rad/s')
+
+        # Note for this test we have to add theta rate to the timeseries outputs since it's
+        # not there by default.
+        phase.add_timeseries_output('theta_rate')
 
         # Minimize final time.
         phase.add_objective('time', loc='final')

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -1201,9 +1201,14 @@ class Phase(om.Group):
 
         # Automatically add the requested variable to the timeseries outputs if it's an ODE output.
         var_type = self.classify_var(name)
-        if var_type == 'ode':
+        if var_type == 'ode' or 'control_rate' in var_type:
+            if self.timeseries_options['use_prefix']:
+                if var_type.startswith('control_rate'):
+                    bc['constraint_name'] = f'control_rates:{constraint_name}'
+                elif var_type.startswith('polynomial_control_rate'):
+                    bc['constraint_name'] = f'polynomial_control_rates:{constraint_name}'
             if constraint_name not in self._timeseries['timeseries']['outputs']:
-                self.add_timeseries_output(name, output_name=constraint_name, units=units, shape=shape)
+                self.add_timeseries_output(name, output_name=bc['constraint_name'], units=units, shape=shape)
 
     def add_path_constraint(self, name, constraint_name=None, units=None, shape=None, indices=None,
                             lower=None, upper=None, equals=None, scaler=None, adder=None, ref=None,
@@ -1308,9 +1313,14 @@ class Phase(om.Group):
 
         # Automatically add the requested variable to the timeseries outputs if it's an ODE output.
         var_type = self.classify_var(name)
-        if var_type == 'ode':
+        if var_type == 'ode' or 'control_rate' in var_type:
+            if self.timeseries_options['use_prefix']:
+                if var_type.startswith('control_rate'):
+                    pc['constraint_name'] = f'control_rates:{constraint_name}'
+                elif var_type.startswith('polynomial_control_rate'):
+                    pc['constraint_name'] = f'polynomial_control_rates:{constraint_name}'
             if constraint_name not in self._timeseries['timeseries']['outputs']:
-                self.add_timeseries_output(name, output_name=constraint_name, units=units, shape=shape)
+                self.add_timeseries_output(name, output_name=pc['constraint_name'], units=units, shape=shape)
 
     def add_timeseries_output(self, name, output_name=None, units=_unspecified, shape=_unspecified,
                               timeseries='timeseries', **kwargs):

--- a/dymos/phase/test/test_phase.py
+++ b/dymos/phase/test/test_phase.py
@@ -403,27 +403,10 @@ class TestPhaseBase(unittest.TestCase):
         p['phase0.controls:theta'] = phase.interp('theta', [5, 100])
         p['phase0.parameters:g'] = 8
 
-        p.run_driver()
+        failed = p.run_driver()
 
-        import matplotlib.pyplot as plt
-
-        plt.plot(p.get_val('phase0.timeseries.x'),
-                 p.get_val('phase0.timeseries.y'), 'ko')
-
-        plt.figure()
-
-        plt.plot(p.get_val('phase0.timeseries.time'),
-                 p.get_val('phase0.timeseries.theta'), 'ro')
-
-        plt.plot(p.get_val('phase0.timeseries.time'),
-                 p.get_val('phase0.timeseries.theta_rate'), 'bo')
-
-        plt.plot(p.get_val('phase0.timeseries.time'),
-                 p.get_val('phase0.timeseries.theta_rate2'), 'go')
-        plt.show()
-
-        assert_near_equal(p.get_val('phase0.timeseries.theta_rate')[-1], 0,
-                          tolerance=1.0E-6)
+        self.assertFalse(failed)
+        assert_near_equal(p.get_val('phase0.timeseries.theta_rate')[-1, ...], 0.0, tolerance=1.0E-3)
 
     def test_control_rate2_boundary_constraint_gl(self):
         p = om.Problem(model=om.Group())
@@ -470,25 +453,10 @@ class TestPhaseBase(unittest.TestCase):
         p['phase0.controls:theta'] = phase.interp('theta', [5, 100])
         p['phase0.parameters:g'] = 8
 
-        p.run_driver()
+        failed = p.run_driver()
 
-        plt.plot(p.get_val('phase0.timeseries.x'),
-                 p.get_val('phase0.timeseries.y'), 'ko')
-
-        plt.figure()
-
-        plt.plot(p.get_val('phase0.timeseries.time'),
-                 p.get_val('phase0.timeseries.theta'), 'ro')
-
-        plt.plot(p.get_val('phase0.timeseries.time'),
-                 p.get_val('phase0.timeseries.theta_rate'), 'bo')
-
-        plt.plot(p.get_val('phase0.timeseries.time'),
-                 p.get_val('phase0.timeseries.theta_rate2'), 'go')
-        plt.show()
-
-        assert_near_equal(p.get_val('phase0.timeseries.theta_rate2')[-1], 0,
-                          tolerance=1.0E-6)
+        self.assertFalse(failed)
+        assert_near_equal(p.get_val('phase0.timeseries.theta_rate2')[-1, ...], 0.0, tolerance=1.0E-3)
 
     def test_parameter_multiple_boundary_constraints(self):
 

--- a/dymos/test/test_run_problem.py
+++ b/dymos/test/test_run_problem.py
@@ -659,6 +659,7 @@ class TestRunProblemPlotting(unittest.TestCase):
         phase0.set_refine_options(refine=True)
 
         phase0.timeseries_options['include_state_rates'] = True
+        phase0.timeseries_options['include_control_rates'] = True
         phase0.timeseries_options['include_t_phase'] = True
 
         p.model.linear_solver = om.DirectSolver()

--- a/dymos/trajectory/test/test_trajectory.py
+++ b/dymos/trajectory/test/test_trajectory.py
@@ -755,6 +755,11 @@ class TestLinkages(unittest.TestCase):
         burn2.add_objective('deltav', loc='final')
 
         # Link Phases
+
+        # Note we have to manually add the control rate here to link it between phases.
+        for phs in (burn1, burn2):
+            phs.add_timeseries_output('u1_rate2')
+
         self.traj.link_phases(phases=['burn1', 'coast', 'burn2'],
                               vars=['time', 'r', 'theta', 'vr', 'vt', 'deltav'])
         self.traj.link_phases(phases=['burn1', 'burn2'], vars=['accel'])
@@ -885,6 +890,11 @@ class TestLinkages(unittest.TestCase):
         burn2.add_objective('deltav', loc='final')
 
         # Link Phases
+
+        # Note that we have to add the control rate to the timeseries in order to link it.
+        for phs in (burn1, burn2):
+            phs.add_timeseries_output('u1_rate')
+
         self.traj.link_phases(phases=['burn1', 'coast', 'burn2'],
                               vars=['time', 'r', 'theta', 'vr', 'vt', 'deltav'])
         self.traj.link_phases(phases=['burn1', 'burn2'], vars=['accel'])
@@ -1015,6 +1025,11 @@ class TestLinkages(unittest.TestCase):
         burn2.add_objective('deltav', loc='final')
 
         # Link Phases
+
+        # Note that we have to add the control rate to the timeseries in order to link it.
+        for phs in (burn1, burn2):
+            phs.add_timeseries_output('u1_rate2')
+
         self.traj.link_phases(phases=['burn1', 'coast', 'burn2'],
                               vars=['time', 'r', 'theta', 'vr', 'vt', 'deltav'])
         self.traj.link_phases(phases=['burn1', 'burn2'], vars=['accel'])

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -189,11 +189,10 @@ class Trajectory(om.Group):
         if shape is not _unspecified:
             self.parameter_options[name]['shape'] = shape
 
-        if dynamic is not _unspecified:
-            self.parameter_options[name]['static_target'] = not dynamic
+        if dynamic is not _unspecified:  # Deprecated
+            self.parameter_options[name]['static_targets'] = not dynamic
 
-        if static_target is not _unspecified:
-            self.parameter_options[name]['static_target'] = static_target
+        if static_target is not _unspecified:  # Deprecated
             self.parameter_options[name]['static_targets'] = static_target
 
         if static_targets is not _unspecified:

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -159,23 +159,6 @@ class TranscriptionBase(object):
             phase.add_subsystem('control_group',
                                 subsys=control_group)
 
-            control_prefix = 'controls:' if phase.timeseries_options['use_prefix'] else ''
-            control_rate_prefix = 'control_rates:' if phase.timeseries_options['use_prefix'] else ''
-
-            for name, options in phase.control_options.items():
-                for ts_name, ts_options in phase._timeseries.items():
-                    if f'{control_prefix}{name}' not in ts_options['outputs']:
-                        phase.add_timeseries_output(name, output_name=f'{control_prefix}{name}',
-                                                    timeseries=ts_name)
-                    if f'{control_rate_prefix}{name}_rate' not in ts_options['outputs'] and \
-                            (phase.timeseries_options['include_control_rates'] or options['rate_targets']):
-                        phase.add_timeseries_output(f'{name}_rate', output_name=f'{control_rate_prefix}{name}_rate',
-                                                    timeseries=ts_name)
-                    if f'{control_rate_prefix}{name}_rate2' not in ts_options['outputs'] and \
-                            (phase.timeseries_options['include_control_rates'] or options['rate2_targets']):
-                        phase.add_timeseries_output(f'{name}_rate2', output_name=f'{control_rate_prefix}{name}_rate2',
-                                                    timeseries=ts_name)
-
     def configure_controls(self, phase):
         """
         Configure the inputs/outputs for the controls.
@@ -185,7 +168,22 @@ class TranscriptionBase(object):
         phase : dymos.Phase
             The phase object to which this transcription instance applies.
         """
-        pass
+        control_prefix = 'controls:' if phase.timeseries_options['use_prefix'] else ''
+        control_rate_prefix = 'control_rates:' if phase.timeseries_options['use_prefix'] else ''
+
+        for name, options in phase.control_options.items():
+            for ts_name, ts_options in phase._timeseries.items():
+                if f'{control_prefix}{name}' not in ts_options['outputs']:
+                    phase.add_timeseries_output(name, output_name=f'{control_prefix}{name}',
+                                                timeseries=ts_name)
+                if f'{control_rate_prefix}{name}_rate' not in ts_options['outputs'] and \
+                        (phase.timeseries_options['include_control_rates'] or options['rate_targets']):
+                    phase.add_timeseries_output(f'{name}_rate', output_name=f'{control_rate_prefix}{name}_rate',
+                                                timeseries=ts_name)
+                if f'{control_rate_prefix}{name}_rate2' not in ts_options['outputs'] and \
+                        (phase.timeseries_options['include_control_rates'] or options['rate2_targets']):
+                    phase.add_timeseries_output(f'{name}_rate2', output_name=f'{control_rate_prefix}{name}_rate2',
+                                                timeseries=ts_name)
 
     def setup_polynomial_controls(self, phase):
         """
@@ -207,6 +205,18 @@ class TranscriptionBase(object):
 
             phase.connect('t_duration_val', 'polynomial_control_group.t_duration')
 
+    def configure_polynomial_controls(self, phase):
+        """
+        Configure the inputs/outputs for the polynomial controls.
+
+        Parameters
+        ----------
+        phase : dymos.Phase
+            The phase object to which this transcription instance applies.
+        """
+        if phase.polynomial_control_options:
+            phase.polynomial_control_group.configure_io()
+
             prefix = 'polynomial_controls:' if phase.timeseries_options['use_prefix'] else ''
             rate_prefix = 'polynomial_control_rates:' if phase.timeseries_options['use_prefix'] else ''
 
@@ -224,17 +234,6 @@ class TranscriptionBase(object):
                         phase.add_timeseries_output(f'{name}_rate2', output_name=f'{rate_prefix}{name}_rate2',
                                                     timeseries=ts_name)
 
-    def configure_polynomial_controls(self, phase):
-        """
-        Configure the inputs/outputs for the polynomial controls.
-
-        Parameters
-        ----------
-        phase : dymos.Phase
-            The phase object to which this transcription instance applies.
-        """
-        if phase.polynomial_control_options:
-            phase.polynomial_control_group.configure_io()
 
     def setup_parameters(self, phase):
         """

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -234,7 +234,6 @@ class TranscriptionBase(object):
                         phase.add_timeseries_output(f'{name}_rate2', output_name=f'{rate_prefix}{name}_rate2',
                                                     timeseries=ts_name)
 
-
     def setup_parameters(self, phase):
         """
         Sets input defaults for parameters and optionally adds design variables.

--- a/dymos/visualization/test/test_timeseries_plots.py
+++ b/dymos/visualization/test/test_timeseries_plots.py
@@ -37,6 +37,7 @@ class TestTimeSeriesPlotsBasics(unittest.TestCase):
                             compressed=compressed)
         traj = dm.Trajectory()
         phase = dm.Phase(ode_class=BrachistochroneODE, transcription=t)
+        phase.timeseries_options['include_control_rates'] = True
         traj.add_phase('phase0', phase)
 
         p.model.add_subsystem('traj0', traj)
@@ -80,22 +81,18 @@ class TestTimeSeriesPlotsBasics(unittest.TestCase):
         self.p = p
 
     def test_brachistochrone_timeseries_plots(self):
-        temp = dm.options['plots']
-        dm.options['plots'] = 'matplotlib'
+        with dm.options.temporary(plots='matplotlib'):
+            dm.run_problem(self.p, make_plots=False)
 
-        dm.run_problem(self.p, make_plots=False)
+            timeseries_plots('dymos_solution.db', problem=self.p)
+            plot_dir = pathlib.Path(_get_reports_dir(self.p)).joinpath('plots')
 
-        timeseries_plots('dymos_solution.db', problem=self.p)
-        plot_dir = pathlib.Path(_get_reports_dir(self.p)).joinpath('plots')
-
-        self.assertTrue(plot_dir.joinpath('x.png').exists())
-        self.assertTrue(plot_dir.joinpath('y.png').exists())
-        self.assertTrue(plot_dir.joinpath('v.png').exists())
-        self.assertTrue(plot_dir.joinpath('theta.png').exists())
-        self.assertTrue(plot_dir.joinpath('theta_rate.png').exists())
-        self.assertTrue(plot_dir.joinpath('theta_rate2.png').exists())
-
-        dm.options['plots'] = temp
+            self.assertTrue(plot_dir.joinpath('x.png').exists())
+            self.assertTrue(plot_dir.joinpath('y.png').exists())
+            self.assertTrue(plot_dir.joinpath('v.png').exists())
+            self.assertTrue(plot_dir.joinpath('theta.png').exists())
+            self.assertTrue(plot_dir.joinpath('theta_rate.png').exists())
+            self.assertTrue(plot_dir.joinpath('theta_rate2.png').exists())
 
     def test_brachistochrone_timeseries_plots_solution_only_set_solution_record_file(self):
         temp = dm.options['plots']
@@ -257,6 +254,7 @@ class TestTimeSeriesPlotsMultiPhase(unittest.TestCase):
             phase.timeseries_options['use_prefix'] = True
             phase.timeseries_options['include_state_rates'] = True
             phase.timeseries_options['include_t_phase'] = True
+            phase.timeseries_options['include_control_rates'] = True
 
         p.setup(check=True)
 
@@ -380,6 +378,7 @@ class TestTimeSeriesPlotsMultiPhase(unittest.TestCase):
         for phase_name, phase in traj._phases.items():
             phase.timeseries_options['include_t_phase'] = True
             phase.timeseries_options['include_state_rates'] = True
+            phase.timeseries_options['include_control_rates'] = True
 
         prob.setup()
 


### PR DESCRIPTION
### Summary

Controls were being added during setup rather than configure which caused control rates to inadvertently end up in the timeseries outputs by default.

### Related Issues

- Resolves #986

### Backwards incompatibilities

None

### New Dependencies

None
