### PR TITLE
Rmove IVCs from control groups

### DIFF
--- a/dymos/transcriptions/common/control_group.py
+++ b/dymos/transcriptions/common/control_group.py
@@ -327,11 +327,6 @@ class ControlGroup(om.Group):
         if len(control_options) < 1:
             return
 
-        opt_controls = [name for name, opts in control_options.items() if opts['opt']]
-
-        if len(opt_controls) > 0:
-            self.add_subsystem('indep_controls', subsys=om.IndepVarComp(), promotes_outputs=['*'])
-
         self.add_subsystem(
             'control_interp_comp',
             subsys=ControlInterpComp(time_units=time_units, grid_data=gd, output_grid_data=ogd,
@@ -381,12 +376,4 @@ class ControlGroup(om.Group):
 
             default_val = reshape_val(options['val'], shape, num_input_nodes)
 
-            ivc = self._get_subsystem('indep_controls')
-            if ivc:
-                ivc.add_output(name=dvname,
-                               val=default_val,
-                               shape=(num_input_nodes,) + shape,
-                               units=options['units'])
-
-            # TODO: When the AutoIVC/MPI issue is fixed in OpenMDAO, replace IVC with following
-            # self.set_input_defaults(name=dvname, val=default_val, units=options['units'])
+            self.set_input_defaults(name=dvname, val=default_val, units=options['units'])

--- a/dymos/transcriptions/common/polynomial_control_group.py
+++ b/dymos/transcriptions/common/polynomial_control_group.py
@@ -238,17 +238,6 @@ class PolynomialControlGroup(om.Group):
         opts = self.options
 
         # Pull out the interpolated controls
-        num_opt = 0
-        for options in opts['polynomial_control_options'].values():
-            if options['order'] < 1:
-                raise ValueError('Interpolation order must be >= 1 (linear)')
-            if options['opt']:
-                num_opt += 1
-
-        if num_opt > 0:
-            self.add_subsystem('indep_polynomial_controls', subsys=om.IndepVarComp(),
-                               promotes_outputs=['*'])
-
         self.add_subsystem(
             'interp_comp',
             subsys=LGLPolynomialControlComp(time_units=opts['time_units'],
@@ -291,12 +280,4 @@ class PolynomialControlGroup(om.Group):
                                     indices=desvar_indices,
                                     flat_indices=True)
 
-            ivc = self._get_subsystem('indep_polynomial_controls')
-            if ivc:
-                ivc.add_output(f'polynomial_controls:{name}',
-                               shape=(num_input_nodes,) + shape,
-                               val=default_val,
-                               units=options['units'])
-
-            # TODO: Remove IVC and use following code instead.
-            # self.set_input_defaults(name=f'polynomial_controls:{name}', val=default_val, units=options['units'])
+            self.set_input_defaults(name=f'polynomial_controls:{name}', val=default_val, units=options['units'])


### PR DESCRIPTION
### Summary

Removed IVCs from control and polynomial control groups. Auto-IVC means we no longer need them

### Related Issues

- Resolves #1012 

### Backwards incompatibilities

None

### New Dependencies

None
