### PR TITLE
Reduced the memory allocation in the TimeseriesOutputComp in common use cases.

### DIFF
--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -426,8 +426,8 @@ class TranscriptionBase(object):
 
             for input_name, src, src_idxs in timeseries_comp._configure_io(timeseries_options):
                 phase.connect(src_name=src,
-                                tgt_name=f'{timeseries_name}.{input_name}',
-                                src_indices=src_idxs)
+                              tgt_name=f'{timeseries_name}.{input_name}',
+                              src_indices=src_idxs)
 
     def configure_boundary_constraints(self, phase):
         """

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -424,23 +424,10 @@ class TranscriptionBase(object):
         for timeseries_name, timeseries_options in phase._timeseries.items():
             timeseries_comp = phase._get_subsystem(f'{timeseries_name}.timeseries_comp')
 
-            for ts_output_name, ts_output in timeseries_options['outputs'].items():
-                name = ts_output['output_name'] if ts_output['output_name'] is not None else ts_output['name']
-                units = ts_output['units']
-                shape = ts_output['shape']
-                src = ts_output['src']
-                is_rate = ts_output['is_rate']
-
-                added_src = timeseries_comp._add_output_configure(name,
-                                                                  shape=shape,
-                                                                  units=units,
-                                                                  desc='',
-                                                                  src=src,
-                                                                  rate=is_rate)
-
-                if added_src:
-                    phase.connect(src_name=src, tgt_name=f'{timeseries_name}.input_values:{name}',
-                                  src_indices=ts_output['src_idxs'])
+            for input_name, src, src_idxs in timeseries_comp._configure_io(timeseries_options):
+                phase.connect(src_name=src,
+                                tgt_name=f'{timeseries_name}.{input_name}',
+                                src_indices=src_idxs)
 
     def configure_boundary_constraints(self, phase):
         """

--- a/dymos/utils/lagrange.py
+++ b/dymos/utils/lagrange.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def lagrange_matrices(x_disc, x_interp):
+def lagrange_matrices(x_disc, x_interp, compute_interp_matrix=True, compute_diff_matrix=True):
     """
     Compute the lagrange matrices.
 
@@ -17,45 +17,56 @@ def lagrange_matrices(x_disc, x_interp):
     x_interp : np.array
         The interior nodes at which interpolated values of the variable or its derivative
         are desired.
+    compute_interp_matrix : bool
+        If True, construct and return the interpolation matrix, otherwise return None.
+    compute_diff_matrix : bool
+        If True, construct and return the differentiation matrix, otherwise return None. The
+        differentiation matrix can be prohibitively expensive to build as the number of
+        discretization points grows large.
 
     Returns
     -------
     np.array
         A num_i x num_c matrix which, when post-multiplied by values specified
-        at the cardinal nodes, returns the intepolated values at the interior
-        nodes.
+        at x_disc, returns the intepolated values at x_interp.
 
-    np.array
+    np.array or None
         A num_i x num_c matrix which, when post-multiplied by values specified
-        at the cardinal nodes, returns the intepolated derivatives at the interior
-        nodes.
+        at x_disc, returns the intepolated derivatives at x_interp. This is returned
+        as None if compute_diff_matrix is None.
     """
     nd = len(x_disc)
     ni = len(x_interp)
 
-    Li = np.zeros((ni, nd))
-    Di = np.zeros((ni, nd))
-    temp = np.zeros((ni, nd))
-
-    # Barycentric Weights
-    diff = np.reshape(x_disc, (nd, 1)) - np.reshape(x_disc, (1, nd))
-    np.fill_diagonal(diff, 1.0)
-    wb = np.prod(1.0 / diff, axis=1)
+    if compute_interp_matrix or compute_diff_matrix:
+        temp = np.zeros((ni, nd))
+        # Barycentric Weights
+        diff = np.reshape(x_disc, (nd, 1)) - np.reshape(x_disc, (1, nd))
+        np.fill_diagonal(diff, 1.0)
+        wb = np.prod(1.0 / diff, axis=1)
 
     # Compute Li
     diff = np.reshape(x_interp, (ni, 1)) - np.reshape(x_disc, (1, nd))
-    for j in range(nd):
-        temp[:] = diff[:]
-        temp[:, j] = 1.0
-        Li[:, j] = wb[j] * np.prod(temp, axis=1)
+    if compute_interp_matrix:
+        Li = np.zeros((ni, nd))
+        for j in range(nd):
+            temp[:] = diff[:]
+            temp[:, j] = 1.0
+            Li[:, j] = wb[j] * np.prod(temp, axis=1)
+    else:
+        Li = None
 
     # Compute Di
-    for j in range(nd):
-        for k in range(nd):
-            if k != j:
-                temp[:] = diff[:]
-                temp[:, j] = 1.0
-                temp[:, k] = 1.0
-                Di[:, j] += wb[j] * np.prod(temp, axis=1)
+    if compute_diff_matrix:
+        Di = np.zeros((ni, nd))
+        for j in range(nd):
+            for k in range(nd):
+                if k != j:
+                    temp[:] = diff[:]
+                    temp[:, j] = 1.0
+                    temp[:, k] = 1.0
+                    Di[:, j] += wb[j] * np.prod(temp, axis=1)
+    else:
+        Di = None
 
     return Li, Di


### PR DESCRIPTION
### Summary

TimeseriesOutputComp was allocating interpolation and differentiation matrices even when they were not used.
This PR refactors the configuration of TimeseriesOutputComp so that it does not bother constructing or saving the interpolation and or differentiation matrices when they are not used.

The `lagrange_matrices` function now takes `compute_L` and `compute_D` as boolean arguments, and will only construct the interpolation and/or differentiation matrices when requested.

### Related Issues

- Resolves #1095

### Backwards incompatibilities

None

### New Dependencies

None
