### PR TITLE
Updated GitHub Workflows

### DIFF
--- a/.github/workflows/dymos_docs_workflow.yml
+++ b/.github/workflows/dymos_docs_workflow.yml
@@ -72,22 +72,24 @@ jobs:
           echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Fetch tags
         run: |
           git fetch --prune --unshallow --tags
 
       - name: Setup conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.PY }}
-          conda-version: "*"
           channels: conda-forge
 
       - name: Install Numpy/Scipy
         shell: bash -l {0}
         run: |
+          echo "Make sure we are not using anaconda packages"
+          conda config --remove channels defaults
+
           echo "============================================================="
           echo "Install Numpy/Scipy"
           echo "============================================================="

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -334,6 +334,7 @@ jobs:
           echo "Install additional packages for testing/coverage"
           echo "============================================================="
           echo "Pre-install playwright dependencies to avoid 'Playwright Host validation warning'"
+          pip install playwright
           playwright install --with-deps
 
       - name: Display environment info

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -12,8 +12,55 @@ on:
   pull_request:
     branches: [ master, develop ]
 
-  # Trigger via workflow_dispatch event
+  # Allow running the workflow manually from the Actions tab
+  # All jobs are excluded by default, desired jobs must be selected
   workflow_dispatch:
+
+    inputs:
+
+      run_name:
+        type: string
+        description: 'Name of workflow run as it will appear under Actions tab:'
+        required: false
+        default: ""
+
+      baseline:
+        type: boolean
+        description: "Include 'baseline' in test matrix"
+        required: false
+        default: false
+
+      no_pyoptsparse:
+        type: boolean
+        description: "Include 'no_pyoptsparse' in test matrix"
+        required: false
+        default: false
+
+      no_snopt:
+        type: boolean
+        description: "Include 'no_snopt' in test matrix"
+        required: false
+        default: false
+
+      no_mpi:
+        type: boolean
+        description: "Include 'no_mpi' Baseline in test matrix"
+        required: false
+        default: false
+
+      latest:
+        type: boolean
+        description: "Include 'latest' in test matrix"
+        required: false
+        default: false
+
+      oldest:
+        type: boolean
+        description: "Include 'oldest' in test matrix"
+        required: false
+        default: false
+
+run-name:  ${{ inputs.run_name }}
 
 jobs:
 
@@ -38,6 +85,7 @@ jobs:
             PEP517: true
             OPTIONAL: '[all]'
             JAX: '0.4.28'
+            EXCLUDE: ${{ github.event_name == 'workflow_dispatch'  && ! inputs.baseline }}
 
           # baseline versions except no pyoptsparse or SNOPT
           - NAME: no_pyoptsparse
@@ -47,6 +95,7 @@ jobs:
             PETSc: 3.21.0
             OPENMDAO: 'latest'
             OPTIONAL: '[test]'
+            EXCLUDE: ${{ github.event_name == 'workflow_dispatch'  && ! inputs.no_pyoptsparse }}
 
           # baseline versions except with pyoptsparse but no SNOPT
           - NAME: no_snopt
@@ -57,6 +106,7 @@ jobs:
             PYOPTSPARSE: 'v2.11.0'
             OPENMDAO: 'latest'
             OPTIONAL: '[test]'
+            EXCLUDE: ${{ github.event_name == 'workflow_dispatch'  && ! inputs.no_snopt }}
 
           # baseline versions except no MPI/PETSc
           - NAME: no_mpi
@@ -66,6 +116,7 @@ jobs:
             PYOPTSPARSE: 'v2.11.0'
             OPENMDAO: 'latest'
             OPTIONAL: '[test]'
+            EXCLUDE: ${{ github.event_name == 'workflow_dispatch'  && ! inputs.no_mpi }}
 
           # try latest versions
           - NAME: latest
@@ -78,6 +129,7 @@ jobs:
             OPENMDAO: 'dev'
             OPTIONAL: '[test]'
             JAX: 'latest'
+            EXCLUDE: ${{ github.event_name == 'workflow_dispatch'  && ! inputs.latest }}
 
           # oldest supported versions
           - NAME: oldest
@@ -87,11 +139,12 @@ jobs:
             OPENMPI: '4.0'
             MPI4PY: '3.0'
             PETSc: 3.13
-            PYOPTSPARSE: 'v2.6.1'
+            PYOPTSPARSE: 'v2.9.0'
             SNOPT: 7.2
             OPENMDAO: 3.28.0
             MATPLOTLIB: 3.5
             OPTIONAL: '[test]'
+            EXCLUDE: ${{ github.event_name == 'workflow_dispatch'  && ! inputs.oldest }}
 
     steps:
       - name: Display run details
@@ -103,21 +156,16 @@ jobs:
           echo "Triggered by: ${GITHUB_EVENT_NAME}"
           echo "Initiated by: ${GITHUB_ACTOR}"
           echo "============================================================="
-
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            if [[ "${{ matrix.NAME }}" == "latest" ]]; then
-              echo "Triggered by 'workflow_dispatch' event, will run '${{ matrix.NAME }}' build."
-              echo "RUN_BUILD=true" >> $GITHUB_ENV
+            if [[ "${{ matrix.EXCLUDE }}" == "false" ]]; then
+              echo "Triggered by 'workflow_dispatch', '${{ matrix.NAME }}' build was selected and will run."
             else
-              echo "Triggered by 'workflow_dispatch' event, will not run '${{ matrix.NAME }}' build."
+              echo "Triggered by 'workflow_dispatch', '${{ matrix.NAME }}' build not selected and will not run."
             fi
-          else
-            echo "Triggered by '${{ github.event_name }}' event, running all builds."
-            echo "RUN_BUILD=true" >> $GITHUB_ENV
           fi
 
       - name: Create SSH key
-        if: env.RUN_BUILD
+        if: ${{ ! matrix.EXCLUDE }}
         shell: bash
         env:
           SSH_PRIVATE_KEY: ${{secrets.SSH_PRIVATE_KEY}}
@@ -129,28 +177,30 @@ jobs:
           echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
 
       - name: Checkout code
-        if: env.RUN_BUILD
-        uses: actions/checkout@v3
+        if: ${{ ! matrix.EXCLUDE }}
+        uses: actions/checkout@v4
 
       - name: Setup conda
-        if: env.RUN_BUILD
-        uses: conda-incubator/setup-miniconda@v2
+        if: ${{ ! matrix.EXCLUDE }}
+        uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.PY }}
-          conda-version: "*"
           channels: conda-forge
 
       - name: Install Numpy/Scipy
-        if: env.RUN_BUILD
+        if: ${{ ! matrix.EXCLUDE }}
         shell: bash -l {0}
         run: |
+          echo "Make sure we are not using anaconda packages"
+          conda config --remove channels defaults
+
           echo "============================================================="
           echo "Install Numpy/Scipy"
           echo "============================================================="
           conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
       - name: Install jax
-        if: env.RUN_BUILD && matrix.JAX
+        if: ${{ ! matrix.EXCLUDE && matrix.JAX }}
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -163,7 +213,7 @@ jobs:
           fi
 
       - name: Install PETSc
-        if: env.RUN_BUILD && matrix.PETSc
+        if: ${{ ! matrix.EXCLUDE && matrix.PETSc }}
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -190,7 +240,7 @@ jobs:
 
       - name: Install pyOptSparse
         id: build_pyoptsparse
-        if: env.RUN_BUILD && matrix.PYOPTSPARSE
+        if: ${{ ! matrix.EXCLUDE && matrix.PYOPTSPARSE }}
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -236,7 +286,7 @@ jobs:
           fi
 
       - name: Install OpenMDAO
-        if: env.RUN_BUILD && matrix.OPENMDAO
+        if: ${{ ! matrix.EXCLUDE && matrix.OPENMDAO }}
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -251,7 +301,7 @@ jobs:
           fi
 
       - name: Install Matplotlib
-        if: env.RUN_BUILD && matrix.MATPLOTLIB
+        if: ${{ ! matrix.EXCLUDE && matrix.MATPLOTLIB }}
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -259,8 +309,17 @@ jobs:
           echo "============================================================="
           python -m pip install matplotlib==${{ matrix.MATPLOTLIB }}
 
+      - name: Install optional dependencies
+        if: ${{ ! matrix.EXCLUDE && matrix.OPTIONAL == '[all]' }}
+        run: |
+          echo "============================================================="
+          echo "Install additional packages for testing/coverage"
+          echo "============================================================="
+          echo "Pre-install playwright dependencies to avoid 'Playwright Host validation warning'"
+          playwright install --with-deps
+
       - name: Install Dymos
-        if: env.RUN_BUILD
+        if: ${{ ! matrix.EXCLUDE }}
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -279,7 +338,7 @@ jobs:
 
       - name: Display environment info
         id: env_info
-        if: env.RUN_BUILD
+        if: ${{ ! matrix.EXCLUDE }}
         shell: bash -l {0}
         run: |
           conda info
@@ -304,16 +363,16 @@ jobs:
           pip install pipdeptree
           pipdeptree
 
-      - name: 'Upload environment artifact'
-        if: env.RUN_BUILD
-        uses: actions/upload-artifact@v3
+      - name: Upload environment artifact
+        if: ${{ ! matrix.EXCLUDE }}
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.NAME }}_environment
           path: ${{ matrix.NAME }}_environment.yml
           retention-days: 5
 
       - name: Check NumPy 2.0 Compatibility
-        if: env.RUN_BUILD
+        if: ${{ ! matrix.EXCLUDE }}
         run: |
           echo "============================================================="
           echo "Check Dymos code for NumPy 2.0 compatibility"
@@ -323,7 +382,7 @@ jobs:
           ruff check . --select NPY201
 
       - name: Perform linting with Ruff
-        if: env.RUN_BUILD && matrix.NAME == 'baseline'
+        if: ${{ ! matrix.EXCLUDE && matrix.NAME == 'baseline' }}
         run: |
           echo "============================================================="
           echo "Lint Dymos code per settings in pyproject.toml"
@@ -332,7 +391,7 @@ jobs:
           ruff check . --config pyproject.toml
 
       - name: Run tests
-        if: env.RUN_BUILD
+        if: ${{ ! matrix.EXCLUDE }}
         env:
           DYMOS_CHECK_PARTIALS: True
         shell: bash -l {0}
@@ -353,7 +412,8 @@ jobs:
           fi
 
       - name: Submit coverage
-        if: ((github.event_name != 'workflow_dispatch') && (matrix.NAME != 'latest'))
+        if: github.event_name != 'workflow_dispatch'
+        continue-on-error: true
         shell: bash -l {0}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -370,7 +430,8 @@ jobs:
 
   coveralls:
     name: Finish coveralls
-    if: (github.event_name != 'workflow_dispatch')
+    if: github.event_name != 'workflow_dispatch'
+    continue-on-error: true
     needs: test_ubuntu
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -309,15 +309,6 @@ jobs:
           echo "============================================================="
           python -m pip install matplotlib==${{ matrix.MATPLOTLIB }}
 
-      - name: Install optional dependencies
-        if: ${{ ! matrix.EXCLUDE && matrix.OPTIONAL == '[all]' }}
-        run: |
-          echo "============================================================="
-          echo "Install additional packages for testing/coverage"
-          echo "============================================================="
-          echo "Pre-install playwright dependencies to avoid 'Playwright Host validation warning'"
-          playwright install --with-deps
-
       - name: Install Dymos
         if: ${{ ! matrix.EXCLUDE }}
         shell: bash -l {0}
@@ -335,6 +326,15 @@ jobs:
           else
             python -m pip install .${{ matrix.OPTIONAL }}
           fi
+
+      - name: Install optional dependencies
+        if: ${{ ! matrix.EXCLUDE && matrix.OPTIONAL == '[all]' }}
+        run: |
+          echo "============================================================="
+          echo "Install additional packages for testing/coverage"
+          echo "============================================================="
+          echo "Pre-install playwright dependencies to avoid 'Playwright Host validation warning'"
+          playwright install --with-deps
 
       - name: Display environment info
         id: env_info


### PR DESCRIPTION
### Summary

Updated the oldest tested version of `pyoptsparse` to v2.9.0, since the previous version was broken by an update to `setuptools`

Also:
- added inputs to the `workflow_dispatch` trigger to enable selecting specific builds
  - this is a somewhat cleaner solution to the `openmdao` workflow integration and has more flexible functionality
- updated versions of `checkout`, `upload-artifact` and `setup-miniconda` actions
- explicitly removed `defaults` channel from `conda` settings
- added a pre-install of `playwright` dependencies to prevent an annoying warning message

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
