### PR TITLE
Added readme to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "hatchling.build"
 name = "dymos"
 dynamic = ["version"]
 description = "Open-Source Optimization of Dynamic Multidisciplinary Systems"
+readme = "readme.md"
 license = "Apache-2.0"
 requires-python = ">=3.9"
 classifiers = [


### PR DESCRIPTION
### Summary

Added the `readme` field to `pyproject.toml`.

This is needed to populate the `Project description` on [pypi](https://pypi.org/project/dymos/).

The description was previously provided in `setup.py`, which has been replaced by `pyproject.toml` since the last release.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
