### PR TITLE
Fix for Vanderpol example under updated OpenMDAO MPI operation.

### DIFF
--- a/dymos/examples/finite_burn_orbit_raise/test/test_multi_phase_restart.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_multi_phase_restart.py
@@ -4,8 +4,7 @@ import warnings
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal, assert_warnings, assert_no_warning
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
-from openmdao.utils.mpi import MPI
-import scipy
+from openmdao.utils.mpi import MPI, multi_proc_exception_check
 
 from dymos.examples.finite_burn_orbit_raise.finite_burn_orbit_raise_problem import two_burn_orbit_raise_problem
 from dymos.utils.testing_utils import assert_cases_equal
@@ -25,9 +24,10 @@ class TestExampleTwoBurnOrbitRaiseConnectedRestart(unittest.TestCase):
                                          compressed=False, optimizer=optimizer,
                                          show_output=False, connected=True)
 
-        if p.model.traj.phases.burn2 in p.model.traj.phases._subsystems_myproc:
-            assert_near_equal(p.get_val('traj.burn2.states:deltav')[0], 0.3995,
-                              tolerance=4.0E-3)
+        with multi_proc_exception_check(p.comm):
+            if p.model.traj.phases.burn2 in p.model.traj.phases._subsystems_myproc:
+                assert_near_equal(p.get_val('traj.burn2.states:deltav')[0], 0.3995,
+                                  tolerance=4.0E-3)
 
         case1 = om.CaseReader('dymos_solution.db').get_case('final')
         sim_case1 = om.CaseReader('dymos_simulation.db').get_case('final')
@@ -54,9 +54,10 @@ class TestExampleTwoBurnOrbitRaiseConnectedRestart(unittest.TestCase):
         case1 = om.CaseReader('dymos_solution.db').get_case('final')
         sim_case1 = om.CaseReader('dymos_simulation.db').get_case('final')
 
-        if p.model.traj.phases.burn2 in p.model.traj.phases._subsystems_myproc:
-            assert_near_equal(p.get_val('traj.burn2.states:deltav')[-1], 0.3995,
-                              tolerance=2.0E-3)
+        with multi_proc_exception_check(p.comm):
+            if p.model.traj.phases.burn2 in p.model.traj.phases._subsystems_myproc:
+                assert_near_equal(p.get_val('traj.burn2.states:deltav')[-1], 0.3995,
+                                  tolerance=2.0E-3)
 
         # Run again without an actual optimzier
         two_burn_orbit_raise_problem(transcription='radau', transcription_order=3,
@@ -101,9 +102,10 @@ class TestExampleTwoBurnOrbitRaiseConnected(unittest.TestCase):
                 if (issubclass(warn.category, category) and str(warn.message) == msg):
                     raise AssertionError(f"Saw unexpected warning {category.__name__}: {msg}")
 
-        if p.model.traj.phases.burn2 in p.model.traj.phases._subsystems_myproc:
-            assert_near_equal(p.get_val('traj.burn2.states:deltav')[0], 0.3995,
-                              tolerance=4.0E-3)
+        with multi_proc_exception_check(p.comm):
+            if p.model.traj.phases.burn2 in p.model.traj.phases._subsystems_myproc:
+                assert_near_equal(p.get_val('traj.burn2.states:deltav')[0], 0.3995,
+                                  tolerance=4.0E-3)
 
         case1 = om.CaseReader('dymos_solution.db').get_case('final')
         sim_case1 = om.CaseReader('dymos_simulation.db').get_case('final')
@@ -117,7 +119,7 @@ class TestExampleTwoBurnOrbitRaiseConnected(unittest.TestCase):
 
         case2 = om.CaseReader('dymos_solution2.db').get_case('final')
         sim_case2 = om.CaseReader('dymos_simulation2.db').get_case('final')
-#
+
         # Verify that the second case has the same inputs and outputs
         assert_cases_equal(case1, case2, tol=1.0E-8)
         assert_cases_equal(sim_case1, sim_case2, tol=1.0E-8)
@@ -130,9 +132,10 @@ class TestExampleTwoBurnOrbitRaiseConnected(unittest.TestCase):
                                          compressed=False, optimizer=optimizer,
                                          show_output=False, connected=True)
 
-        if p.model.traj.phases.burn2 in p.model.traj.phases._subsystems_myproc:
-            assert_near_equal(p.get_val('traj.burn2.states:deltav')[0], 0.3995,
-                              tolerance=4.0E-3)
+        with multi_proc_exception_check(p.comm):
+            if p.model.traj.phases.burn2 in p.model.traj.phases._subsystems_myproc:
+                assert_near_equal(p.get_val('traj.burn2.states:deltav')[0], 0.3995,
+                                  tolerance=4.0E-3)
 
         case1 = om.CaseReader('dymos_solution.db').get_case('final')
         sim_case1 = om.CaseReader('dymos_simulation.db').get_case('final')

--- a/dymos/examples/vanderpol/doc/test_doc_vanderpol.py
+++ b/dymos/examples/vanderpol/doc/test_doc_vanderpol.py
@@ -1,8 +1,12 @@
 import os
 import unittest
 
+import openmdao
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.mpi import MPI
+
+
+om_version = tuple([int(s) for s in openmdao.__version__.split('-')[0].split('.')])
 
 
 @use_tempdirs
@@ -21,6 +25,7 @@ class TestVanderpolForDocs(unittest.TestCase):
 
         dm.run_problem(p, run_driver=False, simulate=True, make_plots=True)
 
+    @unittest.skipIf(om_version < (3, 29, 0), 'Test requires OpenMDAO 3.29.0 or later')
     def test_vanderpol_for_docs_optimize(self):
         import dymos as dm
         from dymos.examples.vanderpol.vanderpol_dymos import vanderpol
@@ -31,6 +36,7 @@ class TestVanderpolForDocs(unittest.TestCase):
 
         dm.run_problem(p, simulate=True, make_plots=True)
 
+    @unittest.skipIf(om_version < (3, 29, 0), 'Test requires OpenMDAO 3.29.0 or later')
     def test_vanderpol_for_docs_optimize_refine(self):
         import dymos as dm
         from dymos.examples.vanderpol.vanderpol_dymos import vanderpol
@@ -56,6 +62,7 @@ class TestVanderpolForDocs(unittest.TestCase):
 class TestVanderpolDelayMPI(unittest.TestCase):
     N_PROCS = 2
 
+    @unittest.skipIf(om_version < (3, 29, 0), 'Test requires OpenMDAO 3.29.0 or later')
     def test_vanderpol_delay_mpi(self):
         import openmdao.api as om
         import dymos as dm

--- a/dymos/examples/vanderpol/test/test_vanderpol.py
+++ b/dymos/examples/vanderpol/test/test_vanderpol.py
@@ -2,11 +2,15 @@ import unittest
 from numpy.testing import assert_almost_equal
 import numpy as np
 
+import openmdao
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from openmdao.utils.mpi import MPI
 
 import dymos as dm
 from dymos.examples.vanderpol.vanderpol_dymos import vanderpol
+
+
+om_version = tuple([int(s) for s in openmdao.__version__.split('-')[0].split('.')])
 
 
 @use_tempdirs
@@ -16,14 +20,15 @@ class TestVanderpolExample(unittest.TestCase):
         p = vanderpol(transcription='gauss-lobatto', num_segments=75)
         p.run_model()
 
+    @unittest.skipIf(om_version < (3, 29, 0), 'Test requires OpenMDAO 3.29.0 or later')
     @require_pyoptsparse(optimizer='IPOPT')
     def test_vanderpol_simulate_true(self):
-        # simulate true
         p = vanderpol(transcription='radau-ps', num_segments=30, transcription_order=3,
                       compressed=True, optimizer='IPOPT', delay=0.005, distrib=True, use_pyoptsparse=True)
 
         dm.run_problem(p, run_driver=True, simulate=True)
 
+    @unittest.skipIf(om_version < (3, 29, 0), 'Test requires OpenMDAO 3.29.0 or later')
     def test_vanderpol_optimal(self):
         p = vanderpol(transcription='gauss-lobatto', num_segments=75)
         dm.run_problem(p)  # find optimal control solution to stop oscillation
@@ -34,6 +39,7 @@ class TestVanderpolExample(unittest.TestCase):
         assert_almost_equal(p.get_val('traj.phase0.states:x1')[-1, ...], np.zeros(1))
         assert_almost_equal(p.get_val('traj.phase0.controls:u')[-1, ...], np.zeros(1), decimal=3)
 
+    @unittest.skipIf(om_version < (3, 29, 0), 'Test requires OpenMDAO 3.29.0 or later')
     def test_vanderpol_optimal_grid_refinement(self):
         # enabling grid refinement gives a faster and better solution with fewer segments
         p = vanderpol(transcription='gauss-lobatto', num_segments=15)
@@ -53,6 +59,7 @@ class TestVanderpolExampleMPI(unittest.TestCase):
 
     N_PROCS = 4
 
+    @unittest.skipIf(om_version < (3, 29, 0), 'Test requires OpenMDAO 3.29.0 or later')
     @require_pyoptsparse(optimizer='IPOPT')
     @unittest.skipUnless(MPI, 'this test requires MPI')
     def test_vanderpol_optimal_mpi(self):

--- a/dymos/examples/vanderpol/vanderpol_dymos.py
+++ b/dymos/examples/vanderpol/vanderpol_dymos.py
@@ -20,7 +20,7 @@ def vanderpol(transcription='gauss-lobatto', num_segments=40, transcription_orde
         if optimizer == 'SNOPT':
             p.driver.opt_settings['iSumm'] = 6  # show detailed SNOPT output
         elif optimizer == 'IPOPT':
-            p.driver.opt_settings['print_level'] = 0
+            p.driver.opt_settings['print_level'] = 1
     p.driver.declare_coloring()
 
     # define a Trajectory object and add to model
@@ -76,7 +76,7 @@ def vanderpol(transcription='gauss-lobatto', num_segments=40, transcription_orde
     phase.add_objective('J', loc='final')
 
     # setup the problem
-    p.setup(check=True)
+    p.setup(check=True, force_alloc_complex=True)
 
     p['traj.phase0.t_initial'] = 0.0
     p['traj.phase0.t_duration'] = t_final


### PR DESCRIPTION
### Summary

Vanderpol has distributed outputs and nondistributed inputs and therefore is _required_ to have matrix-free partials.

### Related Issues

- Resolves #1024

### Backwards incompatibilities

None

### New Dependencies

None
