### PR TITLE
Timeseries report tooltip hover change.

### DIFF
--- a/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise_bokeh_plots.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise_bokeh_plots.py
@@ -44,8 +44,8 @@ class TestExampleTwoBurnOrbitRaise(unittest.TestCase):
         with set_env_vars_context(OPENMDAO_REPORTS='1'):
             with dm.options.temporary(plots='bokeh'):
                 p = two_burn_orbit_raise_problem(transcription='gauss-lobatto', transcription_order=3,
-                                                compressed=False, optimizer='SLSQP', show_output=False,
-                                                run_driver=False)
+                                                 compressed=False, optimizer='SLSQP', show_output=False,
+                                                 run_driver=False)
 
                 html_file = pathlib.Path(_get_reports_dir(p)) / 'traj_results_report.html'
                 self.assertTrue(html_file.exists(), msg=f'{html_file} does not exist!')
@@ -54,12 +54,12 @@ class TestExampleTwoBurnOrbitRaise(unittest.TestCase):
     def test_mpl_plots(self):
         with dm.options.temporary(plots='matplotlib'):
             p = two_burn_orbit_raise_problem(transcription='gauss-lobatto', transcription_order=3,
-                                            compressed=False, optimizer='SLSQP', show_output=False,
-                                            run_driver=False)
+                                             compressed=False, optimizer='SLSQP', show_output=False,
+                                             run_driver=False)
 
             expected_files = ('deltav.png', 'r.png', 'accel.png',
-                            'u1.png', 'vr.png', 'pos_x.png',
-                            'vt.png', 'pos_y.png', 'theta.png')
+                              'u1.png', 'vr.png', 'pos_x.png',
+                              'vt.png', 'pos_y.png', 'theta.png')
 
             for file in expected_files:
                 plotfile = pathlib.Path(_get_reports_dir(p)).joinpath('plots') / file

--- a/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise_bokeh_plots.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise_bokeh_plots.py
@@ -11,7 +11,7 @@ except ImportError:
 
 from openmdao.utils.testing_utils import require_pyoptsparse
 from openmdao.utils.general_utils import set_pyoptsparse_opt
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, set_env_vars_context
 
 
 import dymos as dm
@@ -41,30 +41,29 @@ class TestExampleTwoBurnOrbitRaise(unittest.TestCase):
 
     @unittest.skipIf(not bokeh_available, 'bokeh unavailable')
     def test_bokeh_plots(self):
-        dm.options['plots'] = 'bokeh'
+        with set_env_vars_context(OPENMDAO_REPORTS='1'):
+            with dm.options.temporary(plots='bokeh'):
+                p = two_burn_orbit_raise_problem(transcription='gauss-lobatto', transcription_order=3,
+                                                compressed=False, optimizer='SLSQP', show_output=False,
+                                                run_driver=False)
 
-        p = two_burn_orbit_raise_problem(transcription='gauss-lobatto', transcription_order=3,
-                                         compressed=False, optimizer='SLSQP', show_output=False,
-                                         run_driver=False)
-
-        html_file = pathlib.Path(_get_reports_dir(p)) / 'traj_results_report.html'
-        self.assertTrue(html_file.exists(), msg=f'{html_file} does not exist!')
+                html_file = pathlib.Path(_get_reports_dir(p)) / 'traj_results_report.html'
+                self.assertTrue(html_file.exists(), msg=f'{html_file} does not exist!')
 
     @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_mpl_plots(self):
-        dm.options['plots'] = 'matplotlib'
+        with dm.options.temporary(plots='matplotlib'):
+            p = two_burn_orbit_raise_problem(transcription='gauss-lobatto', transcription_order=3,
+                                            compressed=False, optimizer='SLSQP', show_output=False,
+                                            run_driver=False)
 
-        p = two_burn_orbit_raise_problem(transcription='gauss-lobatto', transcription_order=3,
-                                         compressed=False, optimizer='SLSQP', show_output=False,
-                                         run_driver=False)
+            expected_files = ('deltav.png', 'r.png', 'accel.png',
+                            'u1.png', 'vr.png', 'pos_x.png',
+                            'vt.png', 'pos_y.png', 'theta.png')
 
-        expected_files = ('deltav.png', 'r.png', 'accel.png',
-                          'u1.png', 'vr.png', 'pos_x.png',
-                          'vt.png', 'pos_y.png', 'theta.png')
-
-        for file in expected_files:
-            plotfile = pathlib.Path(_get_reports_dir(p)).joinpath('plots') / file
-            self.assertTrue(plotfile.exists(), msg=f'{plotfile} does not exist!')
+            for file in expected_files:
+                plotfile = pathlib.Path(_get_reports_dir(p)).joinpath('plots') / file
+                self.assertTrue(plotfile.exists(), msg=f'{plotfile} does not exist!')
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/visualization/timeseries/bokeh_timeseries_report.py
+++ b/dymos/visualization/timeseries/bokeh_timeseries_report.py
@@ -455,7 +455,7 @@ def make_timeseries_report(prob, solution_record_file=None, simulation_record_fi
             for var_name in sorted(ts_units_dict.keys(), key=str.casefold):
                 fig_kwargs = {'x_range': x_range} if x_range is not None else {}
 
-                tool_tips = [(f'{x_name}', '$x'), (f'{var_name}', '$y')]
+                tool_tips = [(f'{x_name}', f'@{x_name}'), (f'{var_name}', f'@{var_name}')]
 
                 fig = figure(tools='pan,box_zoom,xwheel_zoom,hover,undo,reset,save',
                              tooltips=tool_tips,


### PR DESCRIPTION
### Summary

When using the bokeh timeseries report, the tooltip hover will now show the value of the nearest data point, rather than the value under the cursor.

Addressed timeeseries report test failure that fails if environment variable OPENMDAO_REPORTS=0. This test now temporarily sets the value to 1 and runs. Note that this function isn't a true report, although it hijacks the report machinery to place the resulting file in the reports directory. This function can be run offline from record files, so when reports are not active it assumes that it is running in this mode and outputs the file to the current working directory.

### Related Issues

- Resolves #1092
- Resolves #1097

### Backwards incompatibilities

None

### New Dependencies

None
