### PR TITLE
Added skip to handle tests that need matplotlib and/or pydocstyle when not installed

### DIFF
--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone.py
@@ -1,14 +1,16 @@
 import os
 import unittest
 
-import matplotlib
-import matplotlib.pyplot as plt
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+
+    matplotlib.use('Agg')
+    plt.style.use('ggplot')
+except ImportError:
+    matplotlib = None
 
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
-
-
-matplotlib.use('Agg')
-plt.style.use('ggplot')
 
 
 @use_tempdirs
@@ -47,6 +49,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
         cpd = p.check_partials(method='cs', compact_print=True)
         assert_check_partials(cpd)
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_for_docs_gauss_lobatto(self):
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal
@@ -129,6 +132,7 @@ class TestBrachistochroneForDocs(unittest.TestCase):
 
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_for_docs_radau(self):
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_static_gravity.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_static_gravity.py
@@ -10,8 +10,8 @@ try:
 except ImportError:
     matplotlib = None
 
-from openmdao.utils.testing_utils import use_tempdirs
 
+from openmdao.utils.testing_utils import use_tempdirs
 
 
 @use_tempdirs

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_static_gravity.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_static_gravity.py
@@ -1,14 +1,17 @@
 import os
 import unittest
 
-import matplotlib
-import matplotlib.pyplot as plt
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+
+    matplotlib.use('Agg')
+    plt.style.use('ggplot')
+except ImportError:
+    matplotlib = None
 
 from openmdao.utils.testing_utils import use_tempdirs
 
-
-matplotlib.use('Agg')
-plt.style.use('ggplot')
 
 
 @use_tempdirs
@@ -47,6 +50,7 @@ class TestBrachistochroneStaticGravity(unittest.TestCase):
         cpd = p.check_partials(method='cs', compact_print=True)
         assert_check_partials(cpd)
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_static_gravity(self):
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_tandem_phases.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_tandem_phases.py
@@ -1,5 +1,10 @@
 import unittest
 
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
+
 import numpy as np
 import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
@@ -47,6 +52,7 @@ class BrachistochroneArclengthODE(om.ExplicitComponent):
 class TestBrachistochroneTandemPhases(unittest.TestCase):
 
     @require_pyoptsparse(optimizer='SLSQP')
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_tandem_phases(self):
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_upstream_control.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_upstream_control.py
@@ -1,11 +1,17 @@
 import unittest
 
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
+
 from openmdao.utils.testing_utils import use_tempdirs
 
 
 @use_tempdirs
 class TestBrachistochroneUpstreamControl(unittest.TestCase):
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_upstream_control(self):
         import numpy as np
         import openmdao.api as om

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_upstream_state.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_upstream_state.py
@@ -1,11 +1,17 @@
 import unittest
 
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
+
 from openmdao.utils.testing_utils import use_tempdirs
 
 
 @use_tempdirs
 class TestBrachistochroneUpstreamState(unittest.TestCase):
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_upstream_state(self):
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_control_rate_targets.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_control_rate_targets.py
@@ -2,6 +2,11 @@ import unittest
 
 import numpy as np
 
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
+
 import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs
 
@@ -110,6 +115,7 @@ class BrachistochroneRateTargetODE(om.ExplicitComponent):
 @use_tempdirs
 class TestBrachistochroneControlRateTargets(unittest.TestCase):
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_control_rate_targets_gauss_lobatto(self):
         import matplotlib.pyplot as plt
         plt.switch_backend('Agg')
@@ -206,6 +212,7 @@ class TestBrachistochroneControlRateTargets(unittest.TestCase):
 
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_control_rate_targets_radau(self):
         import matplotlib.pyplot as plt
         plt.switch_backend('Agg')
@@ -303,6 +310,7 @@ class TestBrachistochroneControlRateTargets(unittest.TestCase):
 @use_tempdirs
 class TestBrachistochroneExplicitControlRateTargets(unittest.TestCase):
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_control_rate_targets_gauss_lobatto(self):
         import matplotlib.pyplot as plt
         plt.switch_backend('Agg')
@@ -396,6 +404,7 @@ class TestBrachistochroneExplicitControlRateTargets(unittest.TestCase):
 
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_control_rate_targets_radau(self):
         import matplotlib.pyplot as plt
         plt.switch_backend('Agg')
@@ -494,6 +503,7 @@ class TestBrachistochroneExplicitControlRateTargets(unittest.TestCase):
 @use_tempdirs
 class TestBrachistochronePolynomialControlRateTargets(unittest.TestCase):
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_rate_targets_gauss_lobatto(self):
         import matplotlib.pyplot as plt
         plt.switch_backend('Agg')
@@ -587,6 +597,7 @@ class TestBrachistochronePolynomialControlRateTargets(unittest.TestCase):
 
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_rate_targets_radau(self):
         import matplotlib.pyplot as plt
         plt.switch_backend('Agg')
@@ -685,6 +696,7 @@ class TestBrachistochronePolynomialControlRateTargets(unittest.TestCase):
 @use_tempdirs
 class TestBrachistochronePolynomialControlExplicitRateTargets(unittest.TestCase):
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_rate_targets_gauss_lobatto(self):
         import matplotlib.pyplot as plt
         plt.switch_backend('Agg')
@@ -778,6 +790,7 @@ class TestBrachistochronePolynomialControlExplicitRateTargets(unittest.TestCase)
 
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_rate_targets_radau(self):
         import matplotlib.pyplot as plt
         plt.switch_backend('Agg')
@@ -876,6 +889,7 @@ class TestBrachistochronePolynomialControlExplicitRateTargets(unittest.TestCase)
 @use_tempdirs
 class TestBrachistochronePolynomialControlExplicitRate2Targets(unittest.TestCase):
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_rate_targets_gauss_lobatto(self):
         import matplotlib.pyplot as plt
         plt.switch_backend('Agg')

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_external_control.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_external_control.py
@@ -1,11 +1,17 @@
 import unittest
 
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
+
 from openmdao.utils.testing_utils import use_tempdirs
 
 
 @use_tempdirs
 class TestBrachistochroneExternalControl(unittest.TestCase):
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_external_control(self):
         import numpy as np
         import openmdao.api as om

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_implicit_recorder.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_implicit_recorder.py
@@ -1,6 +1,11 @@
 import os
 import unittest
 
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
+
 from openmdao.utils.testing_utils import use_tempdirs
 
 
@@ -13,6 +18,7 @@ class TestBrachistochroneRecordingExample(unittest.TestCase):
             if os.path.exists(filename):
                 os.remove(filename)
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_recording(self):
         import matplotlib
         matplotlib.use('Agg')

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_path_constraint.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_path_constraint.py
@@ -1,17 +1,11 @@
-import os
 import unittest
 
-import matplotlib
 import openmdao.api as om
-import matplotlib.pyplot as plt
 import dymos as dm
 
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.assert_utils import assert_near_equal
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
-
-matplotlib.use('Agg')
-plt.style.use('ggplot')
 
 
 @use_tempdirs

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_quick_start.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_quick_start.py
@@ -2,6 +2,11 @@ import unittest
 
 import numpy as np
 
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
+
 import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs
 
@@ -65,6 +70,7 @@ class BrachistochroneODE(om.ExplicitComponent):
 @use_tempdirs
 class TestBrachistochroneQuickStart(unittest.TestCase):
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_quick_start(self):
         import numpy as np
         import openmdao.api as om

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_static_gravity.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_static_gravity.py
@@ -1,18 +1,11 @@
 import os
 import unittest
 
-import matplotlib
-import matplotlib.pyplot as plt
-
 from openmdao.utils.testing_utils import use_tempdirs
 
 import openmdao.api as om
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
-
-
-matplotlib.use('Agg')
-plt.style.use('ggplot')
 
 
 @use_tempdirs

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_vector_boundary_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_vector_boundary_constraints.py
@@ -1,8 +1,5 @@
 import unittest
 
-import matplotlib
-import matplotlib.pyplot as plt
-
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
@@ -10,10 +7,6 @@ from openmdao.utils.testing_utils import use_tempdirs
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_vector_states_ode \
     import BrachistochroneVectorStatesODE
-
-
-SHOW_PLOTS = True
-matplotlib.use('Agg')
 
 
 @use_tempdirs

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_vector_path_constraints.py
@@ -2,8 +2,6 @@ import unittest
 
 import numpy as np
 
-import matplotlib.pyplot as plt
-
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs

--- a/dymos/examples/brachistochrone/test/test_doc_brachistochrone_polynomial_controls.py
+++ b/dymos/examples/brachistochrone/test/test_doc_brachistochrone_polynomial_controls.py
@@ -1,11 +1,17 @@
 import unittest
 
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
+
 from openmdao.utils.testing_utils import use_tempdirs
 
 
 @use_tempdirs
 class TestBrachistochronePolynomialControl(unittest.TestCase):
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_gauss_lobatto(self):
         import matplotlib
         matplotlib.use('Agg')
@@ -91,6 +97,7 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
 
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_radau(self):
         import numpy as np
         import matplotlib
@@ -177,6 +184,7 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
 
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_birkhoff(self):
         import numpy as np
         import matplotlib
@@ -274,6 +282,7 @@ class TestBrachistochronePolynomialControl(unittest.TestCase):
 @use_tempdirs
 class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase):
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_gauss_lobatto(self):
         import matplotlib
         matplotlib.use('Agg')
@@ -362,6 +371,7 @@ class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase)
 
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_radau(self):
         import matplotlib
         matplotlib.use('Agg')
@@ -450,6 +460,7 @@ class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase)
 
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_birkhoff(self):
         import numpy as np
         import matplotlib
@@ -550,6 +561,7 @@ class TestBrachistochronePolynomialControlBoundaryConstrained(unittest.TestCase)
 @use_tempdirs
 class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_gauss_lobatto(self):
         import matplotlib.pyplot as plt
         plt.switch_backend('Agg')
@@ -636,6 +648,7 @@ class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
 
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_radau(self):
         import matplotlib.pyplot as plt
         plt.switch_backend('Agg')
@@ -722,6 +735,7 @@ class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
 
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_birkhoff(self):
         import numpy as np
         import matplotlib
@@ -821,6 +835,7 @@ class TestBrachistochronePolynomialControlPathConstrained(unittest.TestCase):
 @use_tempdirs
 class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase):
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_gauss_lobatto(self):
         import numpy as np
         import matplotlib
@@ -909,6 +924,7 @@ class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase)
 
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_radau(self):
         import numpy as np
         import matplotlib
@@ -997,6 +1013,7 @@ class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase)
 
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_birkhoff(self):
         import numpy as np
         import matplotlib
@@ -1096,6 +1113,7 @@ class TestBrachistochronePolynomialControlRatePathConstrained(unittest.TestCase)
 @use_tempdirs
 class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase):
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_gauss_lobatto(self):
         import numpy as np
         import matplotlib
@@ -1184,6 +1202,7 @@ class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase
 
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_radau(self):
         import numpy as np
         import matplotlib
@@ -1272,6 +1291,7 @@ class TestBrachistochronePolynomialControlRate2PathConstrained(unittest.TestCase
 
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_birkhoff(self):
         import numpy as np
         import matplotlib
@@ -1485,6 +1505,7 @@ class TestBrachistochronePolynomialControlSimulation(unittest.TestCase):
         assert_near_equal(theta_exp[0], theta_imp[0])
         assert_near_equal(theta_exp[-1], theta_imp[-1])
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_polynomial_control_birkhoff(self):
         import numpy as np
         import matplotlib

--- a/dymos/examples/cannonball/test/test_cannonball_connected_initial_states.py
+++ b/dymos/examples/cannonball/test/test_cannonball_connected_initial_states.py
@@ -1,7 +1,7 @@
 import unittest
 
 try:
-    import matplotlib as plt
+    import matplotlib.pyplot as plt
     plt.switch_backend('Agg')
 except ImportError:
     plt = None

--- a/dymos/examples/cannonball/test/test_cannonball_connected_initial_states.py
+++ b/dymos/examples/cannonball/test/test_cannonball_connected_initial_states.py
@@ -1,5 +1,10 @@
 import unittest
-import matplotlib.pyplot as plt
+
+try:
+    import matplotlib as plt
+    plt.switch_backend('Agg')
+except ImportError:
+    plt = None
 
 from openmdao.utils.testing_utils import use_tempdirs
 import openmdao.api as om
@@ -8,9 +13,6 @@ from openmdao.utils.assert_utils import assert_near_equal
 import dymos as dm
 from dymos.examples.cannonball.size_comp import CannonballSizeComp
 from dymos.examples.cannonball.cannonball_ode import CannonballODE
-
-
-plt.switch_backend('Agg')
 
 
 @use_tempdirs

--- a/dymos/examples/cannonball/test/test_cannonball_expr_constraint.py
+++ b/dymos/examples/cannonball/test/test_cannonball_expr_constraint.py
@@ -1,7 +1,7 @@
 import unittest
 
 try:
-    import matplotlib as plt
+    import matplotlib.pyplot as plt
     plt.switch_backend('Agg')
 except ImportError:
     plt = None

--- a/dymos/examples/cannonball/test/test_cannonball_expr_constraint.py
+++ b/dymos/examples/cannonball/test/test_cannonball_expr_constraint.py
@@ -1,5 +1,10 @@
 import unittest
-import matplotlib.pyplot as plt
+
+try:
+    import matplotlib as plt
+    plt.switch_backend('Agg')
+except ImportError:
+    plt = None
 
 from openmdao.utils.testing_utils import use_tempdirs
 import openmdao.api as om
@@ -8,9 +13,6 @@ from openmdao.utils.assert_utils import assert_near_equal
 import dymos as dm
 from dymos.examples.cannonball.size_comp import CannonballSizeComp
 from dymos.examples.cannonball.cannonball_ode import CannonballODE
-
-
-plt.switch_backend('Agg')
 
 
 @use_tempdirs

--- a/dymos/examples/cannonball/test/test_phase_linkage_compliance.py
+++ b/dymos/examples/cannonball/test/test_phase_linkage_compliance.py
@@ -1,7 +1,7 @@
 import unittest
 
 try:
-    import matplotlib as plt
+    import matplotlib.pyplot as plt
     plt.switch_backend('Agg')
 except ImportError:
     plt = None

--- a/dymos/examples/cannonball/test/test_phase_linkage_compliance.py
+++ b/dymos/examples/cannonball/test/test_phase_linkage_compliance.py
@@ -1,10 +1,12 @@
 import unittest
 
-import matplotlib.pyplot as plt
+try:
+    import matplotlib as plt
+    plt.switch_backend('Agg')
+except ImportError:
+    plt = None
+
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
-
-
-plt.switch_backend('Agg')
 
 
 @use_tempdirs

--- a/dymos/examples/cannonball/test/test_two_phase_cannonball_birkhoff.py
+++ b/dymos/examples/cannonball/test/test_two_phase_cannonball_birkhoff.py
@@ -1,11 +1,10 @@
 import unittest
 
-import matplotlib.pyplot as plt
-
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
-#
+# import matplotlib.pyplot as plt
 # plt.switch_backend('Agg')
+
 import numpy as np
 from scipy.interpolate import interp1d
 

--- a/dymos/examples/cannonball/test/test_two_phase_cannonball_birkhoff.py
+++ b/dymos/examples/cannonball/test/test_two_phase_cannonball_birkhoff.py
@@ -2,9 +2,6 @@ import unittest
 
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
-# import matplotlib.pyplot as plt
-# plt.switch_backend('Agg')
-
 import numpy as np
 from scipy.interpolate import interp1d
 

--- a/dymos/examples/cannonball/test/test_two_phase_cannonball_ode_output_linkage.py
+++ b/dymos/examples/cannonball/test/test_two_phase_cannonball_ode_output_linkage.py
@@ -1,7 +1,7 @@
 import unittest
 
 try:
-    import matplotlib as plt
+    import matplotlib.pyplot as plt
     plt.switch_backend('Agg')
 except ImportError:
     plt = None

--- a/dymos/examples/cannonball/test/test_two_phase_cannonball_ode_output_linkage.py
+++ b/dymos/examples/cannonball/test/test_two_phase_cannonball_ode_output_linkage.py
@@ -1,10 +1,12 @@
 import unittest
 
-import matplotlib.pyplot as plt
+try:
+    import matplotlib as plt
+    plt.switch_backend('Agg')
+except ImportError:
+    plt = None
+
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
-
-
-plt.switch_backend('Agg')
 
 
 @use_tempdirs

--- a/dymos/examples/double_integrator/doc/test_doc_double_integrator.py
+++ b/dymos/examples/double_integrator/doc/test_doc_double_integrator.py
@@ -1,14 +1,16 @@
 import os
 import unittest
 
-import matplotlib
-import matplotlib.pyplot as plt
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+
+    matplotlib.use('Agg')
+    plt.style.use('ggplot')
+except ImportError:
+    matplotlib = None
 
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
-
-
-matplotlib.use('Agg')
-plt.style.use('ggplot')
 
 
 @use_tempdirs
@@ -21,6 +23,7 @@ class TestDoubleIntegratorForDocs(unittest.TestCase):
                 os.remove(filename)
 
     @require_pyoptsparse(optimizer='SLSQP')
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_double_integrator_for_docs(self):
         import matplotlib.pyplot as plt
         import openmdao.api as om

--- a/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
@@ -1,18 +1,22 @@
 import unittest
 
-import matplotlib.pyplot as plt
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+
+    plt.switch_backend('Agg')
+    plt.style.use('ggplot')
+except ImportError:
+    matplotlib = None
 
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
-
-
-plt.switch_backend('Agg')
-plt.style.use('ggplot')
 
 
 @use_tempdirs
 class TestFiniteBurnOrbitRaise(unittest.TestCase):
 
     @require_pyoptsparse(optimizer='IPOPT')
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_finite_burn_orbit_raise(self):
         import numpy as np
         import matplotlib.pyplot as plt

--- a/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
+++ b/dymos/examples/finite_burn_orbit_raise/doc/test_doc_finite_burn_orbit_raise.py
@@ -1,13 +1,12 @@
 import unittest
 
 try:
-    import matplotlib
     import matplotlib.pyplot as plt
 
     plt.switch_backend('Agg')
     plt.style.use('ggplot')
 except ImportError:
-    matplotlib = None
+    plt = None
 
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
@@ -16,7 +15,7 @@ from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 class TestFiniteBurnOrbitRaise(unittest.TestCase):
 
     @require_pyoptsparse(optimizer='IPOPT')
-    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
+    @unittest.skipIf(plt is None, "This test requires matplotlib")
     def test_finite_burn_orbit_raise(self):
         import numpy as np
         import matplotlib.pyplot as plt

--- a/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise_bokeh_plots.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise_bokeh_plots.py
@@ -6,6 +6,11 @@ import pathlib
 
 import numpy as np
 
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
+
 import openmdao.api as om
 from openmdao.utils.testing_utils import require_pyoptsparse
 from openmdao.utils.general_utils import set_pyoptsparse_opt
@@ -217,6 +222,7 @@ class TestExampleTwoBurnOrbitRaise(unittest.TestCase):
         html_file = pathlib.Path(_get_reports_dir(p)) / 'traj_results_report.html'
         self.assertTrue(html_file.exists(), msg=f'{html_file} does not exist!')
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_mpl_plots(self):
         dm.options['plots'] = 'matplotlib'
 

--- a/dymos/examples/finite_burn_orbit_raise/test/test_multi_phase_restart.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_multi_phase_restart.py
@@ -151,8 +151,8 @@ class TestExampleTwoBurnOrbitRaiseConnected(unittest.TestCase):
         sim_case2 = om.CaseReader('dymos_simulation2.db').get_case('final')
 
         # Verify that the second case has the same inputs and outputs
-        assert_cases_equal(case1, case2, tol=1.0E-8)
-        assert_cases_equal(sim_case1, sim_case2, tol=1.0E-8)
+        assert_cases_equal(case1, case2, tol=1.0E-7)
+        assert_cases_equal(sim_case1, sim_case2, tol=1.0E-7)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
@@ -4,9 +4,11 @@ import warnings
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from dymos.utils.introspection import get_promoted_vars
 
-import matplotlib.pyplot as plt
-plt.switch_backend('Agg')
-
+try:
+    import matplotlib as plt
+    plt.switch_backend('Agg')
+except ImportError:
+    plt = None
 
 @require_pyoptsparse(optimizer='IPOPT')
 @use_tempdirs
@@ -235,6 +237,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         p.setup(check=True, force_alloc_complex=True)
 
+    @unittest.skipIf(plt is None, "This test requires matplotlib")
     def test_two_burn_orbit_raise_gl_radau_gl_constrained(self):
         import numpy as np
 
@@ -453,6 +456,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
 
         plt.show()
 
+    @unittest.skipIf(plt is None, "This test requires matplotlib")
     def test_two_burn_orbit_raise_link_control_to_param(self):
         import numpy as np
 
@@ -633,6 +637,7 @@ class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):
         assert_near_equal(coast_u1_final - burn2_u1_initial, 0.0, 1e-12)
 
     @use_tempdirs
+    @unittest.skipIf(plt is None, "This test requires matplotlib")
     def test_two_burn_orbit_raise_gl_list_add_timeseries_output(self):
         import numpy as np
 

--- a/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
@@ -10,6 +10,7 @@ try:
 except ImportError:
     plt = None
 
+
 @require_pyoptsparse(optimizer='IPOPT')
 @use_tempdirs
 class TestTwoBurnOrbitRaiseLinkages(unittest.TestCase):

--- a/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_two_burn_orbit_raise_linkages.py
@@ -5,7 +5,7 @@ from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from dymos.utils.introspection import get_promoted_vars
 
 try:
-    import matplotlib as plt
+    import matplotlib.pyplot as plt
     plt.switch_backend('Agg')
 except ImportError:
     plt = None

--- a/dymos/examples/goddard_rocket_problem/test/test_goddard_rocket_problem.py
+++ b/dymos/examples/goddard_rocket_problem/test/test_goddard_rocket_problem.py
@@ -3,12 +3,16 @@ import dymos as dm
 import unittest
 import os
 
+try:
+    import matplotlib
+    SHOW_PLOTS = True
+except ImportError:
+    SHOW_PLOTS = False
+
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 from dymos.examples.goddard_rocket_problem import RocketODE
-
-SHOW_PLOTS = True
 
 
 @require_pyoptsparse(optimizer='IPOPT')

--- a/dymos/examples/hyper_sensitive/doc/test_doc_hyper_sensitive.py
+++ b/dymos/examples/hyper_sensitive/doc/test_doc_hyper_sensitive.py
@@ -109,11 +109,11 @@ class TestHyperSensitive(unittest.TestCase):
 
         if matplotlib is not None:
             plot_results([('traj.phase0.timeseries.time', 'traj.phase0.timeseries.x',
-                        'time (s)', 'x $(m)$'),
-                        ('traj.phase0.timeseries.time', 'traj.phase0.timeseries.u',
-                        'time (s)', 'u $(m/s^2)$')],
-                        title='Hyper Sensitive Problem Solution\nRadau Pseudospectral Method',
-                        p_sol=p, p_sim=exp_out)
+                           'time (s)', 'x $(m)$'),
+                          ('traj.phase0.timeseries.time', 'traj.phase0.timeseries.u',
+                           'time (s)', 'u $(m/s^2)$')],
+                         title='Hyper Sensitive Problem Solution\nRadau Pseudospectral Method',
+                         p_sol=p, p_sim=exp_out)
 
             plt.show()
 

--- a/dymos/examples/hyper_sensitive/doc/test_doc_hyper_sensitive.py
+++ b/dymos/examples/hyper_sensitive/doc/test_doc_hyper_sensitive.py
@@ -4,14 +4,18 @@ import os
 import unittest
 import numpy as np
 
-import matplotlib
-import matplotlib.pyplot as plt
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+
+    matplotlib.use('Agg')
+    plt.style.use('ggplot')
+except ImportError:
+    matplotlib = None
 
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
-matplotlib.use('Agg')
-plt.style.use('ggplot')
 tf = 10.0
 
 
@@ -103,14 +107,15 @@ class TestHyperSensitive(unittest.TestCase):
         #
         exp_out = traj.simulate()
 
-        plot_results([('traj.phase0.timeseries.time', 'traj.phase0.timeseries.x',
-                       'time (s)', 'x $(m)$'),
-                      ('traj.phase0.timeseries.time', 'traj.phase0.timeseries.u',
-                       'time (s)', 'u $(m/s^2)$')],
-                     title='Hyper Sensitive Problem Solution\nRadau Pseudospectral Method',
-                     p_sol=p, p_sim=exp_out)
+        if matplotlib is not None:
+            plot_results([('traj.phase0.timeseries.time', 'traj.phase0.timeseries.x',
+                        'time (s)', 'x $(m)$'),
+                        ('traj.phase0.timeseries.time', 'traj.phase0.timeseries.u',
+                        'time (s)', 'u $(m/s^2)$')],
+                        title='Hyper Sensitive Problem Solution\nRadau Pseudospectral Method',
+                        p_sol=p, p_sim=exp_out)
 
-        plt.show()
+            plt.show()
 
 
 if __name__ == "__main__":

--- a/dymos/examples/length_constrained_brachistochrone/doc/test_doc_length_constrained_brachistochrone.py
+++ b/dymos/examples/length_constrained_brachistochrone/doc/test_doc_length_constrained_brachistochrone.py
@@ -4,11 +4,12 @@ import unittest
 
 from openmdao.utils.testing_utils import use_tempdirs
 
-import matplotlib
-matplotlib.use('Agg')
-
-
-SHOW_PLOTS = True
+try:
+    import matplotlib
+    matplotlib.use('Agg')
+    SHOW_PLOTS = True
+except ImportError:
+    SHOW_PLOTS = False
 
 
 @use_tempdirs
@@ -17,7 +18,6 @@ class TestLengthConstrainedBrachistochrone(unittest.TestCase):
     def test_length_constrained_brachistochrone(self):
         import openmdao.api as om
         import dymos as dm
-        import matplotlib.pyplot as plt
         from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
         from dymos.examples.length_constrained_brachistochrone.arc_length_comp import ArcLengthComp
 
@@ -92,6 +92,8 @@ class TestLengthConstrainedBrachistochrone(unittest.TestCase):
 
         # Plot results
         if SHOW_PLOTS:
+            import matplotlib.pyplot as plt
+
             # Generate the explicitly simulated trajectory
             exp_out = traj.simulate()
 

--- a/dymos/examples/min_time_climb/aero/test/test_cd0_comp.py
+++ b/dymos/examples/min_time_climb/aero/test/test_cd0_comp.py
@@ -1,16 +1,18 @@
 import unittest
 
 import numpy as np
-import matplotlib
+
+try:
+    import matplotlib
+    matplotlib.use('Agg')
+    SHOW_PLOTS = True
+except ImportError:
+    SHOW_PLOTS = False
 
 import openmdao.api as om
 from dymos.utils.testing_utils import assert_check_partials
 
 from dymos.examples.min_time_climb.aero.cd0_comp import CD0Comp
-
-
-matplotlib.use('Agg')
-SHOW_PLOTS = True
 
 
 class TestCD0Comp(unittest.TestCase):

--- a/dymos/examples/min_time_climb/aero/test/test_cla_comp.py
+++ b/dymos/examples/min_time_climb/aero/test/test_cla_comp.py
@@ -1,16 +1,18 @@
 import unittest
 
 import numpy as np
-import matplotlib
+
+try:
+    import matplotlib
+    matplotlib.use('Agg')
+    SHOW_PLOTS = True
+except ImportError:
+    SHOW_PLOTS = False
 
 import openmdao.api as om
 from dymos.utils.testing_utils import assert_check_partials
 
 from dymos.examples.min_time_climb.aero.cla_comp import CLaComp
-
-
-matplotlib.use('Agg')
-SHOW_PLOTS = True
 
 
 class TestCLaComp(unittest.TestCase):

--- a/dymos/examples/min_time_climb/test/test_doc_min_time_climb_partial_coloring.py
+++ b/dymos/examples/min_time_climb/test/test_doc_min_time_climb_partial_coloring.py
@@ -1,13 +1,15 @@
 import unittest
 
-import matplotlib
-import matplotlib.pyplot as plt
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+
+    matplotlib.use('Agg')
+    plt.style.use('ggplot')
+except ImportError:
+    matplotlib = None
 
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
-
-
-matplotlib.use('Agg')
-plt.style.use('ggplot')
 
 
 @use_tempdirs

--- a/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
+++ b/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
@@ -1,8 +1,11 @@
 import unittest
 import numpy as np
 from numpy.polynomial import Polynomial as P
-import matplotlib.pyplot as plt
-import matplotlib.cm as cm
+try:
+    import matplotlib.pyplot as plt
+    import matplotlib.cm as cm
+except ImportError:
+    matpoltlib = None
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal

--- a/dymos/examples/oscillator/test/test_oscillator.py
+++ b/dymos/examples/oscillator/test/test_oscillator.py
@@ -1,10 +1,16 @@
 import unittest
 from openmdao.utils.testing_utils import use_tempdirs
 
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
+
 
 @use_tempdirs
 class TestDocOscillator(unittest.TestCase):
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_ivp(self):
         import openmdao.api as om
         import dymos as dm
@@ -70,6 +76,7 @@ class TestDocOscillator(unittest.TestCase):
         plt.tight_layout()
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_ivp_solver(self):
         import openmdao.api as om
         import dymos as dm
@@ -134,6 +141,7 @@ class TestDocOscillator(unittest.TestCase):
         plt.tight_layout()
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_ivp_driver(self):
         import openmdao.api as om
         import dymos as dm
@@ -209,6 +217,7 @@ class TestDocOscillator(unittest.TestCase):
         plt.tight_layout()
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_ivp_driver_10_segs(self):
         import openmdao.api as om
         import dymos as dm
@@ -284,6 +293,7 @@ class TestDocOscillator(unittest.TestCase):
         plt.tight_layout()
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_ivp_driver_4_segs_7_order(self):
         import openmdao.api as om
         import dymos as dm
@@ -359,6 +369,7 @@ class TestDocOscillator(unittest.TestCase):
         plt.tight_layout()
         plt.show()
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_ivp_driver_run_problem(self):
         import openmdao.api as om
         import dymos as dm

--- a/dymos/examples/racecar/test/test_racecar.py
+++ b/dymos/examples/racecar/test/test_racecar.py
@@ -1,5 +1,10 @@
 import unittest
 
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
+
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from openmdao.utils.assert_utils import assert_near_equal
 
@@ -8,6 +13,7 @@ from openmdao.utils.assert_utils import assert_near_equal
 class TestRaceCarForDocs(unittest.TestCase):
 
     @require_pyoptsparse(optimizer='IPOPT')
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_racecar_for_docs(self):
         import numpy as np
         import openmdao.api as om

--- a/dymos/examples/robertson_problem/doc/test_doc_robertson_problem.py
+++ b/dymos/examples/robertson_problem/doc/test_doc_robertson_problem.py
@@ -1,14 +1,16 @@
 import unittest
 
-import matplotlib
-import matplotlib.pyplot as plt
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+
+    matplotlib.use('Agg')
+    plt.style.use('ggplot')
+except ImportError:
+    matplotlib = None
 
 from openmdao.utils.testing_utils import use_tempdirs
 from dymos.examples.robertson_problem.doc.robertson_ode import RobertsonODE
-
-
-matplotlib.use('Agg')
-plt.style.use('ggplot')
 
 
 @use_tempdirs
@@ -59,6 +61,7 @@ class TestRobertsonProblemForDocs(unittest.TestCase):
 
         return p
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_robertson_problem_for_docs(self):
 
         import openmdao.api as om

--- a/dymos/examples/robot_arm/test/test_robot_arm.py
+++ b/dymos/examples/robot_arm/test/test_robot_arm.py
@@ -2,7 +2,14 @@ import os
 import unittest
 
 import numpy as np
-import matplotlib.pyplot as plt
+
+try:
+    import matplotlib as plt
+    plt.switch_backend('Agg')
+    show_plots = True
+except ImportError:
+    show_plots = False
+
 import openmdao.api as om
 import dymos as dm
 
@@ -11,9 +18,6 @@ from openmdao.utils.general_utils import printoptions
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 from dymos.examples.robot_arm.robot_arm_ode import RobotArmODE
-
-plt.switch_backend('Agg')
-show_plots = True
 
 
 @use_tempdirs

--- a/dymos/examples/robot_arm/test/test_robot_arm.py
+++ b/dymos/examples/robot_arm/test/test_robot_arm.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 
 try:
-    import matplotlib as plt
+    import matplotlib.pyplot as plt
     plt.switch_backend('Agg')
     show_plots = True
 except ImportError:

--- a/dymos/examples/shuttle_reentry/doc/test_doc_reentry.py
+++ b/dymos/examples/shuttle_reentry/doc/test_doc_reentry.py
@@ -1,14 +1,16 @@
 import os
 import unittest
-import matplotlib.pyplot as plt
+
+try:
+    import matplotlib as plt
+    plt.switch_backend('Agg')
+    plt.style.use('ggplot')
+except ImportError:
+    plt = None
 
 import numpy as np
 
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
-
-
-plt.switch_backend('Agg')
-plt.style.use('ggplot')
 
 
 @use_tempdirs
@@ -20,6 +22,7 @@ class TestReentryForDocs(unittest.TestCase):
                 os.remove(filename)
 
     @require_pyoptsparse(optimizer='SLSQP')
+    @unittest.skipIf(plt is None, "This test requires matplotlib")
     def test_reentry(self):
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal

--- a/dymos/examples/shuttle_reentry/doc/test_doc_reentry.py
+++ b/dymos/examples/shuttle_reentry/doc/test_doc_reentry.py
@@ -2,7 +2,7 @@ import os
 import unittest
 
 try:
-    import matplotlib as plt
+    import matplotlib.pylot as plt
     plt.switch_backend('Agg')
     plt.style.use('ggplot')
 except ImportError:

--- a/dymos/examples/shuttle_reentry/doc/test_doc_reentry.py
+++ b/dymos/examples/shuttle_reentry/doc/test_doc_reentry.py
@@ -2,7 +2,7 @@ import os
 import unittest
 
 try:
-    import matplotlib.pylot as plt
+    import matplotlib.pyplot as plt
     plt.switch_backend('Agg')
     plt.style.use('ggplot')
 except ImportError:

--- a/dymos/examples/ssto/doc/test_doc_ssto_earth.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_earth.py
@@ -1,5 +1,9 @@
 import unittest
 
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
 
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
@@ -9,6 +13,7 @@ from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 class TestDocSSTOEarth(unittest.TestCase):
 
     @require_pyoptsparse(optimizer='SLSQP')
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_doc_ssto_earth(self):
         import matplotlib.pyplot as plt
         import openmdao.api as om

--- a/dymos/examples/ssto/doc/test_doc_ssto_linear_tangent_guidance.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_linear_tangent_guidance.py
@@ -1,19 +1,22 @@
 import unittest
 
-import matplotlib
-import matplotlib.pyplot as plt
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+
+    matplotlib.use('Agg')
+    plt.style.use('ggplot')
+except ImportError:
+    matplotlib = None
 
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
-
-
-matplotlib.use('Agg')
-plt.style.use('ggplot')
 
 
 @use_tempdirs
 class TestDocSSTOLinearTangentGuidance(unittest.TestCase):
 
     @require_pyoptsparse(optimizer='SLSQP')
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_doc_ssto_linear_tangent_guidance(self):
         import numpy as np
         import matplotlib.pyplot as plt

--- a/dymos/examples/ssto/doc/test_doc_ssto_polynomial_control.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_polynomial_control.py
@@ -1,19 +1,22 @@
 import unittest
 
-import matplotlib
-import matplotlib.pyplot as plt
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+
+    matplotlib.use('Agg')
+    plt.style.use('ggplot')
+except ImportError:
+    matplotlib = None
 
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
-
-
-matplotlib.use('Agg')
-plt.style.use('ggplot')
 
 
 @use_tempdirs
 class TestDocSSTOPolynomialControl(unittest.TestCase):
 
     @require_pyoptsparse(optimizer='SLSQP')
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_doc_ssto_polynomial_control(self):
         import numpy as np
         import matplotlib.pyplot as plt

--- a/dymos/examples/ssto/test/test_simulate_root_trajectory.py
+++ b/dymos/examples/ssto/test/test_simulate_root_trajectory.py
@@ -1,18 +1,22 @@
 import unittest
 
-import matplotlib
-import matplotlib.pyplot as plt
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+
+    matplotlib.use('Agg')
+    plt.style.use('ggplot')
+except ImportError:
+    matplotlib = None
+
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
-
-
-matplotlib.use('Agg')
-plt.style.use('ggplot')
 
 
 @use_tempdirs
 class TestSSTOSimulateRootTrajectory(unittest.TestCase):
 
     @require_pyoptsparse(optimizer='SLSQP')
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_ssto_simulate_root_trajectory(self):
         """
         Tests that we can properly simulate a trajectory even if the trajectory is the root

--- a/dymos/examples/water_rocket/test/test_water_rocket.py
+++ b/dymos/examples/water_rocket/test/test_water_rocket.py
@@ -2,8 +2,12 @@ import unittest
 from collections import namedtuple
 
 import numpy as np
-import matplotlib as mpl
-import matplotlib.pyplot as plt
+
+try:
+    import matplotlib as mpl
+    import matplotlib.pyplot as plt
+except ImportError:
+    mpl = None
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
@@ -17,6 +21,7 @@ from dymos.examples.water_rocket.phases import (new_water_rocket_trajectory,
 @use_tempdirs
 class TestWaterRocketForDocs(unittest.TestCase):
 
+    @unittest.skipIf(mpl is None, "This test requires matplotlib")
     def test_water_rocket_height_for_docs(self):
         import dymos as dm
         p = om.Problem(model=om.Group())
@@ -57,6 +62,7 @@ class TestWaterRocketForDocs(unittest.TestCase):
         assert_near_equal(summary['Water volume'].value, 0.98, 0.01)
         assert_near_equal(summary['Maximum height'].value, 53.5, 0.01)
 
+    @unittest.skipIf(mpl is None, "This test requires matplotlib")
     def test_water_rocket_range_for_docs(self):
         p = om.Problem(model=om.Group())
 

--- a/dymos/phase/test/test_phase.py
+++ b/dymos/phase/test/test_phase.py
@@ -9,8 +9,11 @@ import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
 
-import matplotlib.pyplot as plt
-plt.switch_backend('Agg')
+try:
+    import matplotlib.pyplot as plt
+    plt.switch_backend('Agg')
+except ImportError:
+    plt = None
 
 
 OPTIMIZER = 'SLSQP'

--- a/dymos/test/test_pycodestyle.py
+++ b/dymos/test/test_pycodestyle.py
@@ -1,9 +1,11 @@
 import os
 import sys
 import unittest
-from io import StringIO
 
-import pycodestyle
+try:
+    import pycodestyle
+except ImportError:
+    pycodestyle = None
 
 import dymos
 
@@ -31,6 +33,7 @@ def _discover_python_files(path):
     return python_files
 
 
+@unittest.skipIf(pycodestyle is None, "This test requires pycodestyle")
 class TestPyCodeStyle(unittest.TestCase):
 
     def test_pycodestyle(self):

--- a/dymos/test/test_run_problem.py
+++ b/dymos/test/test_run_problem.py
@@ -6,6 +6,11 @@ import pathlib
 import numpy as np
 from numpy.testing import assert_almost_equal
 
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
+
 import openmdao
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
@@ -676,6 +681,7 @@ class TestRunProblemPlotting(unittest.TestCase):
 
         self.p = p
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_run_brachistochrone_problem_make_plots(self):
         plots_cache = dm.options['plots']
         dm.options['plots'] = 'matplotlib'
@@ -688,6 +694,7 @@ class TestRunProblemPlotting(unittest.TestCase):
                             msg=f'{varname}.png' + ' does not exist.')
         dm.options['plots'] = plots_cache
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_run_brachistochrone_problem_make_plots_set_plot_dir(self):
         _cache = dm.options['plots']
         dm.options['plots'] = 'matplotlib'
@@ -722,6 +729,7 @@ class TestRunProblemPlotting(unittest.TestCase):
 
         self.assertTrue(os.path.exists(solution_record_file))
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_run_brachistochrone_problem_plot_simulation(self):
         plots_cache = dm.options['plots']
         dm.options['plots'] = 'matplotlib'
@@ -735,6 +743,7 @@ class TestRunProblemPlotting(unittest.TestCase):
             self.assertTrue(plotfile.exists(), msg=f'plot file {plotfile} does not exist!')
         dm.options['plots'] = plots_cache
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_run_brachistochrone_problem_plot_no_simulation_record_file_given(self):
         plots_cache = dm.options['plots']
         dm.options['plots'] = 'matplotlib'

--- a/dymos/visualization/test/test_timeseries_plots.py
+++ b/dymos/visualization/test/test_timeseries_plots.py
@@ -1,8 +1,12 @@
-import os
 import unittest
 import pathlib
 
 import numpy as np
+
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
 
 import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
@@ -80,6 +84,7 @@ class TestTimeSeriesPlotsBasics(unittest.TestCase):
 
         self.p = p
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_timeseries_plots(self):
         with dm.options.temporary(plots='matplotlib'):
             dm.run_problem(self.p, make_plots=False)
@@ -94,6 +99,7 @@ class TestTimeSeriesPlotsBasics(unittest.TestCase):
             self.assertTrue(plot_dir.joinpath('theta_rate.png').exists())
             self.assertTrue(plot_dir.joinpath('theta_rate2.png').exists())
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_timeseries_plots_solution_only_set_solution_record_file(self):
         temp = dm.options['plots']
         dm.options['plots'] = 'matplotlib'
@@ -113,6 +119,7 @@ class TestTimeSeriesPlotsBasics(unittest.TestCase):
 
         dm.options['plots'] = temp
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_timeseries_plots_solution_and_simulation(self):
         temp = dm.options['plots']
         dm.options['plots'] = 'matplotlib'
@@ -132,6 +139,7 @@ class TestTimeSeriesPlotsBasics(unittest.TestCase):
 
         dm.options['plots'] = temp
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_brachistochrone_timeseries_plots_set_plot_dir(self):
 
         temp = dm.options['plots']
@@ -156,6 +164,7 @@ class TestTimeSeriesPlotsBasics(unittest.TestCase):
 class TestTimeSeriesPlotsMultiPhase(unittest.TestCase):
 
     @require_pyoptsparse(optimizer='IPOPT')
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_trajectory_linked_phases_make_plot(self):
         temp = dm.options['plots']
 
@@ -312,6 +321,7 @@ class TestTimeSeriesPlotsMultiPhase(unittest.TestCase):
 
         dm.options['plots'] = temp
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_overlapping_phases_make_plot(self):
 
         _temp = dm.options['plots']
@@ -409,6 +419,7 @@ class TestTimeSeriesPlotsMultiPhase(unittest.TestCase):
         dm.options['plots'] = _temp
 
     @require_pyoptsparse(optimizer='IPOPT')
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_trajectory_linked_phases_make_plot_missing_data(self):
         """
         Test that plots are still generated even if the phases don't share the exact same

--- a/joss/test/test_brachistochrone_for_joss.py
+++ b/joss/test/test_brachistochrone_for_joss.py
@@ -1,4 +1,10 @@
 import unittest
+
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
+
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.assert_utils import assert_near_equal
 
@@ -6,6 +12,7 @@ from openmdao.utils.assert_utils import assert_near_equal
 @use_tempdirs
 class TestBrachistochroneForJOSS(unittest.TestCase):
 
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_results(self):
 
         # Begin code for paper

--- a/joss/test/test_cannonball_for_joss.py
+++ b/joss/test/test_cannonball_for_joss.py
@@ -2,11 +2,16 @@ import unittest
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from openmdao.utils.assert_utils import assert_near_equal
 
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
 
 @use_tempdirs
 class TestCannonballForJOSS(unittest.TestCase):
 
     @require_pyoptsparse(optimizer='SLSQP')
+    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_results(self):
         # begin code for paper
         import numpy as np


### PR DESCRIPTION
### Summary

Added `skipIf` to tests that need matplotlib and/or pydocstyle so that they will be skipped when the required package is not installed.


### Related Issues

- Resolves #1061

### Backwards incompatibilities

None

### New Dependencies

None
