### PR TITLE
Added optional `integ_var_options` for `time_options` when the integration variable is not time.

### DIFF
--- a/docs/dymos_book/examples/racecar/racecar.ipynb
+++ b/docs/dymos_book/examples/racecar/racecar.ipynb
@@ -209,19 +209,19 @@
    ]
   },
   {
-    "cell_type": "code",
-    "execution_count": null,
-    "metadata": {
-     "tags": [
-      "active-ipynb",
-      "remove-input",
-      "remove-output"
-     ]
-    },
-    "outputs": [],
-    "source": [
-     "%matplotlib inline"
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "active-ipynb",
+     "remove-input",
+     "remove-output"
     ]
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
   },
   {
    "cell_type": "code",
@@ -277,9 +277,10 @@
     "# the rate of change of curvature.\n",
     "# The state equations are written with respect to time, the variable change occurs in\n",
     "# timeODE.py\n",
-    "phase.set_time_options(fix_initial=True, fix_duration=True, duration_val=s_final,\n",
-    "                       targets=['curv.s'], units='m', duration_ref=s_final,\n",
-    "                       duration_ref0=10, name='s')\n",
+    "# Here we're using set_integ_var_options, which is just an alias for set_time_options.\n",
+    "phase.set_integ_var_options(fix_initial=True, fix_duration=True, duration_val=s_final,\n",
+    "                            targets=['curv.s'], units='m', duration_ref=s_final,\n",
+    "                            duration_ref0=10, name='s')\n",
     "\n",
     "# Define states\n",
     "phase.add_state('t', fix_initial=True, fix_final=False, units='s', lower=0,\n",
@@ -602,6 +603,15 @@
     "# Test this example in Dymos' continuous integration process\n",
     "assert_near_equal(p.get_val('traj.phase0.timeseries.t')[-1], 22.2657, tolerance=0.01)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(s)"
+   ]
   }
  ],
  "metadata": {
@@ -629,7 +639,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/dymos/examples/racecar/test/test_racecar.py
+++ b/dymos/examples/racecar/test/test_racecar.py
@@ -64,9 +64,9 @@ class TestRaceCarForDocs(unittest.TestCase):
                 # the rate of change of curvature.
                 # The state equations are written with respect to time, the variable change occurs in
                 # timeODE.py
-                phase.set_time_options(fix_initial=True, fix_duration=True, duration_val=s_final,
-                                       name='s', targets=['curv.s'], units='m', duration_ref=s_final,
-                                       duration_ref0=10)
+                phase.set_integ_var_options(fix_initial=True, fix_duration=True, duration_val=s_final,
+                                            name='s', targets=['curv.s'], units='m', duration_ref=s_final,
+                                            duration_ref0=10)
 
                 # Define states
                 phase.add_state('t', fix_initial=True, fix_final=False, units='s', lower=0,
@@ -163,6 +163,11 @@ class TestRaceCarForDocs(unittest.TestCase):
                 # Setup the problem
                 p.setup(check=True)  # force_alloc_complex=True
                 # Now that the OpenMDAO problem is setup, we can set the values of the states.
+
+                # Test that set_integ_var_val works.
+                # This isn't necessary because we already set the fixed endpoints
+                # in set_integ_var_options, but here it's serving as a test of the method.
+                phase.set_integ_var_val(initial=0, duration=s_final, units='m')
 
                 # States
                 # Nonzero velocity to avoid division by zero errors

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -207,6 +207,15 @@ class Phase(om.Group):
         self.options['time_options'] = tod
 
     @property
+    def integ_var_options(self):
+        """ An alias for time options. """
+        return self.options['time_options']
+
+    @integ_var_options.setter
+    def integ_var_options(self, iod: TimeOptionsDictionary):
+        self.options['time_options'] = iod
+
+    @property
     def state_options(self):
         return self.options['state_options']
 
@@ -1875,6 +1884,15 @@ class Phase(om.Group):
         if name is not _unspecified:
             self.time_options['name'] = name
 
+    def set_integ_var_options(self, *args, **kwargs):
+        """
+        Set the integration variable options for the phase.
+
+        This is an alias for set_time_options that may be more intuitive
+        when the variable of integration is not time.
+        """
+        self.set_time_options(*args, **kwargs)
+
     def set_time_val(self, initial=None, duration=None, units=None):
         """
         Set the values for initial time and the duration of the phase.
@@ -1894,6 +1912,15 @@ class Phase(om.Group):
             self.set_val('t_initial', initial, units=units)
         if duration is not None:
             self.set_val('t_duration', duration, units=units)
+
+    def set_integ_var_val(self, initial=None, duration=None, units=None):
+        """
+        Set the values for initial integration variable value and duration in the phase.
+
+        This is an alias for set_time_val that may be more intuitive
+        when the variable of integration is not time.
+        """
+        self.set_time_val(initial, duration, units)
 
     def set_state_val(self, name, vals=None, time_vals=None,
                       units=None, interpolation_kind='linear'):

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -1890,6 +1890,15 @@ class Phase(om.Group):
 
         This is an alias for set_time_options that may be more intuitive
         when the variable of integration is not time.
+
+        See `set_time_options` for descirptions of the arguments.
+
+        Parameters
+        ----------
+        *args : tuple
+            Positional arguments to be passed to set_time_options.
+        **kwargs : dict
+            Keyword arguments to be passed to set_time_options.
         """
         self.set_time_options(*args, **kwargs)
 
@@ -1919,6 +1928,15 @@ class Phase(om.Group):
 
         This is an alias for set_time_val that may be more intuitive
         when the variable of integration is not time.
+
+        Parameters
+        ----------
+        initial : float or None
+            Initial value for the integation variable.
+        duration : float or None
+            Value for the phase duration in the integration variable.
+        units : str or None
+            Units of the time. If none are specified, the default units are used.
         """
         self.set_time_val(initial, duration, units)
 


### PR DESCRIPTION
### Summary

Added `phase.integ_var_options`, `phase.set_integ_var_options`, and `phase.set_integ_var_val` as aliases for `phase.time_options`, `phase.set_time_options`, and `phase.set_time_val`, respectively.  These aliases might seem more natural when the integration variable of the phase is not `time`.

### Related Issues

- Resolves #1048

### Backwards incompatibilities

None

### New Dependencies

None
