### PR TITLE
Fixed matplotlib calls that were broken by a change in the matplotlib API

### DIFF
--- a/.github/workflows/dymos_docs_workflow.yml
+++ b/.github/workflows/dymos_docs_workflow.yml
@@ -26,14 +26,14 @@ jobs:
           # baseline versions except with pyoptsparse but no SNOPT
           # build docs to verify those that use pyoptsparse do not use SNOPT
           - NAME: baseline_no_snopt
-            PY: '3.10'
-            NUMPY: 1.22
-            SCIPY: 1.7
-            PETSc: 3.17
-            PYOPTSPARSE: 'v2.9.3'
+            PY: '3.11'
+            NUMPY: '1.26'
+            SCIPY: '1.13'
+            PETSc: '3.19'
+            PYOPTSPARSE: 'v2.11.0'
             OPENMDAO: 'latest'
             OPTIONAL: '[docs]'
-            JAX: '0.4.14'
+            JAX: '0.4.28'
             PUBLISH_DOCS: 1
 
           # make sure the latest versions of things don't break the docs
@@ -206,6 +206,7 @@ jobs:
           pip install .${{ matrix.OPTIONAL }}
 
       - name: Display environment info
+        id: env_info
         shell: bash -l {0}
         run: |
           conda info
@@ -222,6 +223,12 @@ jobs:
 
           python -c "import scipy; assert str(scipy.__version__).startswith(str(${{ matrix.SCIPY }})), \
                     f'Scipy version {scipy.__version__} is not the requested version (${{ matrix.SCIPY }})'"
+
+      - name: Display dependency tree
+        if: failure() && steps.env_info.outcome == 'failure'
+        run: |
+          pip install pipdeptree
+          pipdeptree
 
       - name: Build docs
         id: build_docs

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -28,7 +28,7 @@ jobs:
         include:
           # baseline versions
           - NAME: baseline
-            PY: '3.10'
+            PY: '3.12'
             NUMPY: 1.26
             SCIPY: 1.13
             PETSc: 3.21.0
@@ -41,7 +41,7 @@ jobs:
 
           # baseline versions except no pyoptsparse or SNOPT
           - NAME: no_pyoptsparse
-            PY: '3.10'
+            PY: '3.12'
             NUMPY: 1.26
             SCIPY: 1.13
             PETSc: 3.21.0
@@ -50,7 +50,7 @@ jobs:
 
           # baseline versions except with pyoptsparse but no SNOPT
           - NAME: no_snopt
-            PY: '3.10'
+            PY: '3.12'
             NUMPY: 1.26
             SCIPY: 1.13
             PETSc: 3.21.0
@@ -60,7 +60,7 @@ jobs:
 
           # baseline versions except no MPI/PETSc
           - NAME: no_mpi
-            PY: '3.10'
+            PY: '3.12'
             NUMPY: 1.26
             SCIPY: 1.13
             PYOPTSPARSE: 'v2.11.0'
@@ -314,7 +314,7 @@ jobs:
       - name: Check NumPy 2.0 Compatibility
         run: |
           echo "============================================================="
-          echo "Check OpenMDAO code for NumPy 2.0 compatibility"
+          echo "Check Dymos code for NumPy 2.0 compatibility"
           echo "See: https://numpy.org/devdocs/numpy_2_0_migration_guide.html"
           echo "============================================================="
           python -m pip install ruff

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -29,41 +29,41 @@ jobs:
           # baseline versions
           - NAME: baseline
             PY: '3.10'
-            NUMPY: 1.22.4
-            SCIPY: 1.7
-            PETSc: 3.17
-            PYOPTSPARSE: 'v2.9.3'
+            NUMPY: 1.26
+            SCIPY: 1.13
+            PETSc: 3.21.0
+            PYOPTSPARSE: 'v2.11.0'
             SNOPT: 7.7
             OPENMDAO: 'latest'
             PEP517: true
             OPTIONAL: '[all]'
-            JAX: '0.4.14'
+            JAX: '0.4.28'
 
           # baseline versions except no pyoptsparse or SNOPT
           - NAME: no_pyoptsparse
             PY: '3.10'
-            NUMPY: 1.22
-            SCIPY: 1.7
-            PETSc: 3.17
+            NUMPY: 1.26
+            SCIPY: 1.13
+            PETSc: 3.21.0
             OPENMDAO: 'latest'
             OPTIONAL: '[test]'
 
           # baseline versions except with pyoptsparse but no SNOPT
           - NAME: no_snopt
             PY: '3.10'
-            NUMPY: 1.22
-            SCIPY: 1.7
-            PETSc: 3.17
-            PYOPTSPARSE: 'v2.9.3'
+            NUMPY: 1.26
+            SCIPY: 1.13
+            PETSc: 3.21.0
+            PYOPTSPARSE: 'v2.11.0'
             OPENMDAO: 'latest'
             OPTIONAL: '[test]'
 
           # baseline versions except no MPI/PETSc
           - NAME: no_mpi
             PY: '3.10'
-            NUMPY: 1.22
-            SCIPY: 1.7
-            PYOPTSPARSE: 'v2.9.3'
+            NUMPY: 1.26
+            SCIPY: 1.13
+            PYOPTSPARSE: 'v2.11.0'
             OPENMDAO: 'latest'
             OPTIONAL: '[test]'
 
@@ -90,6 +90,7 @@ jobs:
             PYOPTSPARSE: 'v2.6.1'
             SNOPT: 7.2
             OPENMDAO: 3.28.0
+            MATPLOTLIB: 3.5
             OPTIONAL: '[test]'
 
     steps:
@@ -249,6 +250,15 @@ jobs:
             pip install openmdao==${{ matrix.OPENMDAO }}
           fi
 
+      - name: Install Matplotlib
+        if: env.RUN_BUILD && matrix.MATPLOTLIB
+        shell: bash -l {0}
+        run: |
+          echo "============================================================="
+          echo "Install requested version of Matpltlib"
+          echo "============================================================="
+          python -m pip install matplotlib==${{ matrix.MATPLOTLIB }}
+
       - name: Install Dymos
         if: env.RUN_BUILD
         shell: bash -l {0}
@@ -268,6 +278,7 @@ jobs:
           fi
 
       - name: Display environment info
+        id: env_info
         if: env.RUN_BUILD
         shell: bash -l {0}
         run: |
@@ -287,12 +298,27 @@ jobs:
           python -c "ver='${{ matrix.SCIPY }}'; import scipy; assert str(scipy.__version__).startswith(ver), \
                     f'Scipy version {scipy.__version__} is not the requested version ({ver})'"
 
+      - name: Display dependency tree
+        if: failure() && steps.env_info.outcome == 'failure'
+        run: |
+          pip install pipdeptree
+          pipdeptree
+
       - name: 'Upload environment artifact'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.NAME }}_environment
           path: ${{ matrix.NAME }}_environment.yml
           retention-days: 5
+
+      - name: Check NumPy 2.0 Compatibility
+        run: |
+          echo "============================================================="
+          echo "Check OpenMDAO code for NumPy 2.0 compatibility"
+          echo "See: https://numpy.org/devdocs/numpy_2_0_migration_guide.html"
+          echo "============================================================="
+          python -m pip install ruff
+          ruff check . --select NPY201
 
       - name: Run tests
         if: env.RUN_BUILD

--- a/docs/dymos_book/examples/racecar/racecar.ipynb
+++ b/docs/dymos_book/examples/racecar/racecar.ipynb
@@ -458,7 +458,7 @@
     "    s_new = np.linspace(0, s_final, npoints)\n",
     "\n",
     "    # Colormap and norm of the track plot\n",
-    "    cmap = mpl.cm.get_cmap('viridis')\n",
+    "    cmap = mpl.colormaps['viridis']\n",
     "    norm = mpl.colors.Normalize(vmin=np.amin(state), vmax=np.amax(state))\n",
     "\n",
     "    fig, ax = plt.subplots(figsize=(15, 6))\n",

--- a/dymos/examples/racecar/test/test_racecar.py
+++ b/dymos/examples/racecar/test/test_racecar.py
@@ -228,7 +228,7 @@ class TestRaceCarForDocs(unittest.TestCase):
             s_new = np.linspace(0, s_final, npoints)
 
             # Colormap and norm of the track plot
-            cmap = mpl.cm.get_cmap('viridis')
+            cmap = matplotlib.colormaps['viridis']
             norm = mpl.colors.Normalize(vmin=np.amin(state), vmax=np.amax(state))
 
             fig, ax = plt.subplots(figsize=(15, 6))

--- a/dymos/visualization/timeseries_plots.py
+++ b/dymos/visualization/timeseries_plots.py
@@ -59,7 +59,7 @@ def _mpl_timeseries_plots(time_units, var_units, phase_names, phases_node_path,
     backend_save = plt.get_backend()
     plt.switch_backend('Agg')
     # use a colormap with 20 values
-    cm = matplotlib.cm.get_cmap('tab20')
+    cm = matplotlib.colormaps['tab20']
     plotfiles = []
 
     for var_name, var_unit in var_units.items():


### PR DESCRIPTION
### Summary

- Updated calls to matplotlib's `cm.get_cmap()` function to use the [colormap registry](https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.5.0.html#colormap-registry-experimental) 
- Updated baseline versions of dependencies used in continuous integration testing
- Added a preinstall of matplotlib 3.5 as the `oldest` supported version in the Tests workflow
- Added a `pipdeptree` step to the Tests workflow to assist in determining the cause of dependency changes
- Added a Numpy 2.0 compatibility check to the Tests workflow

### Related Issues

- Resolves #1068 

### Backwards incompatibilities

None

### New Dependencies

None
