### PR TITLE
Added times_per_seg to SimulateOptionsDictionary

### DIFF
--- a/dymos/phase/analytic_phase.py
+++ b/dymos/phase/analytic_phase.py
@@ -455,29 +455,20 @@ class AnalyticPhase(Phase):
         """
         raise NotImplementedError('Method `simulate` is not available for AnalyticPhase.')
 
-    def set_simulate_options(self, method=_unspecified, atol=_unspecified, rtol=_unspecified,
-                             first_step=_unspecified, max_step=_unspecified):
+    def set_simulate_options(self, *args, **kwargs):
         """
         Stub to make sure users are informed that simulate cannot be done on AnalyticPhase.
 
         Parameters
         ----------
-        method : str
-            The scipy.integrate.solve_ivp integration method.
-        atol : float
-            Absolute convergence tolerance for scipy.integrate.solve_ivp.
-        rtol : float
-            Relative convergence tolerance for scipy.integrate.solve_ivp.
-        first_step : float
-            Initial step size for the integration.
-        max_step : float
-            Maximum step size for the integration.
+        *args
+            Position arguments.
+        *kwargs : float
+            Keyword arguments.
 
-        Returns
-        -------
-        problem
-            An OpenMDAO Problem in which the simulation is implemented.  This Problem interface
-            can be interrogated to obtain timeseries outputs in the same manner as other Phases
-            to obtain results at the requested times.
+        Raises
+        ------
+        NotImplementedError
+            Simulation cannot be performed on AnalyticPhase.
         """
         raise NotImplementedError('Method set_simulate_options is not available for AnalyticPhase.')

--- a/dymos/phase/analytic_phase.py
+++ b/dymos/phase/analytic_phase.py
@@ -463,7 +463,7 @@ class AnalyticPhase(Phase):
         ----------
         *args
             Position arguments.
-        *kwargs : float
+        **kwargs : float
             Keyword arguments.
 
         Raises

--- a/dymos/phase/options.py
+++ b/dymos/phase/options.py
@@ -641,6 +641,11 @@ class SimulateOptionsDictionary(om.OptionsDictionary):
         self.declare(name='max_step', types=float, default=np.inf,
                      desc='Maximum allowable step size')
 
+        self.declare(name='times_per_seg', types=int, allow_none=True, default=10,
+                     desc='The default number of output times per segment for Phase.simulate.'
+                          'If None, and not provided as an argument to simulate, use the'
+                          'same grid as the Phase transcription.')
+
 
 class ConstraintOptionsDictionary(om.OptionsDictionary):
     """

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -2200,7 +2200,7 @@ class Phase(om.Group):
             res = res.T
         return res
 
-    def get_simulation_phase(self, times_per_seg=None, method=_unspecified, atol=_unspecified,
+    def get_simulation_phase(self, times_per_seg=_unspecified, method=_unspecified, atol=_unspecified,
                              rtol=_unspecified, first_step=_unspecified, max_step=_unspecified,
                              reports=False):
         """
@@ -2237,6 +2237,7 @@ class Phase(om.Group):
             times.  This instance has not yet been setup.
         """
         from .simulation_phase import SimulationPhase
+
         sim_phase = SimulationPhase(from_phase=self, times_per_seg=times_per_seg, method=method,
                                     atol=atol, rtol=rtol, first_step=first_step, max_step=max_step,
                                     reports=reports)
@@ -2317,7 +2318,7 @@ class Phase(om.Group):
                 prob_path = f'{self.name}.parameters:{name}'
             prob.set_val(prob_path, val)
 
-    def simulate(self, times_per_seg=10, method=_unspecified, atol=_unspecified, rtol=_unspecified,
+    def simulate(self, times_per_seg=None, method=_unspecified, atol=_unspecified, rtol=_unspecified,
                  first_step=_unspecified, max_step=_unspecified, record_file=None):
         """
         Simulate the Phase using scipy.integrate.solve_ivp.
@@ -2350,7 +2351,7 @@ class Phase(om.Group):
         """
         sim_prob = om.Problem(model=om.Group())
 
-        sim_phase = self.get_simulation_phase(times_per_seg, method=method, atol=atol, rtol=rtol,
+        sim_phase = self.get_simulation_phase(times_per_seg=times_per_seg, method=method, atol=atol, rtol=rtol,
                                               first_step=first_step, max_step=max_step)
 
         sim_prob.model.add_subsystem(self.name, sim_phase)
@@ -2405,7 +2406,7 @@ class Phase(om.Group):
             self.refine_options['smoothness_factor'] = smoothness_factor
 
     def set_simulate_options(self, method=_unspecified, atol=_unspecified, rtol=_unspecified,
-                             first_step=_unspecified, max_step=_unspecified):
+                             first_step=_unspecified, max_step=_unspecified, times_per_seg=_unspecified):
         """
         Set the specified option(s) for grid refinement in the phase.
 
@@ -2421,6 +2422,8 @@ class Phase(om.Group):
             Initial step size for the integration.
         max_step : float
             Maximum step size for the integration.
+        times_per_seg : int
+            The number of time steps to output per segment.
         """
         if method is not _unspecified:
             self.simulate_options['method'] = method
@@ -2432,6 +2435,8 @@ class Phase(om.Group):
             self.simulate_options['first_step'] = first_step
         if max_step is not _unspecified:
             self.simulate_options['max_step'] = max_step
+        if times_per_seg is not _unspecified:
+            self.simulate_options['times_per_seg'] = times_per_seg
 
     def is_time_fixed(self, loc):
         """

--- a/dymos/phase/simulation_phase.py
+++ b/dymos/phase/simulation_phase.py
@@ -37,7 +37,7 @@ class SimulationPhase(Phase):
     **kwargs : dict
         Dictionary of optional phase arguments.
     """
-    def __init__(self, from_phase, times_per_seg=None, method=_unspecified, atol=_unspecified,
+    def __init__(self, from_phase, times_per_seg=_unspecified, method=_unspecified, atol=_unspecified,
                  rtol=_unspecified, first_step=_unspecified, max_step=_unspecified,
                  reports=False, **kwargs):
 
@@ -47,11 +47,14 @@ class SimulationPhase(Phase):
         seg_ends = phase_tx.grid_data.segment_ends
         compressed = phase_tx.grid_data.compressed
 
-        _method = method if method is not _unspecified else from_phase.simulate_options['method']
-        _atol = atol if atol is not _unspecified else from_phase.simulate_options['atol']
-        _rtol = rtol if rtol is not _unspecified else from_phase.simulate_options['rtol']
-        _first_step = first_step if first_step is not _unspecified else from_phase.simulate_options['first_step']
-        _max_step = max_step if max_step is not _unspecified else from_phase.simulate_options['max_step']
+        sim_options = from_phase.simulate_options
+
+        _method = method if method is not _unspecified else sim_options['method']
+        _atol = atol if atol is not _unspecified else sim_options['atol']
+        _rtol = rtol if rtol is not _unspecified else sim_options['rtol']
+        _first_step = first_step if first_step is not _unspecified else sim_options['first_step']
+        _max_step = max_step if max_step is not _unspecified else sim_options['max_step']
+        _times_per_seg = times_per_seg if times_per_seg is not _unspecified else sim_options['times_per_seg']
 
         if isinstance(phase_tx, GaussLobatto):
             grid = GaussLobattoGrid(num_segments=num_seg, nodes_per_seg=seg_order, segment_ends=seg_ends,
@@ -66,10 +69,10 @@ class SimulationPhase(Phase):
             raise RuntimeError(f'Unexpected grid class for {phase_tx.grid_data}. Only phases with GaussLobatto '
                                f'or Radau grids can be simulated.')
 
-        if times_per_seg is None:
+        if _times_per_seg is None:
             output_grid = None
         else:
-            output_grid = UniformGrid(num_segments=num_seg, nodes_per_seg=times_per_seg, segment_ends=seg_ends,
+            output_grid = UniformGrid(num_segments=num_seg, nodes_per_seg=_times_per_seg, segment_ends=seg_ends,
                                       compressed=compressed)
 
         tx = ExplicitShooting(propagate_derivs=False,

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -1353,7 +1353,7 @@ class Trajectory(om.Group):
 
         printer('', file=outstream)
 
-    def simulate(self, times_per_seg=10, method=_unspecified, atol=_unspecified, rtol=_unspecified,
+    def simulate(self, times_per_seg=_unspecified, method=_unspecified, atol=_unspecified, rtol=_unspecified,
                  first_step=_unspecified, max_step=_unspecified, record_file=None, case_prefix=None,
                  reset_iter_counts=True, reports=False):
         """

--- a/dymos/transcriptions/explicit_shooting/explicit_shooting.py
+++ b/dymos/transcriptions/explicit_shooting/explicit_shooting.py
@@ -144,7 +144,6 @@ class ExplicitShooting(TranscriptionBase):
             if t_phase_name not in ts_options['outputs'] and phase.timeseries_options['include_t_phase']:
                 phase.add_timeseries_output(t_phase_name, timeseries=ts_name)
 
-        # if times_per_seg is None:
         # Case 1:  Compute times at 'all' node set.
         num_nodes = self._output_grid_data.num_nodes
         node_ptau = self._output_grid_data.node_ptau


### PR DESCRIPTION
### Summary

The density of output for simulation can now be controlled easily on a phase-by-phase basis.
If `times_per_seg` is given as an option to simulate it still takes precedence.

### Related Issues

- Resolves #992

### Backwards incompatibilities

None

### New Dependencies

None
