### PR TITLE
Reduce memory usage for timeseries jac computation

### DIFF
--- a/dymos/transcriptions/analytic/analytic_timeseries_output_comp.py
+++ b/dymos/transcriptions/analytic/analytic_timeseries_output_comp.py
@@ -9,9 +9,6 @@ from ...utils.lagrange import lagrange_matrices
 from ..common.timeseries_output_comp import TimeseriesOutputCompBase
 
 
-_USE_SPARSE = True
-
-
 class AnalyticTimeseriesOutputComp(TimeseriesOutputCompBase):
     """
     Class definition of the timeseries output comp for AnalyticPhase.
@@ -86,12 +83,8 @@ class AnalyticTimeseriesOutputComp(TimeseriesOutputCompBase):
             L_blocks.append(L)
             D_blocks.append(D)
 
-        if _USE_SPARSE:
-            self.interpolation_matrix = sp.block_diag(L_blocks, format='csr')
-            self.differentiation_matrix = sp.block_diag(D_blocks, format='csr')
-        else:
-            self.interpolation_matrix = block_diag(*L_blocks)
-            self.differentiation_matrix = block_diag(*D_blocks)
+        self.interpolation_matrix = sp.block_diag(L_blocks, format='csr')
+        self.differentiation_matrix = sp.block_diag(D_blocks, format='csr')
 
         self.add_input('dt_dstau', shape=(self.input_num_nodes,), units=self.options['time_units'])
 

--- a/dymos/transcriptions/analytic/analytic_timeseries_output_comp.py
+++ b/dymos/transcriptions/analytic/analytic_timeseries_output_comp.py
@@ -150,35 +150,49 @@ class AnalyticTimeseriesOutputComp(TimeseriesOutputCompBase):
         self._vars[name] = (input_name, output_name, shape, rate)
 
         size = np.prod(shape)
-        jac = np.zeros((output_num_nodes, size, input_num_nodes, size))
 
         if rate:
             mat = self.differentiation_matrix
         else:
             mat = self.interpolation_matrix
 
-        for i in range(size):
-            if _USE_SPARSE:
-                jac[:, i, :, i] = mat.toarray()
-            else:
-                jac[:, i, :, i] = mat
+        # Preallocate lists to hold data for jac
+        jac_data = []
+        jac_indices = []
+        jac_indptr = [0]
 
-        jac = jac.reshape((output_num_nodes * size, input_num_nodes * size), order='C')
+        # Iterate over the dense dimension 'size'
+        for s in range(size):
+            # Extend the data and indices using the CSR attributes of mat
+            jac_data.extend(mat.data)
+            jac_indices.extend(mat.indices + s * input_num_nodes)
+            
+            # For every non-zero row in mat, update jac's indptr
+            new_indptr = mat.indptr[1:] + s * len(mat.data)
+            jac_indptr.extend(new_indptr)
 
-        jac_rows, jac_cols = np.nonzero(jac)
+        # Correct the last entry of jac_indptr
+        jac_indptr[-1] = len(jac_data)
+
+        # Construct the sparse jac matrix in CSR format
+        jac = sp.csr_matrix((jac_data, jac_indices, jac_indptr), shape=(output_num_nodes * size, input_num_nodes * size))
+
+        # Now, if you want to get the row and column indices of the non-zero entries in the jac matrix:
+        jac_rows, jac_cols = jac.nonzero()
 
         # There's a chance that the input for this output was pulled from another variable with
         # different units, so account for that with a conversion.
+        val = np.squeeze(np.array(jac[jac_rows, jac_cols]))
         if input_units is None or units is None:
             self.declare_partials(of=output_name, wrt=input_name,
-                                  rows=jac_rows, cols=jac_cols, val=jac[jac_rows, jac_cols])
+                                  rows=jac_rows, cols=jac_cols, val=val)
         else:
             scale, offset = unit_conversion(input_units, units)
             self._conversion_factors[output_name] = scale, offset
 
             self.declare_partials(of=output_name, wrt=input_name,
                                   rows=jac_rows, cols=jac_cols,
-                                  val=scale * jac[jac_rows, jac_cols])
+                                  val=scale * val)
 
         return added_source
 

--- a/dymos/transcriptions/analytic/analytic_timeseries_output_comp.py
+++ b/dymos/transcriptions/analytic/analytic_timeseries_output_comp.py
@@ -159,7 +159,7 @@ class AnalyticTimeseriesOutputComp(TimeseriesOutputCompBase):
             # Extend the data and indices using the CSR attributes of mat
             jac_data.extend(mat.data)
             jac_indices.extend(mat.indices + s * input_num_nodes)
-            
+
             # For every non-zero row in mat, update jac's indptr
             new_indptr = mat.indptr[1:] + s * len(mat.data)
             jac_indptr.extend(new_indptr)
@@ -168,7 +168,8 @@ class AnalyticTimeseriesOutputComp(TimeseriesOutputCompBase):
         jac_indptr[-1] = len(jac_data)
 
         # Construct the sparse jac matrix in CSR format
-        jac = sp.csr_matrix((jac_data, jac_indices, jac_indptr), shape=(output_num_nodes * size, input_num_nodes * size))
+        jac = sp.csr_matrix((jac_data, jac_indices, jac_indptr),
+                            shape=(output_num_nodes * size, input_num_nodes * size))
 
         # Now, if you want to get the row and column indices of the non-zero entries in the jac matrix:
         jac_rows, jac_cols = jac.nonzero()

--- a/dymos/transcriptions/pseudospectral/components/pseudospectral_timeseries_output_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/pseudospectral_timeseries_output_comp.py
@@ -159,7 +159,7 @@ class PseudospectralTimeseriesOutputComp(TimeseriesOutputCompBase):
             # Extend the data and indices using the CSR attributes of mat
             jac_data.extend(mat.data)
             jac_indices.extend(mat.indices + s * input_num_nodes)
-            
+
             # For every non-zero row in mat, update jac's indptr
             new_indptr = mat.indptr[1:] + s * len(mat.data)
             jac_indptr.extend(new_indptr)
@@ -168,7 +168,8 @@ class PseudospectralTimeseriesOutputComp(TimeseriesOutputCompBase):
         jac_indptr[-1] = len(jac_data)
 
         # Construct the sparse jac matrix in CSR format
-        jac = sp.csr_matrix((jac_data, jac_indices, jac_indptr), shape=(output_num_nodes * size, input_num_nodes * size))
+        jac = sp.csr_matrix((jac_data, jac_indices, jac_indptr),
+                            shape=(output_num_nodes * size, input_num_nodes * size))
 
         # Now, if you want to get the row and column indices of the non-zero entries in the jac matrix:
         jac_rows, jac_cols = jac.nonzero()

--- a/dymos/transcriptions/pseudospectral/components/pseudospectral_timeseries_output_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/pseudospectral_timeseries_output_comp.py
@@ -9,9 +9,6 @@ from ....utils.lagrange import lagrange_matrices
 from ...common.timeseries_output_comp import TimeseriesOutputCompBase
 
 
-_USE_SPARSE = True
-
-
 class PseudospectralTimeseriesOutputComp(TimeseriesOutputCompBase):
     """
     Class definition of the PseudospectralTimeseriesOutputComp.
@@ -86,12 +83,8 @@ class PseudospectralTimeseriesOutputComp(TimeseriesOutputCompBase):
             L_blocks.append(L)
             D_blocks.append(D)
 
-        if _USE_SPARSE:
-            self.interpolation_matrix = sp.block_diag(L_blocks, format='csr')
-            self.differentiation_matrix = sp.block_diag(D_blocks, format='csr')
-        else:
-            self.interpolation_matrix = block_diag(*L_blocks)
-            self.differentiation_matrix = block_diag(*D_blocks)
+        self.interpolation_matrix = sp.block_diag(L_blocks, format='csr')
+        self.differentiation_matrix = sp.block_diag(D_blocks, format='csr')
 
         self.add_input('dt_dstau', shape=(self.input_num_nodes,), units=self.options['time_units'])
 


### PR DESCRIPTION
### Summary

After a good amount of digging into cases that scaled poorly as number of procs increased, I found a `toarray()` call that was turning a sparse array into a dense before going back to sparse. In the case of @kanekosh's run script with relatively high `num_segments` and a memory-expensive parallel ODE, this caused a large increase in memory usage during `setup()`.

This new implementation keeps the jac in sparse format throughout. I've changed it in the two places where it happened -- and maybe those files could be combined into one? Or @robfalck were they two separate files on purpose?

Prior `setup()` mem usage:
![without_fix](https://github.com/OpenMDAO/dymos/assets/16373529/1869acee-24cc-49bb-b8ee-ee1d5d12292e)

Mem usage for `setup()` with the fix:
![with_fix](https://github.com/OpenMDAO/dymos/assets/16373529/805fa2fb-6bca-44e9-8a2f-f5b568acdb71)

This PR does not address potentially large memory usage in `final_setup()` as that is a separate but related issue regarding how `PETScVectors` are created and used. We should further discuss if we have action items there.

### Related Issues

- Resolves OpenMDAO/OpenMDAO#3012

### Backwards incompatibilities

None

### New Dependencies

None