### PR TITLE
Modified `latest` workflow build to use petsc 3.21.0

### DIFF
--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -72,7 +72,7 @@ jobs:
             PY: 3
             NUMPY: 1
             SCIPY: 1
-            PETSc: 3
+            PETSc: 3.21.0
             PYOPTSPARSE: 'latest'
             SNOPT: 7.7
             OPENMDAO: 'dev'


### PR DESCRIPTION
### Summary

Pin the PETSc version used in the `latest` workflow build to 3.21.0, to avoid the [bug](https://gitlab.com/petsc/petsc/-/issues/1587) in in PETSc 3.21.1

This can be revisited after a new release that fixes the bug.

The version has also been pinned for the nightly benchmark/integration tests

### Related Issues

- Resolves #1063

### Backwards incompatibilities

None

### New Dependencies

None
