### PR TITLE
Fixed bug in timeseries plots under MPI.

### DIFF
--- a/dymos/visualization/timeseries/bokeh_timeseries_report.py
+++ b/dymos/visualization/timeseries/bokeh_timeseries_report.py
@@ -363,7 +363,7 @@ def _gather_system_options(model, sys_cls=None, rank=0):
 
     system_options = {}
     for subsys in model.system_iter(include_self=True, recurse=True, typ=sys_cls):
-        system_options[subsys.pathname] = subsys.options
+        system_options[subsys.pathname] = {k: v['val'] for k, v in subsys.options._dict.items() if v['recordable']}
 
     if comm_size > 1:
         gathered = MPI.COMM_WORLD.gather(system_options, rank)


### PR DESCRIPTION
### Summary

The timeseries plots currently gather all phase options and trajectory options onto the root pro non-picklable options have been added to phases and trajectories.

This PR addresses that by limiting the MPI gather to only the variable-related options upon which the timeseries plots depend.

### Related Issues

- Resolves #1115

### Backwards incompatibilities

None

### New Dependencies

None
