### PR TITLE
Added linear solver for cases where states solved via optimizer have `input_initial=True` 

### DIFF
--- a/dymos/examples/finite_burn_orbit_raise/finite_burn_orbit_raise_problem.py
+++ b/dymos/examples/finite_burn_orbit_raise/finite_burn_orbit_raise_problem.py
@@ -224,6 +224,7 @@ def two_burn_orbit_raise_problem(transcription='gauss-lobatto', optimizer='SLSQP
         p.driver.opt_settings['nlp_scaling_method'] = 'gradient-based'  # for faster convergence
         p.driver.opt_settings['alpha_for_y'] = 'safer-min-dual-infeas'
         p.driver.opt_settings['mu_strategy'] = 'monotone'
+        p.driver.opt_settings['derivative_test'] = 'first-order'
         if show_output:
             p.driver.opt_settings['print_level'] = 5
 

--- a/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise.py
@@ -39,8 +39,6 @@ class TestExampleTwoBurnOrbitRaiseConnected(unittest.TestCase):
                                          compressed=False, optimizer=optimizer,
                                          show_output=False, connected=True, run_driver=True)
 
-        p.check_totals(compact_print=True)
-
         if p.model.traj.phases.burn2 in p.model.traj.phases._subsystems_myproc:
             assert_near_equal(p.get_val('traj.burn2.states:deltav')[0], 0.3995,
                               tolerance=4.0E-3)

--- a/dymos/transcriptions/pseudospectral/pseudospectral_base.py
+++ b/dymos/transcriptions/pseudospectral/pseudospectral_base.py
@@ -95,6 +95,7 @@ class PseudospectralBase(TranscriptionBase):
         if self.any_solved_segs or self.any_connected_opt_segs:
             indep = StateIndependentsComp(grid_data=grid_data,
                                           state_options=phase.state_options)
+            indep.linear_solver = om.DirectSolver()
         else:
             indep = om.IndepVarComp()
 
@@ -513,8 +514,6 @@ class PseudospectralBase(TranscriptionBase):
                 newton.options['stall_limit'] = 3
                 newton.linesearch = om.BoundsEnforceLS()
 
-        # even though you don't need a nl_solver for connections, you still ln_solver since its implicit
-        if self.any_solved_segs or self._implicit_duration:
             if isinstance(phase.linear_solver, om.LinearRunOnce):
                 phase.linear_solver = om.DirectSolver()
 


### PR DESCRIPTION
### Summary

This adds a linear solver directly to the StateIndependentsComp in such cases, since having it apply to the entire phase is generally overkill here.

### Related Issues

- Resolves #990

### Backwards incompatibilities

None

### New Dependencies

None
