### PR TITLE
Updated phase.load_case so that it uses the state_xxx_vals API.  Specify parent when subproblems are used.

### DIFF
--- a/dymos/examples/brachistochrone/test/test_brachistochrone_subprob_reports.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_subprob_reports.py
@@ -17,8 +17,8 @@ import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
 
-def setup_model_radau(do_reports):
-    p = om.Problem(model=om.Group())
+def setup_model_radau(do_reports, probname):
+    p = om.Problem(model=om.Group(), name=probname)
 
     p.driver = om.ScipyOptimizeDriver()
     p.driver.declare_coloring(tol=1.0E-12)
@@ -64,16 +64,13 @@ def setup_model_radau(do_reports):
     phase.set_control_val('theta', [5, 100.5])
     phase.set_parameter_val('g', 9.80665)
 
-    if do_reports:
-        dm.run_problem(p, run_driver=True, simulate=True, simulate_kwargs={'reports': True})
-    else:
-        dm.run_problem(p, run_driver=True, simulate=True)
+    dm.run_problem(p, run_driver=True, simulate=True, simulate_kwargs={'reports': do_reports})
 
     return p
 
 
-def setup_model_shooting(do_reports):
-    prob = om.Problem()
+def setup_model_shooting(do_reports, probname):
+    prob = om.Problem(name=probname)
 
     prob.driver = om.ScipyOptimizeDriver()
     prob.driver.declare_coloring(tol=1.0E-12)
@@ -112,198 +109,89 @@ def setup_model_shooting(do_reports):
     phase.set_control_val('theta', [0.01, 90], units='deg')
     phase.set_parameter_val('g', 1.0)
 
-    dm.run_problem(prob, run_driver=True, simulate=False)
+    dm.run_problem(prob, run_driver=True, simulate=True)
 
     return prob
 
 
-# reports API between 3.18 and 3.19, so handle it here in order to be able to test against older
-# versions of openmdao
-if Version(openmdao_version) > Version("3.18"):
-    from openmdao.utils.reports_system import get_reports_dir, clear_reports
+@use_tempdirs
+class TestSubproblemReportToggle(unittest.TestCase):
 
-    @use_tempdirs
-    class TestSubproblemReportToggle(unittest.TestCase):
+    def setUp(self):
+        self.n2_filename = _default_n2_filename
+        self.scaling_filename = _default_scaling_filename
 
-        def setUp(self):
-            self.n2_filename = _default_n2_filename
-            self.scaling_filename = _default_scaling_filename
+        # set things to a known initial state for all the test runs
+        openmdao.core.problem._problem_names = []  # need to reset these to simulate separate runs
+        os.environ.pop('OPENMDAO_REPORTS', None)
+        os.environ.pop('OPENMDAO_REPORTS_DIR', None)
+        # We need to remove the TESTFLO_RUNNING environment variable for these tests to run.
+        # The reports code checks to see if TESTFLO_RUNNING is set and will not do anything if set
+        # But we need to remember whether it was set so we can restore it
+        self.testflo_running = os.environ.pop('TESTFLO_RUNNING', None)
 
-            # set things to a known initial state for all the test runs
-            openmdao.core.problem._problem_names = []  # need to reset these to simulate separate runs
-            os.environ.pop('OPENMDAO_REPORTS', None)
-            os.environ.pop('OPENMDAO_REPORTS_DIR', None)
-            # We need to remove the TESTFLO_RUNNING environment variable for these tests to run.
-            # The reports code checks to see if TESTFLO_RUNNING is set and will not do anything if set
-            # But we need to remember whether it was set so we can restore it
-            self.testflo_running = os.environ.pop('TESTFLO_RUNNING', None)
-            clear_reports()
+        self.count = 0
 
-            self.count = 0
+    def tearDown(self):
+        # restore what was there before running the test
+        if self.testflo_running is not None:
+            os.environ['TESTFLO_RUNNING'] = self.testflo_running
 
-        def tearDown(self):
-            # restore what was there before running the test
-            if self.testflo_running is not None:
-                os.environ['TESTFLO_RUNNING'] = self.testflo_running
+    @hooks_active
+    def test_no_sim_reports(self):
+        p = setup_model_radau(do_reports=False, probname='test_no_sim_reports')
 
-        @hooks_active
-        def test_no_sim_reports(self):
-            p = setup_model_radau(do_reports=False)
+        main_outputs_dir = p.get_outputs_dir()
+        main_reports_dir = p.get_reports_dir()
 
-            report_subdirs = sorted([e for e in pathlib.Path(get_reports_dir()).iterdir() if e.is_dir()])
+        sim_outputs_dir = main_outputs_dir / 'traj0_simulation_out'
+        sim_reports_dir = sim_outputs_dir / 'reports'
 
-            # Test that a report subdir was made
-            self.assertEqual(len(report_subdirs), 1)
+        self.assertFalse(sim_reports_dir.exists())
 
-            path = pathlib.Path(report_subdirs[0]).joinpath(self.n2_filename)
-            self.assertTrue(path.is_file(), f'The N2 report file, {str(path)} was not found')
-            path = pathlib.Path(report_subdirs[0]).joinpath(self.scaling_filename)
-            self.assertTrue(path.is_file(), f'The scaling report file, {str(path)}, was not found')
+    @hooks_active
+    def test_make_sim_reports(self):
+        p = setup_model_radau(do_reports=True, probname='test_make_sim_reports')
 
-        @hooks_active
-        def test_make_sim_reports(self):
-            p = setup_model_radau(do_reports=True)
+        main_outputs_dir = p.get_outputs_dir()
+        main_reports_dir = p.get_reports_dir()
 
-            report_subdirs = sorted([e for e in pathlib.Path(get_reports_dir()).iterdir() if e.is_dir()])
+        sim_outputs_dir = main_outputs_dir / 'traj0_simulation_out'
+        sim_reports_dir = sim_outputs_dir / 'reports'
 
-            # Test that a report subdir was made
-            # There is the nominal problem, the simulation problem, and a subproblem for the simulation.
-            self.assertEqual(len(report_subdirs), 3)
+        self.assertTrue(sim_reports_dir.exists())
+        self.assertTrue((sim_reports_dir / self.n2_filename).exists())
 
-            for subdir in report_subdirs:
-                path = pathlib.Path(subdir).joinpath(self.n2_filename)
-                self.assertTrue(path.is_file(), f'The N2 report file, {str(path)} was not found')
+    @hooks_active
+    def test_explicitshooting_no_subprob_reports(self):
+        p = setup_model_shooting(do_reports=False,
+                                 probname='test_explicitshooting_no_subprob_reports')
 
-        @hooks_active
-        def test_explicitshooting_no_subprob_reports(self):
-            p = setup_model_shooting(do_reports=False)
+        main_reports_dir = p.get_reports_dir()
+        subprob_reports_dir = p.model.phase0.integrator._eval_subprob.get_reports_dir()
 
-            report_subdirs = sorted([e for e in pathlib.Path(get_reports_dir()).iterdir() if e.is_dir()])
+        main_reports = os.listdir(main_reports_dir)
 
-            # Test that a report subdir was made
-            self.assertEqual(len(report_subdirs), 1)
+        self.assertFalse(subprob_reports_dir.exists())
 
-            path = pathlib.Path(report_subdirs[0]).joinpath(self.n2_filename)
-            self.assertTrue(path.is_file(), f'The N2 report file, {str(path)} was not found')
-            path = pathlib.Path(report_subdirs[0]).joinpath(self.scaling_filename)
-            self.assertTrue(path.is_file(), f'The scaling report file, {str(path)}, was not found')
+        self.assertIn(self.n2_filename, main_reports)
+        self.assertIn(self.scaling_filename, main_reports)
 
-        @hooks_active
-        def test_explicitshooting_make_subprob_reports(self):
-            p = setup_model_shooting(do_reports=True)
+    @hooks_active
+    def test_explicitshooting_make_subprob_reports(self):
+        p = setup_model_shooting(do_reports=True,
+                                 probname='test_explicitshooting_make_subprob_reports')
 
-            report_subdirs = sorted([e for e in pathlib.Path(get_reports_dir()).iterdir() if e.is_dir()])
+        main_reports_dir = p.get_reports_dir()
+        subprob_reports_dir = p.model.phase0.integrator._eval_subprob.get_reports_dir()
 
-            # Test that a report subdir was made
-            # There is the nominal problem, a subproblem for integration, and a subproblem for the derivatives.
-            self.assertEqual(len(report_subdirs), 2)
+        main_reports = os.listdir(main_reports_dir)
+        subprob_reports = os.listdir(subprob_reports_dir)
 
-            path = pathlib.Path(report_subdirs[0]).joinpath(self.n2_filename)
-            self.assertTrue(path.is_file(), f'The N2 report file, {str(path)} was not found')
-            path = pathlib.Path(report_subdirs[0]).joinpath(self.scaling_filename)
-            self.assertTrue(path.is_file(), f'The scaling report file, {str(path)}, was not found')
+        self.assertIn(self.n2_filename, main_reports)
+        self.assertIn(self.n2_filename, subprob_reports)
 
-            for subdir in report_subdirs:
-                path = pathlib.Path(subdir).joinpath(self.n2_filename)
-                self.assertTrue(path.is_file(), f'The N2 report file, {str(path)} was not found')
+        self.assertIn(self.scaling_filename, main_reports)
 
-else:  # old OM versions before reports API changed...
-    from openmdao.utils.reports_system import set_default_reports_dir, _reports_dir, clear_reports, \
-        setup_default_reports
-
-    @use_tempdirs
-    class TestSubproblemReportToggle(unittest.TestCase):
-
-        def setUp(self):
-            self.n2_filename = _default_n2_filename
-            self.scaling_filename = _default_scaling_filename
-
-            # set things to a known initial state for all the test runs
-            openmdao.core.problem._problem_names = []  # need to reset these to simulate separate runs
-            os.environ.pop('OPENMDAO_REPORTS', None)
-            os.environ.pop('OPENMDAO_REPORTS_DIR', None)
-            # We need to remove the TESTFLO_RUNNING environment variable for these tests to run.
-            # The reports code checks to see if TESTFLO_RUNNING is set and will not do anything if set
-            # But we need to remember whether it was set so we can restore it
-            self.testflo_running = os.environ.pop('TESTFLO_RUNNING', None)
-            clear_reports()
-            set_default_reports_dir(_reports_dir)
-
-            self.count = 0
-
-        def tearDown(self):
-            # restore what was there before running the test
-            if self.testflo_running is not None:
-                os.environ['TESTFLO_RUNNING'] = self.testflo_running
-
-        @hooks_active
-        def test_no_sim_reports(self):
-            setup_default_reports()
-
-            p = setup_model_radau(do_reports=False)
-
-            problem_reports_dir = pathlib.Path(_reports_dir).joinpath(p._name)
-            report_subdirs = sorted([e for e in pathlib.Path(_reports_dir).iterdir() if e.is_dir()])
-
-            # Test that a report subdir was made
-            self.assertEqual(len(report_subdirs), 1)
-
-            path = pathlib.Path(problem_reports_dir).joinpath(self.n2_filename)
-            self.assertTrue(path.is_file(), f'The N2 report file, {str(path)} was not found')
-            path = pathlib.Path(problem_reports_dir).joinpath(self.scaling_filename)
-            self.assertTrue(path.is_file(), f'The scaling report file, {str(path)}, was not found')
-
-        @hooks_active
-        def test_make_sim_reports(self):
-            setup_default_reports()
-
-            p = setup_model_radau(do_reports=True)
-
-            report_subdirs = sorted([e for e in pathlib.Path(_reports_dir).iterdir() if e.is_dir()])
-
-            # Test that a report subdir was made
-            # # There is the nominal problem, the simulation problem, and a subproblem for each segment in the simulation.
-            self.assertEqual(len(report_subdirs), 12)
-
-            for subdir in report_subdirs:
-                path = pathlib.Path(subdir).joinpath(self.n2_filename)
-                self.assertTrue(path.is_file(), f'The N2 report file, {str(path)} was not found')
-
-        @hooks_active
-        def test_explicitshooting_no_subprob_reports(self):
-            setup_default_reports()
-
-            p = setup_model_shooting(do_reports=False)
-
-            problem_reports_dir = pathlib.Path(_reports_dir).joinpath(p._name)
-            report_subdirs = sorted([e for e in pathlib.Path(_reports_dir).iterdir() if e.is_dir()])
-
-            # Test that a report subdir was made
-            self.assertEqual(len(report_subdirs), 1)
-
-            path = pathlib.Path(problem_reports_dir).joinpath(self.n2_filename)
-            self.assertTrue(path.is_file(), f'The N2 report file, {str(path)} was not found')
-            path = pathlib.Path(problem_reports_dir).joinpath(self.scaling_filename)
-            self.assertTrue(path.is_file(), f'The scaling report file, {str(path)}, was not found')
-
-        @hooks_active
-        def test_explicitshooting_make_subprob_reports(self):
-            setup_default_reports()
-
-            p = setup_model_shooting(do_reports=True)
-
-            problem_reports_dir = pathlib.Path(_reports_dir).joinpath(p._name)
-            report_subdirs = sorted([e for e in pathlib.Path(_reports_dir).iterdir() if e.is_dir()])
-
-            # Test that a report subdir was made
-            # There is the nominal problem and a subproblem for integration
-            self.assertEqual(len(report_subdirs), 2)
-
-            path = pathlib.Path(problem_reports_dir).joinpath(self.n2_filename)
-            self.assertTrue(path.is_file(), f'The N2 report file, {str(path)} was not found')
-            path = pathlib.Path(problem_reports_dir).joinpath(self.scaling_filename)
-            self.assertTrue(path.is_file(), f'The scaling report file, {str(path)}, was not found')
-
-            for subdir in report_subdirs:
-                path = pathlib.Path(subdir).joinpath(self.n2_filename)
-                self.assertTrue(path.is_file(), f'The N2 report file, {str(path)} was not found')
+        # The subprob has no optimization, so should not have a scaling report
+        self.assertNotIn(self.scaling_filename, subprob_reports)

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_subprob_reports.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_subprob_reports.py
@@ -140,7 +140,8 @@ class TestSubproblemReportToggle(unittest.TestCase):
         if self.testflo_running is not None:
             os.environ['TESTFLO_RUNNING'] = self.testflo_running
 
-    @unittest.skipIf(om_version <= (3, 34, 2))
+
+    @unittest.skipIf(om_version <= (3, 34, 2), 'Requires OpenMDAO version later than 3.34.2')
     @hooks_active
     def test_no_sim_reports(self):
         p = setup_model_radau(do_reports=False, probname='test_no_sim_reports')
@@ -153,22 +154,21 @@ class TestSubproblemReportToggle(unittest.TestCase):
 
         self.assertFalse(sim_reports_dir.exists())
 
-    @unittest.skipIf(om_version <= (3, 34, 2))
+    @unittest.skipIf(om_version <= (3, 34, 2), 'Requires OpenMDAO version later than 3.34.2')
     @hooks_active
     def test_make_sim_reports(self):
         p = setup_model_radau(do_reports=True, probname='test_make_sim_reports')
 
-        main_outputs_dir = p.get_outputs_dir()
         main_reports_dir = p.get_reports_dir()
 
-        sim_outputs_dir = main_outputs_dir / 'traj0_simulation_out'
-        sim_reports_dir = sim_outputs_dir / 'reports'
+        traj = p.model._get_subsystem('traj0')
+        sim_reports_dir = traj.sim_prob.get_reports_dir()
 
         self.assertTrue((main_reports_dir / self.n2_filename).exists())
         self.assertTrue(sim_reports_dir.exists())
         self.assertTrue((sim_reports_dir / self.n2_filename).exists())
 
-    @unittest.skipIf(om_version <= (3, 34, 2))
+    @unittest.skipIf(om_version <= (3, 34, 2), 'Requires OpenMDAO version later than 3.34.2')
     @hooks_active
     def test_explicitshooting_no_subprob_reports(self):
         p = setup_model_shooting(do_reports=False,
@@ -184,7 +184,7 @@ class TestSubproblemReportToggle(unittest.TestCase):
         self.assertIn(self.n2_filename, main_reports)
         self.assertIn(self.scaling_filename, main_reports)
 
-    @unittest.skipIf(om_version <= (3, 34, 2))
+    @unittest.skipIf(om_version <= (3, 34, 2), 'Requires OpenMDAO version later than 3.34.2')
     @hooks_active
     def test_explicitshooting_make_subprob_reports(self):
         p = setup_model_shooting(do_reports=True,
@@ -203,3 +203,7 @@ class TestSubproblemReportToggle(unittest.TestCase):
 
         # The subprob has no optimization, so should not have a scaling report
         self.assertNotIn(self.scaling_filename, subprob_reports)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_subprob_reports.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_subprob_reports.py
@@ -4,17 +4,20 @@ import pathlib
 import os
 from packaging.version import Version
 
+import openmdao
 import openmdao.api as om
 import openmdao.core.problem
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.tests.test_hooks import hooks_active
 from openmdao.visualization.n2_viewer.n2_viewer import _default_n2_filename
 from openmdao.visualization.scaling_viewer.scaling_report import _default_scaling_filename
-from openmdao import __version__ as openmdao_version
 
 
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
+
+
+om_version = tuple([int(s) for s in openmdao.__version__.split('-')[0].split('.')])
 
 
 def setup_model_radau(do_reports, probname):
@@ -137,6 +140,7 @@ class TestSubproblemReportToggle(unittest.TestCase):
         if self.testflo_running is not None:
             os.environ['TESTFLO_RUNNING'] = self.testflo_running
 
+    @unittest.skipIf(om_version <= (3, 34, 2))
     @hooks_active
     def test_no_sim_reports(self):
         p = setup_model_radau(do_reports=False, probname='test_no_sim_reports')
@@ -149,6 +153,7 @@ class TestSubproblemReportToggle(unittest.TestCase):
 
         self.assertFalse(sim_reports_dir.exists())
 
+    @unittest.skipIf(om_version <= (3, 34, 2))
     @hooks_active
     def test_make_sim_reports(self):
         p = setup_model_radau(do_reports=True, probname='test_make_sim_reports')
@@ -159,9 +164,11 @@ class TestSubproblemReportToggle(unittest.TestCase):
         sim_outputs_dir = main_outputs_dir / 'traj0_simulation_out'
         sim_reports_dir = sim_outputs_dir / 'reports'
 
+        self.assertTrue((main_reports_dir / self.n2_filename).exists())
         self.assertTrue(sim_reports_dir.exists())
         self.assertTrue((sim_reports_dir / self.n2_filename).exists())
 
+    @unittest.skipIf(om_version <= (3, 34, 2))
     @hooks_active
     def test_explicitshooting_no_subprob_reports(self):
         p = setup_model_shooting(do_reports=False,
@@ -177,6 +184,7 @@ class TestSubproblemReportToggle(unittest.TestCase):
         self.assertIn(self.n2_filename, main_reports)
         self.assertIn(self.scaling_filename, main_reports)
 
+    @unittest.skipIf(om_version <= (3, 34, 2))
     @hooks_active
     def test_explicitshooting_make_subprob_reports(self):
         p = setup_model_shooting(do_reports=True,

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_subprob_reports.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_subprob_reports.py
@@ -140,7 +140,6 @@ class TestSubproblemReportToggle(unittest.TestCase):
         if self.testflo_running is not None:
             os.environ['TESTFLO_RUNNING'] = self.testflo_running
 
-
     @unittest.skipIf(om_version <= (3, 34, 2), 'Requires OpenMDAO version later than 3.34.2')
     @hooks_active
     def test_no_sim_reports(self):

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -2729,7 +2729,7 @@ class Phase(om.Group):
             can be interrogated to obtain timeseries outputs in the same manner as other Phases
             to obtain results at the requested times.
         """
-        sim_prob = om.Problem(model=om.Group())
+        sim_prob = om.Problem(model=om.Group(), comm=self.comm, name=f'{self.name}_simulation')
 
         sim_phase = self.get_simulation_phase(times_per_seg=times_per_seg, method=method, atol=atol, rtol=rtol,
                                               first_step=first_step, max_step=max_step)
@@ -2740,7 +2740,7 @@ class Phase(om.Group):
             rec = om.SqliteRecorder(record_file)
             sim_prob.add_recorder(rec)
 
-        sim_prob.setup(check=True)
+        sim_prob.setup(check=True, parent=self)
         sim_prob.final_setup()
 
         sim_phase.set_vals_from_phase(from_phase=self)

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -52,18 +52,18 @@ class Phase(om.Group):
     On setup, the Phase runs through its setup stack which will add the appropriate OpenMDAO
     systems as prescribed by its associated Transcription.
 
-    Attributes
-    ----------
-    sim_prob : Problem or None
-        The OpenMDAO problem used for trajectory simulation.
-        This is None unless the simulate method has been called.
-
     Parameters
     ----------
     from_phase : <Phase> or None
         A phase instance from which the initialized phase should copy its data.
     **kwargs : dict
         Dictionary of optional phase arguments.
+
+    Attributes
+    ----------
+    sim_prob : Problem or None
+        The OpenMDAO problem used for trajectory simulation.
+        This is None unless the simulate method has been called.
     """
     def __init__(self, from_phase=None, **kwargs):
         _kwargs = kwargs.copy()

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -2740,7 +2740,10 @@ class Phase(om.Group):
             rec = om.SqliteRecorder(record_file)
             sim_prob.add_recorder(rec)
 
-        sim_prob.setup(check=True, parent=self)
+        if om_version <= (3, 42, 2):
+            sim_prob.setup(check=True)
+        else:
+            sim_prob.setup(check=True, parent=self)
         sim_prob.final_setup()
 
         sim_phase.set_vals_from_phase(from_phase=self)

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -1484,7 +1484,7 @@ class Trajectory(om.Group):
             sim_prob_name = f'{self.name}_simulation_{i}'
 
         self.sim_prob = sim_prob = om.Problem(model=om.Group(), reports=reports, comm=self.comm,
-                                               name=sim_prob_name)
+                                              name=sim_prob_name)
 
         traj_name = self.name if self.name else 'sim_traj'
         sim_prob.model.add_subsystem(traj_name, sim_traj)

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -1466,7 +1466,8 @@ class Trajectory(om.Group):
 
         sim_traj.parameter_options.update(self.parameter_options)
 
-        sim_prob = om.Problem(model=om.Group(), reports=reports, comm=self.comm)
+        sim_prob = om.Problem(model=om.Group(), reports=reports, comm=self.comm,
+                              name=f'{self.name}_simulation')
 
         traj_name = self.name if self.name else 'sim_traj'
         sim_prob.model.add_subsystem(traj_name, sim_traj)
@@ -1483,7 +1484,7 @@ class Trajectory(om.Group):
             # fault of the user.
             warnings.filterwarnings(action='ignore', category=om.UnusedOptionWarning)
             warnings.filterwarnings(action='ignore', category=om.SetupWarning)
-            sim_prob.setup()
+            sim_prob.setup(parent=self)
             sim_prob.final_setup()
 
         # Assign trajectory parameter values

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -11,6 +11,7 @@ from openmdao.utils.units import unit_conversion
 import numpy as np
 import networkx as nx
 
+import openmdao
 import openmdao.api as om
 from openmdao.utils.mpi import MPI
 
@@ -24,6 +25,9 @@ from ..transcriptions.common import ParameterComp
 from ..utils.misc import get_rate_units, _unspecified, _none_or_unspecified
 from ..utils.introspection import get_promoted_vars, get_source_metadata, _get_common_metadata
 from .._options import options as dymos_options
+
+
+om_version = tuple([int(s) for s in openmdao.__version__.split('-')[0].split('.')])
 
 
 class Trajectory(om.Group):
@@ -1484,7 +1488,10 @@ class Trajectory(om.Group):
             # fault of the user.
             warnings.filterwarnings(action='ignore', category=om.UnusedOptionWarning)
             warnings.filterwarnings(action='ignore', category=om.SetupWarning)
-            sim_prob.setup(parent=self)
+            if om_version <= (3, 42, 2):
+                sim_prob.setup(check=True)
+            else:
+                sim_prob.setup(check=True, parent=self)
             sim_prob.final_setup()
 
         # Assign trajectory parameter values

--- a/dymos/transcriptions/explicit_shooting/ode_integration_comp.py
+++ b/dymos/transcriptions/explicit_shooting/ode_integration_comp.py
@@ -93,7 +93,8 @@ class ODEIntegrationComp(om.ExplicitComponent):
                              'transcription where the number of nodes per segment can exceed 20 to 30.')
 
     def _setup_subprob(self):
-        self._eval_subprob = p = om.Problem(comm=self.comm, reports=self._reports)
+        self._eval_subprob = p = om.Problem(comm=self.comm, reports=self._reports,
+                                            name=f'{self.pathname}_subprob')
         p.model.add_subsystem('ode_eval',
                               ODEEvaluationGroup(ode_class=self.options['ode_class'],
                                                  time_options=self.time_options,
@@ -107,7 +108,7 @@ class ODEIntegrationComp(om.ExplicitComponent):
                               promotes_inputs=['*'],
                               promotes_outputs=['*'])
 
-        p.setup()
+        p.setup(parent=self)
         p.final_setup()
 
     def _set_segment_index(self, idx):

--- a/dymos/transcriptions/explicit_shooting/ode_integration_comp.py
+++ b/dymos/transcriptions/explicit_shooting/ode_integration_comp.py
@@ -9,7 +9,7 @@ from ..._options import options as dymos_options
 from .ode_evaluation_group import ODEEvaluationGroup
 
 
-        om_version = tuple([int(s) for s in openmdao.__version__.split('-')[0].split('.')])
+om_version = tuple([int(s) for s in openmdao.__version__.split('-')[0].split('.')])
 
 
 class ODEIntegrationComp(om.ExplicitComponent):

--- a/dymos/transcriptions/explicit_shooting/ode_integration_comp.py
+++ b/dymos/transcriptions/explicit_shooting/ode_integration_comp.py
@@ -1,10 +1,15 @@
 import numpy as np
-import openmdao.api as om
 from scipy.integrate import solve_ivp
+
+import openmdao
+import openmdao.api as om
 
 from ..._options import options as dymos_options
 
 from .ode_evaluation_group import ODEEvaluationGroup
+
+
+        om_version = tuple([int(s) for s in openmdao.__version__.split('-')[0].split('.')])
 
 
 class ODEIntegrationComp(om.ExplicitComponent):
@@ -108,7 +113,10 @@ class ODEIntegrationComp(om.ExplicitComponent):
                               promotes_inputs=['*'],
                               promotes_outputs=['*'])
 
-        p.setup(parent=self)
+        if om_version <= (3, 34, 2):
+            p.setup()
+        else:
+            p.setup(parent=self)
         p.final_setup()
 
     def _set_segment_index(self, idx):

--- a/dymos/transcriptions/pseudospectral/pseudospectral_base.py
+++ b/dymos/transcriptions/pseudospectral/pseudospectral_base.py
@@ -686,7 +686,7 @@ class PseudospectralBase(TranscriptionBase):
         if np.isscalar(vals):
             interp_vals = vals
         else:
-            interp_vals = phase.interp(name, vals, time_vals,
+            interp_vals = phase.interp(name, ys=vals, xs=time_vals,
                                        nodes='state_input',
                                        kind=interpolation_kind)
         input_data[f'states:{name}'] = interp_vals


### PR DESCRIPTION
### Summary

For later version of OpenMDAO, explicit simulation subproblems have their parent set to the trajectory or phase being simulated so that their output files show up nested under the parent problems output directory.

`phase.load_case` was not using the new API for setting times, states, controls, and parameters.
As a result, under Birkhoff, setting state values would only set the values in the segment polynomial, but not the end point values (`initial_states:{name}` and `final-states:{name}`).

### Related Issues

- Resolves #1086
- Resolves #1089 

### Backwards incompatibilities

None

### New Dependencies

None
