### PR TITLE
fixed load_case logic to correctly handle negative-duration phases

### DIFF
--- a/dymos/examples/finite_burn_orbit_raise/test/test_multi_phase_restart.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_multi_phase_restart.py
@@ -14,7 +14,6 @@ from dymos.utils.testing_utils import assert_cases_equal
 @use_tempdirs
 class TestExampleTwoBurnOrbitRaiseConnectedRestart(unittest.TestCase):
 
-    @unittest.skip('Skipped due to a change in interpolation in scipy. Need to come up with better case loading.')
     def test_ex_two_burn_orbit_raise_connected(self):
         optimizer = 'IPOPT'
 
@@ -73,7 +72,6 @@ class TestExampleTwoBurnOrbitRaiseConnectedRestart(unittest.TestCase):
 @use_tempdirs
 class TestExampleTwoBurnOrbitRaiseConnected(unittest.TestCase):
 
-    @unittest.skip('Skipped due to a change in interpolation in scipy. Need to come up with better case loading.')
     def test_ex_two_burn_orbit_raise_connected(self):
         optimizer = 'IPOPT'
 
@@ -100,7 +98,6 @@ class TestExampleTwoBurnOrbitRaiseConnected(unittest.TestCase):
         assert_cases_equal(case1, p, tol=1.0E-8)
         assert_cases_equal(sim_case1, sim_case2, tol=1.0E-8)
 
-    @unittest.skip('Skipped due to a change in interpolation in scipy. Need to come up with better case loading.')
     def test_restart_from_solution_radau_to_connected(self):
         optimizer = 'IPOPT'
 

--- a/dymos/load_case.py
+++ b/dymos/load_case.py
@@ -132,11 +132,15 @@ def load_case(problem, previous_solution, deprecation_warning=True):
             continue
 
         prev_time_val = prev_vars[prev_time_path]['val']
+        t_initial = prev_time_val[0]
+        t_duration = prev_time_val[-1] - prev_time_val[0]
         prev_time_val, unique_idxs = np.unique(prev_time_val, return_index=True)
         prev_time_units = prev_vars[prev_time_path]['units']
 
-        t_initial = prev_time_val[0]
-        t_duration = prev_time_val[-1] - prev_time_val[0]
+        if t_duration < 0:
+            # Unique sorts the data. In reverse-time phases, we need to undo it.
+            prev_time_val = np.flip(prev_time_val, axis=0)
+            unique_idxs = np.flip(unique_idxs, axis=0)
 
         ti_path = [s for s in phase_vars.keys() if s.endswith(f'{phase_name}.t_initial')]
         if ti_path:

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -2733,13 +2733,17 @@ class Phase(om.Group):
 
         prev_timeseries_prom_path, _, _ = prev_time_path.rpartition(f'.{integration_name}')
         prev_phase_prom_path, _, _ = prev_timeseries_prom_path.rpartition('.timeseries')
-
         prev_time_val = prev_vars[prev_time_path]['val']
-        prev_time_val, unique_idxs = np.unique(prev_time_val, return_index=True)
-        prev_time_units = prev_vars[prev_time_path]['units']
 
         t_initial = prev_time_val[0]
         t_duration = prev_time_val[-1] - prev_time_val[0]
+        prev_time_val, unique_idxs = np.unique(prev_time_val, return_index=True)
+        prev_time_units = prev_vars[prev_time_path]['units']
+
+        if t_duration < 0:
+            # Unique sorts the data. In reverse-time phases, we need to undo it.
+            prev_time_val = np.flip(prev_time_val, axis=0)
+            unique_idxs = np.flip(unique_idxs, axis=0)
 
         self.set_val('t_initial', t_initial, units=prev_time_units)
         self.set_val('t_duration', t_duration, units=prev_time_units)


### PR DESCRIPTION
### Summary

* `Phase.load_case` did not handle negative-duration cases correctly.
* The use of `np.unique` in the method sorts the previous phase time values, which caused the time values and the corresponding unique indices to be reversed.
* Tests that were previously skipped due to this issue have been enabled.

### Related Issues

- Resolves #1006

### Backwards incompatibilities

None

### New Dependencies

None
