### PR TITLE
Updated GitHub workflow to use only the conda-forge channel for dependencies

### DIFF
--- a/.github/workflows/dymos_docs_workflow.yml
+++ b/.github/workflows/dymos_docs_workflow.yml
@@ -83,8 +83,7 @@ jobs:
         with:
           python-version: ${{ matrix.PY }}
           conda-version: "*"
-          channels: conda-forge,defaults
-          channel-priority: true
+          channels: conda-forge
 
       - name: Install Numpy/Scipy
         shell: bash -l {0}

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -141,8 +141,7 @@ jobs:
         with:
           python-version: ${{ matrix.PY }}
           conda-version: "*"
-          channels: conda-forge,defaults
-          channel-priority: true
+          channels: conda-forge
 
       - name: Install Numpy/Scipy
         if: env.RUN_BUILD


### PR DESCRIPTION
### Summary

Made the following changes to the GitHub workflows:

- restricted miniconda to use just the `conda-forge` channel to avoid running afoul of Anaconda licensing

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
