### PR TITLE
Disabled `ruff` steps in the tests workflow when a full build is not done

### DIFF
--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -305,6 +305,7 @@ jobs:
           pipdeptree
 
       - name: 'Upload environment artifact'
+        if: env.RUN_BUILD
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.NAME }}_environment
@@ -312,6 +313,7 @@ jobs:
           retention-days: 5
 
       - name: Check NumPy 2.0 Compatibility
+        if: env.RUN_BUILD
         run: |
           echo "============================================================="
           echo "Check Dymos code for NumPy 2.0 compatibility"
@@ -321,7 +323,7 @@ jobs:
           ruff check . --select NPY201
 
       - name: Perform linting with Ruff
-        if: ${{ matrix.NAME == 'baseline' }}
+        if: env.RUN_BUILD && matrix.NAME == 'baseline'
         run: |
           echo "============================================================="
           echo "Lint Dymos code per settings in pyproject.toml"


### PR DESCRIPTION
### Summary

Added RUN_BUILD condition to tests workflow steps that should only run when that flag is true.

Specifically, when the tests workflow is triggered via `workflow_dispatch`, the build & test steps are currently only done for the `latest` configuration.  The `ruff` checks should not be enabled if the build is not enabled.


### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
