### PR TITLE
Removed Python version check from setup.py

### DIFF
--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -166,15 +166,6 @@ jobs:
             python -m pip install jaxlib==${{ matrix.JAX }} jax==${{ matrix.JAX }}
           fi
 
-      - name: Install greenlet
-        if: env.NAME == 'latest'
-        shell: bash -l {0}
-        run: |
-          echo "============================================================="
-          echo "Install greenlet from wheels"
-          echo "============================================================="
-          pip install --only-binary :all: greenlet
-
       - name: Install PETSc
         if: env.RUN_BUILD && matrix.PETSc
         shell: bash -l {0}
@@ -256,7 +247,7 @@ jobs:
           if [[ "${{ matrix.OPENMDAO }}" == "dev" ]]; then
             pip install git+https://github.com/OpenMDAO/OpenMDAO
           elif [[ "${{ matrix.OPENMDAO }}" == "latest" ]]; then
-            pip install openmdao
+            echo "The latest version OpenMDAO will be installed from pypi per the Dymos dependency"
           else
             pip install openmdao==${{ matrix.OPENMDAO }}
           fi

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-from packaging.version import Version
-from platform import python_version
 from setuptools import find_packages, setup
 
 # Setup optional dependencies
@@ -29,12 +27,10 @@ optional_dependencies = {
         'testflo>=1.3.6',
         'matplotlib',
         'numpydoc>=1.1',
+        'playwright>=1.20',
+        'aiounittest'
     ]
 }
-
-# playwright dependencies are currently incompatible with python 3.12
-if Version(python_version()) < Version('3.12.0'):
-    optional_dependencies['test'].extend(['playwright>=1.20', 'aiounittest'])
 
 # Add an optional dependency that concatenates all others
 optional_dependencies['all'] = sorted([


### PR DESCRIPTION
### Summary

Removed Python version check from setup.py

- special handling of playwright testing dependencies is no longer required for Python 3.12
- changed the test workflow to resolve the latest version of OpenMDAO from setup.py rather than pre-installing it

### Related Issues

- Resolves #1026

### Backwards incompatibilities

None

### New Dependencies

None
