### PR TITLE
Fixed a NumPy 2.x testing issue and added a NumPy 2.x build to the test workflow

### DIFF
--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -36,6 +36,12 @@ on:
         required: false
         default: false
 
+      numpy2_no_pyoptsparse:
+        type: boolean
+        description: "Include 'numpy2_no_pyoptsparse' in test matrix"
+        required: false
+        default: false
+
       no_snopt:
         type: boolean
         description: "Include 'no_snopt' in test matrix"
@@ -96,6 +102,15 @@ jobs:
             OPENMDAO: 'latest'
             OPTIONAL: '[test]'
             EXCLUDE: ${{ github.event_name == 'workflow_dispatch'  && ! inputs.no_pyoptsparse }}
+
+          # numpy 2.x but no PETSc, pyoptsparse or SNOPT
+          - NAME: numpy2_no_pyoptsparse
+            PY: '3.12'
+            NUMPY: 2
+            SCIPY: 1.14
+            OPENMDAO: 'latest'
+            OPTIONAL: '[all]'
+            EXCLUDE: ${{ github.event_name == 'workflow_dispatch'  && ! inputs.numpy2_no_pyoptsparse }}
 
           # baseline versions except with pyoptsparse but no SNOPT
           - NAME: no_snopt

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -2962,9 +2962,10 @@ class Phase(om.Group):
             duplicate_idxs = all_flat_idxs.intersection(flat_idxs)
             if duplicate_idxs:
                 s = {'initial': 'initial boundary', 'final': 'final boundary', 'path': 'path'}
-                raise ValueError(f'Duplicate constraint in phase {self.pathname}. '
-                                 f'The following indices of `{name}` are used in '
-                                 f'multiple {s[loc]} constraints:\n{duplicate_idxs}')
+                with np.printoptions(legacy='1.13'):
+                    raise ValueError(f'Duplicate constraint in phase {self.pathname}. '
+                                     f'The following indices of `{name}` are used in '
+                                     f'multiple {s[loc]} constraints:\n{duplicate_idxs}')
 
             all_flat_idxs.update(flat_idxs)
 


### PR DESCRIPTION
### Summary

Tests in `dymos/examples/brachistochrone/test/test_duplicate_constraints.py` were failing with NumPy 2.x due to a change in the numpy representation:
```
AssertionError: 'Dupl[71 chars] `theta` are used in multiple path constraints:\n{np.int64(0)}' != 'Dupl[71 chars] `theta` are used in multiple path constraints:\n{0}'
  Duplicate constraint in phase traj0.phases.phase0. The following indices of `theta` are used in multiple path constraints:
- {np.int64(0)}
+ {0}
```

The generation of that error message has been wrapped in a NumPy `printoptions` context to preserve the previous formatting.

Also:
-  a NumPy 2.x build has been added to the test workflow

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
