### PR TITLE
Fixed a bug where timeserires report use of fig.circle instead of fig.scatter stopped working in Bokeh 3.4.

### DIFF
--- a/dymos/visualization/timeseries/bokeh_timeseries_report.py
+++ b/dymos/visualization/timeseries/bokeh_timeseries_report.py
@@ -483,7 +483,8 @@ def make_timeseries_report(prob, solution_record_file=None, simulation_record_fi
                     if x_name in sol_data and var_name in sol_data:
                         legend_items = []
                         if sol_data:
-                            sol_plot = fig.circle(x='time', y=var_name, source=sol_source, color=color)
+                            sol_plot = fig.scatter(x='time', y=var_name, source=sol_source,
+                                                   color=color, size=5)
                             sol_plot.tags.extend(['sol', f'phase:{phase_name}'])
                             legend_items.append(sol_plot)
                         if sim_data:


### PR DESCRIPTION
### Summary

Users reported timeseries reports were not displaying correctly.
Bokeh 3.4 deprecated the use of `fig.circle` as a scatter plot in favor of the use of `fig.scatter`.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
