### PR TITLE
Fixed an issue where matplotlib was not required to install dymos without specifications but would fail to import.

### DIFF
--- a/dymos/examples/brachistochrone/test/ex_brachistochrone.py
+++ b/dymos/examples/brachistochrone/test/ex_brachistochrone.py
@@ -1,4 +1,3 @@
-import matplotlib
 import numpy as np
 
 import openmdao.api as om
@@ -6,10 +5,6 @@ from openmdao.utils.testing_utils import require_pyoptsparse
 
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
-
-
-SHOW_PLOTS = True
-matplotlib.use('Agg')
 
 
 @require_pyoptsparse(optimizer='SLSQP')

--- a/dymos/examples/cart_pole/animate_cartpole.py
+++ b/dymos/examples/cart_pole/animate_cartpole.py
@@ -1,10 +1,11 @@
 import numpy as np
-import matplotlib.pyplot as plt
-import matplotlib.patches as patches
-from matplotlib import animation
 
 
 def animate_cartpole(x, theta, force, interval=20, force_scaler=0.1, save_gif=False, gif_fps=20):
+
+    import matplotlib.pyplot as plt
+    import matplotlib.patches as patches
+    from matplotlib import animation
     # x: time history of cart location, 1d vector
     # theta: time history of pole angle, 1d vector
     # force: control input force

--- a/dymos/examples/plotting.py
+++ b/dymos/examples/plotting.py
@@ -1,6 +1,3 @@
-import matplotlib.pyplot as plt
-
-
 def plot_results(axes, title, figsize=(10, 8), p_sol=None, p_sim=None):
     """
     Plot the timeseries results of a Dymos problem using matplotlib.
@@ -22,6 +19,8 @@ def plot_results(axes, title, figsize=(10, 8), p_sol=None, p_sim=None):
         The Figure object and sequence of axes associated with the plot.
 
     """
+    import matplotlib.pyplot as plt
+
     nrows = len(axes)
 
     fig, axs = plt.subplots(nrows=nrows, ncols=1, figsize=figsize)

--- a/dymos/visualization/timeseries_plots.py
+++ b/dymos/visualization/timeseries_plots.py
@@ -4,11 +4,6 @@ import pathlib
 
 import numpy as np
 
-import matplotlib
-import matplotlib.pyplot as plt
-import matplotlib.lines as mlines
-import matplotlib.patches as mpatches
-
 import openmdao.api as om
 from .._options import options as dymos_options
 
@@ -55,6 +50,11 @@ def _get_phases_node_in_problem_metadata(node, path=""):
 def _mpl_timeseries_plots(time_units, var_units, phase_names, phases_node_path,
                           last_solution_case, last_simulation_case, plot_dir_path,
                           dpi, include_parameters):
+    import matplotlib
+    import matplotlib.pyplot as plt
+    import matplotlib.lines as mlines
+    import matplotlib.patches as mpatches
+
     # get ready to plot
     backend_save = plt.get_backend()
     plt.switch_backend('Agg')


### PR DESCRIPTION
### Summary

There were some "bare" imports of matplotlib in the dymos source code that would be executed when `import dymos` was invoked. Since basic dymos usage doesn't require matplotlib, it was not listed as a prerequisite except when a modifier like `pip install dymos[tests]` were used.

These bare imports have been moved into more local scopes where they will cause import errors if those particular methods or functions are invoked, but importing dymos will proceed without issue.

### Related Issues

- Resolves #1025 

### Backwards incompatibilities

None

### New Dependencies

None
