### PR TITLE
Add support for PEP517 builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
### Summary

Using [PEP517](https://peps.python.org/pep-0517/) to build the source distribution fails, because the build system dependencies are not specified.

```bash
pip wheel --no-cache-dir --use-pep517 dymos
```

```bash
Collecting dymos
  Downloading dymos-1.10.0.tar.gz (567 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 567.3/567.3 kB 5.1 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [17 lines of output]
      Traceback (most recent call last):
        File "PATH_TO_VIRTUAL_ENV\lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 353, in <module>
          main()
        File "PATH_TO_VIRTUAL_ENV\lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "PATH_TO_VIRTUAL_ENV\lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "PATH_TO_TEMP\pip-build-env-p10744e1\overlay\Lib\site-packages\setuptools\build_meta.py", line 325, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
        File "PATH_TO_TEMP\pip-build-env-p10744e1\overlay\Lib\site-packages\setuptools\build_meta.py", line 295, in _get_build_requires
          self.run_setup()
        File "PATH_TO_TEMP\pip-build-env-p10744e1\overlay\Lib\site-packages\setuptools\build_meta.py", line 487, in run_setup
          super().run_setup(setup_script=setup_script)
        File "PATH_TO_TEMP\pip-build-env-p10744e1\overlay\Lib\site-packages\setuptools\build_meta.py", line 311, in run_setup
          exec(code, locals())
        File "<string>", line 1, in <module>
      ModuleNotFoundError: No module named 'packaging'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

Support for [PEP517](https://peps.python.org/pep-0517/) is required as it is the recommended standard and dependency management systems such as [Poetry](https://python-poetry.org/) use the `--use-pep517` flag.

The error can be easily solved by adding a `pyproject.toml` file that specifies the required build dependencies. This is suggested in this pull request.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None, [setuptools](https://setuptools.pypa.io/) is already required. The requirement is only specified.
