### PR TITLE
Fixed issue with running trajectory timeseries report under MPI

### DIFF
--- a/dymos/examples/finite_burn_orbit_raise/finite_burn_orbit_raise_problem.py
+++ b/dymos/examples/finite_burn_orbit_raise/finite_burn_orbit_raise_problem.py
@@ -296,7 +296,31 @@ def two_burn_orbit_raise_problem(transcription='gauss-lobatto', optimizer='SLSQP
             p.set_val('traj.burn2.controls:u1', val=burn2.interp('u1', [0, 0]))
 
     if run_driver or simulate:
-        dm.run_problem(p, run_driver=run_driver, simulate=simulate, restart=restart, make_plots=False,
+        dm.run_problem(p, run_driver=run_driver, simulate=simulate, restart=restart, make_plots=True,
                        solution_record_file=solution_record_file, simulation_record_file=simulation_record_file)
 
     return p
+
+
+if __name__ == '__main__':  # pragma: no cover
+
+    import openmdao.api as om
+    from openmdao.utils.assert_utils import assert_near_equal
+
+    optimizer = 'IPOPT'
+
+    CONNECTED = False
+
+    p = two_burn_orbit_raise_problem(transcription='gauss-lobatto', transcription_order=3,
+                                        compressed=False, optimizer=optimizer, simulate=True,
+                                        connected=CONNECTED, show_output=False)
+
+    sol_case = om.CaseReader('dymos_solution.db').get_case('final')
+    sim_case = om.CaseReader('dymos_simulation.db').get_case('final')
+
+    # The last phase in this case is run in reverse time if CONNECTED=True,
+    # so grab the correct index to test the resulting delta-V.
+    end_idx = 0 if CONNECTED else -1
+
+    assert_near_equal(sol_case.get_val('traj.burn2.timeseries.deltav')[end_idx], 0.3995, tolerance=2.0E-3)
+    assert_near_equal(sim_case.get_val('traj.burn2.timeseries.deltav')[end_idx], 0.3995, tolerance=2.0E-3)

--- a/dymos/examples/finite_burn_orbit_raise/finite_burn_orbit_raise_problem.py
+++ b/dymos/examples/finite_burn_orbit_raise/finite_burn_orbit_raise_problem.py
@@ -312,8 +312,8 @@ if __name__ == '__main__':  # pragma: no cover
     CONNECTED = False
 
     p = two_burn_orbit_raise_problem(transcription='gauss-lobatto', transcription_order=3,
-                                        compressed=False, optimizer=optimizer, simulate=True,
-                                        connected=CONNECTED, show_output=False)
+                                     compressed=False, optimizer=optimizer, simulate=True,
+                                     connected=CONNECTED, show_output=False)
 
     sol_case = om.CaseReader('dymos_solution.db').get_case('final')
     sim_case = om.CaseReader('dymos_simulation.db').get_case('final')

--- a/dymos/visualization/timeseries/bokeh_timeseries_report.py
+++ b/dymos/visualization/timeseries/bokeh_timeseries_report.py
@@ -213,7 +213,7 @@ def _get_model_options_from_problem(problem: Problem, syspath: str, rank=0):
     return system_options
 
 
-def _get_traj_and_phases_from_problem(problem, rank: int=0):
+def _get_traj_and_phases_from_problem(problem, rank: int = 0):
     """Retrieve a dictionary tree structure of all trajectories and phases in the problem.
 
     Parameters
@@ -245,11 +245,13 @@ def _get_traj_and_phases_from_problem(problem, rank: int=0):
                     trajs[traj_path]['phases'][phase_path] = {'name': phase_path.split('.')[-1]}
                     for opt in ('time_options', 'parameter_options', 'state_options',
                                 'control_options', 'polynomial_control_options'):
-                         trajs[traj_path]['phases'][phase_path][opt] = poptions[opt]
+                        trajs[traj_path]['phases'][phase_path][opt] = poptions[opt]
 
     return trajs
 
-def _get_trajs_and_phases_from_cr(cr, problem=None):
+
+# TODO: Enable this function when system methods are correctly stored under MPI
+def _get_trajs_and_phases_from_cr(cr, problem=None):  # pragma: no cover
     """Retrieve dictionaries of the trajectories and phases from the given case reader and problem.
 
     Due to a bug in OpenMDAO, model options may not be available from the case reader. In this case,
@@ -290,11 +292,11 @@ def _get_trajs_and_phases_from_cr(cr, problem=None):
                 phase_path = pn['path']
                 phase_options = _get_model_options_from_cr(cr=cr, syspath=phase_path)
                 phase_meta = trajs[traj_path]['phases'][phase_path] = {'time_options': None,
-                                                                    'parameter_options': None,
-                                                                    'state_options': None,
-                                                                    'control_options': None,
-                                                                    'polynomial_control_options': None,
-                                                                    'name': pn['name']}
+                                                                       'parameter_options': None,
+                                                                       'state_options': None,
+                                                                       'control_options': None,
+                                                                       'polynomial_control_options': None,
+                                                                       'name': pn['name']}
                 phase_meta['time_options'] = phase_options['time_options']
                 phase_meta['parameter_options'] = phase_options['parameter_options']
                 phase_meta['state_options'] = phase_options['state_options']
@@ -501,10 +503,10 @@ def make_timeseries_report(prob, solution_record_file=None, simulation_record_fi
                     TableColumn(field='units', title='Units'),
                 ]
                 param_tables.append(DataTable(source=ColumnDataSource(param_data),
-                                            columns=columns,
-                                            index_position=None,
-                                            height=30*len(param_data['param']),
-                                            sizing_mode='stretch_both'))
+                                              columns=columns,
+                                              index_position=None,
+                                              height=30*len(param_data['param']),
+                                              sizing_mode='stretch_both'))
 
             # Plot the timeseries
             ts_units_dict = source_data[traj_name]['timeseries_units']
@@ -518,14 +520,14 @@ def make_timeseries_report(prob, solution_record_file=None, simulation_record_fi
                 tool_tips = [(f'{x_name}', '$x'), (f'{var_name}', '$y')]
 
                 fig = figure(tools='pan,box_zoom,xwheel_zoom,hover,undo,reset,save',
-                            tooltips=tool_tips,
-                            x_axis_label=f'{x_name} ({ts_units_dict[x_name]})',
-                            y_axis_label=f'{var_name} ({ts_units_dict[var_name]})',
-                            toolbar_location='above',
-                            sizing_mode='stretch_both',
-                            min_height=250, max_height=300,
-                            margin=margin,
-                            **fig_kwargs)
+                             tooltips=tool_tips,
+                             x_axis_label=f'{x_name} ({ts_units_dict[x_name]})',
+                             y_axis_label=f'{var_name} ({ts_units_dict[var_name]})',
+                             toolbar_location='above',
+                             sizing_mode='stretch_both',
+                             min_height=250, max_height=300,
+                             margin=margin,
+                             **fig_kwargs)
                 fig.xaxis.axis_label_text_font_size = '10pt'
                 fig.yaxis.axis_label_text_font_size = '10pt'
                 fig.toolbar.autohide = True
@@ -565,27 +567,25 @@ def make_timeseries_report(prob, solution_record_file=None, simulation_record_fi
 
             sol_sim_row = row(children=[Div(text='Display data:', sizing_mode='stretch_height'),
                                         sol_sim_toggle],
-                            sizing_mode='stretch_both',
-                            max_height=50)
+                              sizing_mode='stretch_both',
+                              max_height=50)
 
             phase_select = MultiChoice(options=[phase_name for phase_name in phase_names],
-                                    value=[phase_name for phase_name in phase_names],
-                                    sizing_mode='stretch_both',
-                                    min_width=400, min_height=50)
+                                       value=[phase_name for phase_name in phase_names],
+                                       sizing_mode='stretch_both',
+                                       min_width=400, min_height=50)
 
             phase_select_row = row(children=[Div(text='Plot phases:'), phase_select],
-                                sizing_mode='stretch_width')
+                                   sizing_mode='stretch_width')
 
             figures_grid = grid(children=figures, ncols=ncols, sizing_mode='stretch_both')
 
-            ts_layout = column(children=[sol_sim_row,
-                                        phase_select_row,
-                                        figures_grid],
-                            sizing_mode='stretch_both')
+            ts_layout = column(children=[sol_sim_row, phase_select_row, figures_grid],
+                               sizing_mode='stretch_both')
 
             tab_panes = Tabs(tabs=[TabPanel(child=ts_layout, title='Timeseries')] + param_panels,
-                            sizing_mode='stretch_both',
-                            active=0)
+                             sizing_mode='stretch_both',
+                             active=0)
 
             summary = rf'Results of {prob._name}<br>Creation Date: {datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")}'
 
@@ -595,17 +595,17 @@ def make_timeseries_report(prob, solution_record_file=None, simulation_record_fi
 
             sol_sim_toggle.js_on_change("active",
                                         CustomJS(code=_js_show_figures,
-                                                args=dict(figures=figures,
-                                                        sol_sim_toggle=sol_sim_toggle,
-                                                        phase_select=phase_select)))
+                                                 args=dict(figures=figures,
+                                                           sol_sim_toggle=sol_sim_toggle,
+                                                           phase_select=phase_select)))
 
             phase_select.js_on_change("value",
-                                    CustomJS(code=_js_show_figures,
-                                            args=dict(figures=figures,
-                                                        sol_sim_toggle=sol_sim_toggle,
-                                                        phase_select=phase_select)))
+                                      CustomJS(code=_js_show_figures,
+                                               args=dict(figures=figures,
+                                                         sol_sim_toggle=sol_sim_toggle,
+                                                         phase_select=phase_select)))
 
             # Save
 
             save(report_layout, filename=report_path, title=f'trajectory results for {traj_name}',
-                resources=bokeh_resources.INLINE)
+                 resources=bokeh_resources.INLINE)

--- a/dymos/visualization/timeseries/bokeh_timeseries_report.py
+++ b/dymos/visualization/timeseries/bokeh_timeseries_report.py
@@ -148,7 +148,7 @@ def _get_traj_and_phases_from_problem(problem, rank: int = 0):
         A dictionary for each trajectory containing its parameter options dictionary and
         a subdictionary of phases and their associated options. Under MPI, this dictionary
     """
-    comm_rank = MPI.COMM_WORLD.rank
+    comm_rank = 0 if MPI is None else MPI.COMM_WORLD.rank
     traj_options = _gather_system_options(problem.model, sys_cls=Trajectory, rank=rank)
     phase_options = _gather_system_options(problem.model, sys_cls=Phase, rank=rank)
 
@@ -342,8 +342,8 @@ def _gather_system_options(model, sys_cls=None, rank=0):
         The rank onto which the system options shoud be gathered. The retured
         dictionary of system options will only be valid on this rank.
     """
-    comm_size = MPI.COMM_WORLD.size
-    comm_rank = MPI.COMM_WORLD.rank
+    comm_size = 1 if MPI is None else MPI.COMM_WORLD.size
+    comm_rank = 0 if MPI is None else MPI.COMM_WORLD.rank
 
     system_options = {}
     for subsys in model.system_iter(include_self=True, recurse=True, typ=sys_cls):
@@ -380,7 +380,7 @@ def make_timeseries_report(prob, solution_record_file=None, simulation_record_fi
     theme : str
         A valid bokeh theme name to style the report.
     """
-    comm_rank = MPI.COMM_WORLD.rank
+    comm_rank = 0 if MPI is None else MPI.COMM_WORLD.rank
     report_dir = Path(prob.get_reports_dir()) if prob is not None else Path(os.getcwd())
     if not report_dir.exists():
         report_dir = Path(os.getcwd())

--- a/dymos/visualization/timeseries/bokeh_timeseries_report.py
+++ b/dymos/visualization/timeseries/bokeh_timeseries_report.py
@@ -1,7 +1,12 @@
+from collections import ChainMap
 import datetime
 from pathlib import Path
 import os.path
+from threading import local
 from numpy import isin
+
+from dymos.trajectory.trajectory import Trajectory
+from dymos.phase.phase import Phase
 
 try:
     from bokeh.io import output_notebook, output_file, save, show
@@ -16,8 +21,11 @@ except ImportError:
     _NO_BOKEH = True
 
 import openmdao.api as om
+from openmdao.core.problem import Problem
+from openmdao.core.system import System
 from openmdao.utils.units import conversion_to_base_units
-from openmdao.recorders.sqlite_recorder import format_version, META_KEY_SEP
+from openmdao.utils.mpi import MPI
+from openmdao.recorders.sqlite_recorder import META_KEY_SEP
 import dymos as dm
 
 
@@ -125,8 +133,9 @@ def _meta_tree_subsys_iter(tree, recurse=True, cls=None, path=None):
                 yield child
 
 
-def _get_model_options(cr, system, run_number=None):
-    """
+def _get_model_options_from_cr(cr, syspath, run_number=None):
+    """Retrieve model options for the given system from the given case reader.
+
     The the options for system stored in the given case reader.
     If there is more than one set of model options, this function returns the last recorded ones.
 
@@ -134,20 +143,18 @@ def _get_model_options(cr, system, run_number=None):
     ----------
     cr : CaseReader
         The CaseReader instance holding the data.
-    system : str or None
-        Pathname of system (None for all systems).
+    syspath : str
+        Pathname of system whose options are requested.
     run_number : int or None
         Run_driver or run_model iteration to inspect, if given. If None, return the last available.
 
     Returns
     -------
-    dict
-        {system: {key: val}}.
+    dict{system: {key: val}}
+        The model options dictionary for the given system.
     """
     if not cr._system_options:
         raise RuntimeError('System options were not recorded.')
-
-    comp_options = None
 
     # need to handle edge case for v11 recording
     if cr._format_version < 12:
@@ -163,16 +170,103 @@ def _get_model_options(cr, system, run_number=None):
             num = 0
 
         # Get the component associated with the highest run number
-        if name == system and (run_number is None or run_number == int(num)):
-            comp_options = cr._system_options[key]['component_options']
-
-    if comp_options is None:
-        raise ValueError(f'No options found for system {system}')
-
-    return comp_options
+        if name == syspath and (run_number is None or run_number == int(num)):
+            return cr._system_options[key]['component_options']
+    else:
+        raise KeyError(f'No options found for system {syspath}')
 
 
-def _get_trajs_and_phases(cr):
+def _get_model_options_from_problem(problem: Problem, syspath: str, rank=0):
+    """Retrieve model options for the given system from the given problem instance.
+
+    Retrieve the options for the system with the given pathname
+    If there is more than one set of model options, this function returns the last recorded ones.
+
+    Parameters
+    ----------
+    problem : Problem
+        The problem instance
+    syspath : str
+        Pathname of system whose options are requested.
+    rank : int
+        The MPI rank to which the system options are gathered.
+
+    Returns
+    -------
+    dict{system: {key: val}}
+        The model options dictionary for the given system.
+    """
+    if MPI.COMM_WORLD.size == 1:
+        for subsys in problem.model.system_iter(recurse=True, include_self=True):
+            if subsys.pathname == syspath:
+                system_options = subsys.options
+        else:
+            raise KeyError(f'No options found for system {syspath}')
+    else:
+        # If operating in parallel under MPI, gether data from every rank and send it back to zero.
+        for subsys in problem.model.system_iter(recurse=True, include_self=True):
+            if subsys.pathname == syspath:
+                local_system_options = subsys.options
+                break
+
+        system_options = MPI.COMM_WORLD.gather(local_system_options, rank)
+    return system_options
+
+
+def _get_traj_and_phases_from_problem(problem, rank: int=0):
+    """Retrieve a dictionary tree structure of all trajectories and phases in the problem.
+
+    Parameters
+    ----------
+    problem : Problem
+        The problem being searched for trajectories and phases.
+    rank : int
+        Under MPI, the returned trajectory tree is only valid on this rank.
+
+    Returns
+    -------
+    trajs : dict
+        A dictionary for each trajectory containing its parameter options dictionary and
+        a subdictionary of phases and their associated options. Under MPI, this dictionary
+    """
+    comm_rank = MPI.COMM_WORLD.rank
+    traj_options = _gather_system_options(problem.model, sys_cls=Trajectory, rank=rank)
+    phase_options = _gather_system_options(problem.model, sys_cls=Phase, rank=rank)
+
+    trajs = {}
+
+    if comm_rank == 0:
+        for traj_path, toptions in traj_options.items():
+            trajs[traj_path] = {'phases': {},
+                                'parameter_options': toptions['parameter_options'],
+                                'name': traj_path}
+            for phase_path, poptions in phase_options.items():
+                if phase_path.startswith(f'{traj_path}.'):
+                    trajs[traj_path]['phases'][phase_path] = {'name': phase_path.split('.')[-1]}
+                    for opt in ('time_options', 'parameter_options', 'state_options',
+                                'control_options', 'polynomial_control_options'):
+                         trajs[traj_path]['phases'][phase_path][opt] = poptions[opt]
+
+    return trajs
+
+def _get_trajs_and_phases_from_cr(cr, problem=None):
+    """Retrieve dictionaries of the trajectories and phases from the given case reader and problem.
+
+    Due to a bug in OpenMDAO, model options may not be available from the case reader. In this case,
+    use the problem to obtain them.
+
+    Parameters
+    ----------
+    cr : CaseReader
+        The CaseReader from which the model tree should be loaded.
+    problem : Problem, optional
+        The Problem instance from which system options should be loaded as a fallback.
+
+    Returns
+    -------
+    _type_
+        _description_
+    """
     trajs = {}
     traj_cls = 'dymos.trajectory.trajectory:Trajectory'
     phase_cls = ['dymos.phase.phase:Phase',
@@ -186,33 +280,39 @@ def _get_trajs_and_phases(cr):
         phase_nodes = [n for n in _meta_tree_subsys_iter(tn, cls=phase_cls, path=tn['path'])]
         traj_path = tn['path']
         trajs[traj_path] = {'phases': {}, 'parameter_options': {}, 'name': tn['name']}
-        traj_options = _get_model_options(cr=cr, system=traj_path)
-        for param_name, param_options in traj_options['parameter_options'].items():
-            trajs[traj_path]['parameter_options'][param_name] = param_options
-        for pn in phase_nodes:
-            phase_path = pn['path']
-            phase_options = _get_model_options(cr=cr, system=phase_path)
-            phase_meta = trajs[traj_path]['phases'][phase_path] = {'time_options': None,
-                                                                   'parameter_options': None,
-                                                                   'state_options': None,
-                                                                   'control_options': None,
-                                                                   'polynomial_control_options': None,
-                                                                   'name': pn['name']}
-            phase_meta['time_options'] = phase_options['time_options']
-            phase_meta['parameter_options'] = phase_options['parameter_options']
-            phase_meta['state_options'] = phase_options['state_options']
-            phase_meta['control_options'] = phase_options['control_options']
-            phase_meta['polynomial_control_options'] = phase_options['polynomial_control_options']
+
+        traj_options = _get_model_options_from_cr(cr=cr, syspath=traj_path)
+
+        if MPI.COMM_WORLD.rank == 0:
+            for param_name, param_options in traj_options['parameter_options'].items():
+                trajs[traj_path]['parameter_options'][param_name] = param_options
+            for pn in phase_nodes:
+                phase_path = pn['path']
+                phase_options = _get_model_options_from_cr(cr=cr, syspath=phase_path)
+                phase_meta = trajs[traj_path]['phases'][phase_path] = {'time_options': None,
+                                                                    'parameter_options': None,
+                                                                    'state_options': None,
+                                                                    'control_options': None,
+                                                                    'polynomial_control_options': None,
+                                                                    'name': pn['name']}
+                phase_meta['time_options'] = phase_options['time_options']
+                phase_meta['parameter_options'] = phase_options['parameter_options']
+                phase_meta['state_options'] = phase_options['state_options']
+                phase_meta['control_options'] = phase_options['control_options']
+                phase_meta['polynomial_control_options'] = phase_options['polynomial_control_options']
 
     return trajs
 
 
-def _load_data_sources(solution_record_file=None, simulation_record_file=None):
+def _load_data_sources(traj_and_phase_meta=None, solution_record_file=None, simulation_record_file=None):
     """
     Load the data for the timeseries plots from the given solution and record files.
 
     Parameters
     ----------
+    traj_and_phase_meta : dict
+        A tree dictionary structure that contains the trajectories, their child phases,
+        and associated options.
     solution_record_file : str
         The path to the solution record file.
     sim_record_file : str
@@ -224,15 +324,12 @@ def _load_data_sources(solution_record_file=None, simulation_record_file=None):
         A dictionary containing parameter data, solution timeseries data, simulation timeseries data, and
         units for each timeseries output.
     """
-
-    traj_and_phase_meta = None
     data_dict = {}
 
     if Path(solution_record_file).is_file():
         sol_cr = om.CaseReader(solution_record_file)
         sol_case = sol_cr.get_case('final')
         abs2prom_map = sol_cr.problem_metadata['abs2prom']
-        traj_and_phase_meta = _get_trajs_and_phases(sol_cr)
     else:
         sol_case = None
 
@@ -240,15 +337,13 @@ def _load_data_sources(solution_record_file=None, simulation_record_file=None):
         sim_cr = om.CaseReader(simulation_record_file)
         sim_case = sim_cr.get_case('final')
         abs2prom_map = sim_cr.problem_metadata['abs2prom']
-        if traj_and_phase_meta is None:
-            traj_and_phase_meta = _get_trajs_and_phases(sim_cr)
     else:
         sim_case = None
 
-    source_case = sol_case if sol_case else sim_case
+    source_case = sol_case or sim_case or None
     outputs = {abs_path: meta for abs_path, meta in source_case.list_outputs(out_stream=None, units=True)}
 
-    if sol_cr is None and sim_cr is None:
+    if source_case is None:
         om.issue_warning('No recorded data provided. Trajectory results report will not be created.')
         return
 
@@ -269,8 +364,8 @@ def _load_data_sources(solution_record_file=None, simulation_record_file=None):
             phase_sol_data = data_dict[traj_data['name']]['sol_data_by_phase'][phase_name] = {}
             phase_sim_data = data_dict[traj_data['name']]['sim_data_by_phase'][phase_name] = {}
 
-            param_outputs = {op: meta for op, meta in outputs.items()
-                             if op.startswith(f'{phase_path}.param_comp.parameter_vals:')}
+            # param_outputs = {op: meta for op, meta in outputs.items()
+            #                  if op.startswith(f'{phase_path}.param_comp.parameter_vals:')}
             ts_outputs = {op: meta for op, meta in outputs.items()
                           if op.startswith(f'{phase_path}.timeseries.')}
 
@@ -312,6 +407,36 @@ def _load_data_sources(solution_record_file=None, simulation_record_file=None):
     return data_dict
 
 
+def _gather_system_options(model, sys_cls=None, rank=0):
+    """Retreive system options for systems of the given class and/or pathname.
+
+    Parameters
+    ----------
+    model : System
+        The root system from which model options are being gathered.
+    sys_cls : class, optional
+        The class of system for which we want to retrieve options, or None if we
+        should look for all systems regardless of class.
+    rank : int
+        The rank onto which the system options shoud be gathered. The retured
+        dictionary of system options will only be valid on this rank.
+    """
+    comm_size = MPI.COMM_WORLD.size
+    comm_rank = MPI.COMM_WORLD.rank
+
+    system_options = {}
+    for subsys in model.system_iter(include_self=True, recurse=True, typ=sys_cls):
+        system_options[subsys.pathname] = subsys.options
+
+    if comm_size > 1:
+        gathered = MPI.COMM_WORLD.gather(system_options, rank)
+
+        if comm_rank == 0:
+            system_options.update(dict(ChainMap(*gathered)))
+
+    return system_options
+
+
 def make_timeseries_report(prob, solution_record_file=None, simulation_record_file=None,
                            x_name='time', ncols=2, margin=10, theme='light_minimal'):
     """
@@ -334,145 +459,153 @@ def make_timeseries_report(prob, solution_record_file=None, simulation_record_fi
     theme : str
         A valid bokeh theme name to style the report.
     """
+    comm_rank = MPI.COMM_WORLD.rank
     report_dir = Path(prob.get_reports_dir()) if prob is not None else Path(os.getcwd())
     if not report_dir.exists():
         report_dir = Path(os.getcwd())
 
-    # For the primary timeseries in each phase in each trajectory, build a set of the pathnames
-    # to be plotted.
-    source_data = _load_data_sources(solution_record_file, simulation_record_file)
+    if prob is not None:
+        # Retrieve system information fom the problem if available.
+        traj_data = _get_traj_and_phases_from_problem(prob)
 
-    # Colors of each phase in the plot. Start with the bright colors followed by the faded ones.
-    if not _NO_BOKEH:
-        colors = bp.d3['Category20'][20][0::2] + bp.d3['Category20'][20][1::2]
-        curdoc().theme = theme
+    # The rest of the traj report generation occurs on rank 0
+    if comm_rank == 0:
 
-    for traj_path, traj_data in source_data.items():
-        traj_name = traj_path.split('.')[-1]
-        report_filename = f'{traj_path}_results_report.html'
-        report_path = report_dir / report_filename
-        if _NO_BOKEH:
-            with open(report_path, 'wb') as f:
-                f.write("<html>\n<head>\n<title> \nError: bokeh not available</title>\n</head> <body>\n"
-                        "This report requires bokeh but bokeh was not available in this python installation.\n"
-                        "</body></html>".encode())
-            continue
+        # For the primary timeseries in each phase in each trajectory, build a set of the pathnames
+        # to be plotted.
+        source_data = _load_data_sources(traj_data, solution_record_file, simulation_record_file)
 
-        param_tables = []
-        phase_names = [k.split('.')[-1] for k in traj_data['param_data_by_phase']]
-        for phase_name, param_data in traj_data['param_data_by_phase'].items():
-            # Make the parameter table
-            columns = [
-                TableColumn(field='param', title='Parameter'),
-                TableColumn(field='val', title='Value'),
-                TableColumn(field='units', title='Units'),
-            ]
-            param_tables.append(DataTable(source=ColumnDataSource(param_data),
-                                          columns=columns,
-                                          index_position=None,
-                                          height=30*len(param_data['param']),
-                                          sizing_mode='stretch_both'))
+        # Colors of each phase in the plot. Start with the bright colors followed by the faded ones.
+        if not _NO_BOKEH:
+            colors = bp.d3['Category20'][20][0::2] + bp.d3['Category20'][20][1::2]
+            curdoc().theme = theme
 
-        # Plot the timeseries
-        ts_units_dict = source_data[traj_name]['timeseries_units']
+        for traj_path, traj_data in source_data.items():
+            traj_name = traj_path.split('.')[-1]
+            report_filename = f'{traj_path}_results_report.html'
+            report_path = report_dir / report_filename
+            if _NO_BOKEH:
+                with open(report_path, 'wb') as f:
+                    f.write("<html>\n<head>\n<title> \nError: bokeh not available</title>\n</head> <body>\n"
+                            "This report requires bokeh but bokeh was not available in this python installation.\n"
+                            "</body></html>".encode())
+                continue
 
-        figures = []
-        x_range = None
+            param_tables = []
+            phase_names = [k.split('.')[-1] for k in traj_data['param_data_by_phase']]
+            for phase_name, param_data in traj_data['param_data_by_phase'].items():
+                # Make the parameter table
+                columns = [
+                    TableColumn(field='param', title='Parameter'),
+                    TableColumn(field='val', title='Value'),
+                    TableColumn(field='units', title='Units'),
+                ]
+                param_tables.append(DataTable(source=ColumnDataSource(param_data),
+                                            columns=columns,
+                                            index_position=None,
+                                            height=30*len(param_data['param']),
+                                            sizing_mode='stretch_both'))
 
-        for var_name in sorted(ts_units_dict.keys(), key=str.casefold):
-            fig_kwargs = {'x_range': x_range} if x_range is not None else {}
+            # Plot the timeseries
+            ts_units_dict = source_data[traj_name]['timeseries_units']
 
-            tool_tips = [(f'{x_name}', '$x'), (f'{var_name}', '$y')]
+            figures = []
+            x_range = None
 
-            fig = figure(tools='pan,box_zoom,xwheel_zoom,hover,undo,reset,save',
-                         tooltips=tool_tips,
-                         x_axis_label=f'{x_name} ({ts_units_dict[x_name]})',
-                         y_axis_label=f'{var_name} ({ts_units_dict[var_name]})',
-                         toolbar_location='above',
-                         sizing_mode='stretch_both',
-                         min_height=250, max_height=300,
-                         margin=margin,
-                         **fig_kwargs)
-            fig.xaxis.axis_label_text_font_size = '10pt'
-            fig.yaxis.axis_label_text_font_size = '10pt'
-            fig.toolbar.autohide = True
-            legend_data = []
-            if x_range is None:
-                x_range = fig.x_range
-            for i, phase_name in enumerate(phase_names):
-                color = colors[i % 20]
-                sol_data = source_data[traj_name]['sol_data_by_phase'][phase_name]
-                sim_data = source_data[traj_name]['sim_data_by_phase'][phase_name]
-                sol_source = ColumnDataSource(sol_data)
-                sim_source = ColumnDataSource(sim_data)
-                if x_name in sol_data and var_name in sol_data:
-                    legend_items = []
-                    if sol_data:
-                        sol_plot = fig.circle(x='time', y=var_name, source=sol_source, color=color)
-                        sol_plot.tags.extend(['sol', f'phase:{phase_name}'])
-                        legend_items.append(sol_plot)
-                    if sim_data:
-                        sim_plot = fig.line(x='time', y=var_name, source=sim_source, color=color)
-                        sim_plot.tags.extend(['sim', f'phase:{phase_name}'])
-                        legend_items.append(sim_plot)
-                    legend_data.append((phase_name, legend_items))
+            for var_name in sorted(ts_units_dict.keys(), key=str.casefold):
+                fig_kwargs = {'x_range': x_range} if x_range is not None else {}
 
-            legend = Legend(items=legend_data, location='center', label_text_font_size='8pt')
-            fig.add_layout(legend, 'right')
-            figures.append(fig)
+                tool_tips = [(f'{x_name}', '$x'), (f'{var_name}', '$y')]
 
-        # Since we're putting figures in two columns, make sure we have an even number of things to put in the layout.
-        if len(figures) % 2 == 1:
-            figures.append(None)
+                fig = figure(tools='pan,box_zoom,xwheel_zoom,hover,undo,reset,save',
+                            tooltips=tool_tips,
+                            x_axis_label=f'{x_name} ({ts_units_dict[x_name]})',
+                            y_axis_label=f'{var_name} ({ts_units_dict[var_name]})',
+                            toolbar_location='above',
+                            sizing_mode='stretch_both',
+                            min_height=250, max_height=300,
+                            margin=margin,
+                            **fig_kwargs)
+                fig.xaxis.axis_label_text_font_size = '10pt'
+                fig.yaxis.axis_label_text_font_size = '10pt'
+                fig.toolbar.autohide = True
+                legend_data = []
+                if x_range is None:
+                    x_range = fig.x_range
+                for i, phase_name in enumerate(phase_names):
+                    color = colors[i % 20]
+                    sol_data = source_data[traj_name]['sol_data_by_phase'][phase_name]
+                    sim_data = source_data[traj_name]['sim_data_by_phase'][phase_name]
+                    sol_source = ColumnDataSource(sol_data)
+                    sim_source = ColumnDataSource(sim_data)
+                    if x_name in sol_data and var_name in sol_data:
+                        legend_items = []
+                        if sol_data:
+                            sol_plot = fig.circle(x='time', y=var_name, source=sol_source, color=color)
+                            sol_plot.tags.extend(['sol', f'phase:{phase_name}'])
+                            legend_items.append(sol_plot)
+                        if sim_data:
+                            sim_plot = fig.line(x='time', y=var_name, source=sim_source, color=color)
+                            sim_plot.tags.extend(['sim', f'phase:{phase_name}'])
+                            legend_items.append(sim_plot)
+                        legend_data.append((phase_name, legend_items))
 
-        param_panels = [TabPanel(child=table, title=f'{phase_names[i]} parameters')
-                        for i, table in enumerate(param_tables)]
+                legend = Legend(items=legend_data, location='center', label_text_font_size='8pt')
+                fig.add_layout(legend, 'right')
+                figures.append(fig)
 
-        sol_sim_toggle = CheckboxButtonGroup(labels=['Solution', 'Simulation'], active=[0, 1])
+            # Since we're putting figures in two columns, make sure we have an even number of things to put in the layout.
+            if len(figures) % 2 == 1:
+                figures.append(None)
 
-        sol_sim_row = row(children=[Div(text='Display data:', sizing_mode='stretch_height'),
-                                    sol_sim_toggle],
-                          sizing_mode='stretch_both',
-                          max_height=50)
+            param_panels = [TabPanel(child=table, title=f'{phase_names[i]} parameters')
+                            for i, table in enumerate(param_tables)]
 
-        phase_select = MultiChoice(options=[phase_name for phase_name in phase_names],
-                                   value=[phase_name for phase_name in phase_names],
-                                   sizing_mode='stretch_both',
-                                   min_width=400, min_height=50)
+            sol_sim_toggle = CheckboxButtonGroup(labels=['Solution', 'Simulation'], active=[0, 1])
 
-        phase_select_row = row(children=[Div(text='Plot phases:'), phase_select],
-                               sizing_mode='stretch_width')
+            sol_sim_row = row(children=[Div(text='Display data:', sizing_mode='stretch_height'),
+                                        sol_sim_toggle],
+                            sizing_mode='stretch_both',
+                            max_height=50)
 
-        figures_grid = grid(children=figures, ncols=ncols, sizing_mode='stretch_both')
+            phase_select = MultiChoice(options=[phase_name for phase_name in phase_names],
+                                    value=[phase_name for phase_name in phase_names],
+                                    sizing_mode='stretch_both',
+                                    min_width=400, min_height=50)
 
-        ts_layout = column(children=[sol_sim_row,
-                                     phase_select_row,
-                                     figures_grid],
-                           sizing_mode='stretch_both')
+            phase_select_row = row(children=[Div(text='Plot phases:'), phase_select],
+                                sizing_mode='stretch_width')
 
-        tab_panes = Tabs(tabs=[TabPanel(child=ts_layout, title='Timeseries')] + param_panels,
-                         sizing_mode='stretch_both',
-                         active=0)
+            figures_grid = grid(children=figures, ncols=ncols, sizing_mode='stretch_both')
 
-        summary = rf'Results of {prob._name}<br>Creation Date: {datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")}'
+            ts_layout = column(children=[sol_sim_row,
+                                        phase_select_row,
+                                        figures_grid],
+                            sizing_mode='stretch_both')
 
-        report_layout = column(children=[Div(text=summary), tab_panes], sizing_mode='stretch_both')
+            tab_panes = Tabs(tabs=[TabPanel(child=ts_layout, title='Timeseries')] + param_panels,
+                            sizing_mode='stretch_both',
+                            active=0)
 
-        # Assign callbacks
+            summary = rf'Results of {prob._name}<br>Creation Date: {datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")}'
 
-        sol_sim_toggle.js_on_change("active",
+            report_layout = column(children=[Div(text=summary), tab_panes], sizing_mode='stretch_both')
+
+            # Assign callbacks
+
+            sol_sim_toggle.js_on_change("active",
+                                        CustomJS(code=_js_show_figures,
+                                                args=dict(figures=figures,
+                                                        sol_sim_toggle=sol_sim_toggle,
+                                                        phase_select=phase_select)))
+
+            phase_select.js_on_change("value",
                                     CustomJS(code=_js_show_figures,
-                                             args=dict(figures=figures,
-                                                       sol_sim_toggle=sol_sim_toggle,
-                                                       phase_select=phase_select)))
+                                            args=dict(figures=figures,
+                                                        sol_sim_toggle=sol_sim_toggle,
+                                                        phase_select=phase_select)))
 
-        phase_select.js_on_change("value",
-                                  CustomJS(code=_js_show_figures,
-                                           args=dict(figures=figures,
-                                                     sol_sim_toggle=sol_sim_toggle,
-                                                     phase_select=phase_select)))
+            # Save
 
-        # Save
-
-        save(report_layout, filename=report_path, title=f'trajectory results for {traj_name}',
-             resources=bokeh_resources.INLINE)
+            save(report_layout, filename=report_path, title=f'trajectory results for {traj_name}',
+                resources=bokeh_resources.INLINE)

--- a/dymos/visualization/timeseries/bokeh_timeseries_report.py
+++ b/dymos/visualization/timeseries/bokeh_timeseries_report.py
@@ -204,7 +204,7 @@ def _get_trajs_and_phases_from_cr(cr, problem=None):  # pragma: no cover
 
         traj_options = _get_model_options_from_cr(cr=cr, syspath=traj_path)
 
-        if MPI.COMM_WORLD.rank == 0:
+        if MPI and MPI.COMM_WORLD.rank == 0:
             for param_name, param_options in traj_options['parameter_options'].items():
                 trajs[traj_path]['parameter_options'][param_name] = param_options
             for pn in phase_nodes:

--- a/dymos/visualization/timeseries/bokeh_timeseries_report.py
+++ b/dymos/visualization/timeseries/bokeh_timeseries_report.py
@@ -2,14 +2,12 @@ from collections import ChainMap
 import datetime
 from pathlib import Path
 import os.path
-from threading import local
-from numpy import isin
 
 from dymos.trajectory.trajectory import Trajectory
 from dymos.phase.phase import Phase
 
 try:
-    from bokeh.io import output_notebook, output_file, save, show
+    from bokeh.io import save
     from bokeh.layouts import column, grid, row
     from bokeh.models import Legend, DataTable, Div, ColumnDataSource, TableColumn, \
         TabPanel, Tabs, CheckboxButtonGroup, CustomJS, MultiChoice


### PR DESCRIPTION
### Summary

The previous trajectory report update attempted to gather all system option from the recorded files,
but due to a bug in OpenMDAO system options of remote systems are not recorded.

Until that is addressed, we now gather options from all remote systems to rank 0 and build the trajectory report there.

### Related Issues

- Resolves #1045 

### Backwards incompatibilities

None

### New Dependencies

None
