### PR TITLE
Replace deprecated numpy function `in1d()` with `isin()`

### DIFF
--- a/dymos/transcriptions/pseudospectral/birkhoff.py
+++ b/dymos/transcriptions/pseudospectral/birkhoff.py
@@ -721,7 +721,7 @@ class Birkhoff(TranscriptionBase):
                     # Repeat nodes that are on segment bounds (but not the first or last nodes in the phase)
                     nodes_to_repeat = list(set(state_input_idxs).intersection(set(segment_end_idxs)))
                     # Now find these nodes in the state input indices
-                    idxs_of_ntr_in_state_inputs = np.where(np.in1d(state_input_idxs, nodes_to_repeat))[0]
+                    idxs_of_ntr_in_state_inputs = np.where(np.isin(state_input_idxs, nodes_to_repeat))[0]
                     # All state input nodes are used once, but nodes_to_repeat are used twice
                     repeat_idxs[idxs_of_ntr_in_state_inputs] = 2
                 # Now we have a way of mapping the state input indices to all nodes

--- a/dymos/transcriptions/pseudospectral/components/birkhoff_iter_group.py
+++ b/dymos/transcriptions/pseudospectral/components/birkhoff_iter_group.py
@@ -289,7 +289,7 @@ class BirkhoffIterGroup(om.Group):
                 # Repeat nodes that are on segment bounds (but not the first or last nodes in the phase)
                 nodes_to_repeat = list(set(state_input_idxs).intersection(segment_end_idxs))
                 # Now find these nodes in the state input indices
-                idxs_of_ntr_in_state_inputs = np.where(np.in1d(state_input_idxs, nodes_to_repeat))[0]
+                idxs_of_ntr_in_state_inputs = np.where(np.isin(state_input_idxs, nodes_to_repeat))[0]
                 # All state input nodes are used once, but nodes_to_repeat are used twice
                 repeat_idxs[idxs_of_ntr_in_state_inputs] = 2
             # Now we have a way of mapping the state input indices to all nodes

--- a/dymos/transcriptions/pseudospectral/pseudospectral_base.py
+++ b/dymos/transcriptions/pseudospectral/pseudospectral_base.py
@@ -402,7 +402,7 @@ class PseudospectralBase(TranscriptionBase):
         state_disc_idxs = grid_data.subset_node_indices['state_disc']
 
         if any_state_cnty:
-            state_input_subidxs = np.where(np.in1d(state_disc_idxs, segment_end_idxs))[0]
+            state_input_subidxs = np.where(np.isin(state_disc_idxs, segment_end_idxs))[0]
 
             for name, options in phase.state_options.items():
                 shape = options['shape']

--- a/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
+++ b/dymos/transcriptions/pseudospectral/radau_pseudospectral.py
@@ -245,7 +245,7 @@ class Radau(PseudospectralBase):
                 # Repeat nodes that are on segment bounds (but not the first or last nodes in the phase)
                 nodes_to_repeat = list(set(state_input_idxs).intersection(segment_end_idxs))
                 # Now find these nodes in the state input indices
-                idxs_of_ntr_in_state_inputs = np.where(np.in1d(state_input_idxs, nodes_to_repeat))[0]
+                idxs_of_ntr_in_state_inputs = np.where(np.isin(state_input_idxs, nodes_to_repeat))[0]
                 # All state input nodes are used once, but nodes_to_repeat are used twice
                 repeat_idxs[idxs_of_ntr_in_state_inputs] = 2
             # Now we have a way of mapping the state input indices to all nodes
@@ -349,7 +349,7 @@ class Radau(PseudospectralBase):
                 # Repeat nodes that are on segment bounds (but not the first or last nodes in the phase)
                 nodes_to_repeat = list(set(state_input_idxs).intersection(set(segment_end_idxs)))
                 # Now find these nodes in the state input indices
-                idxs_of_ntr_in_state_inputs = np.where(np.in1d(state_input_idxs, nodes_to_repeat))[0]
+                idxs_of_ntr_in_state_inputs = np.where(np.isin(state_input_idxs, nodes_to_repeat))[0]
                 # All state input nodes are used once, but nodes_to_repeat are used twice
                 repeat_idxs[idxs_of_ntr_in_state_inputs] = 2
             # Now we have a way of mapping the state input indices to all nodes


### PR DESCRIPTION
### Summary

Replaced multiple occurrences of the  numpy function `in1d()`, which was deprecated in NumPy 2.0, with `isin()` per the [NumPy 2.0 Migration Guide](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html).

This will allow NumPy 2.0 compatibility check to pass in the GitHub CI workflow.

### Related Issues

- Resolves #1080

### Backwards incompatibilities

None

### New Dependencies

None
