### PR TITLE
Changed oldest support python to 3.9

### DIFF
--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -81,7 +81,7 @@ jobs:
 
           # oldest supported versions
           - NAME: oldest
-            PY: 3.8
+            PY: 3.9
             NUMPY: 1.22
             SCIPY: 1.7
             OPENMPI: '4.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "dymos"
 dynamic = ["version"]
 description = "Open-Source Optimization of Dynamic Multidisciplinary Systems"
 license = "Apache-2.0"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
### Summary

Remove support for Python 3.8.

### Related Issues

- Resolves #1066

### Backwards incompatibilities

Future version of dymos will no longer be guaranteed to work on Python 3.8.

### New Dependencies

None
