### PR TITLE
Refactored the Radau transcription to avoid the use of StateIndependentsComp

### DIFF
--- a/dymos/transcriptions/__init__.py
+++ b/dymos/transcriptions/__init__.py
@@ -1,5 +1,6 @@
 from .analytic.analytic import Analytic
 from .explicit_shooting import ExplicitShooting
 from .pseudospectral.gauss_lobatto import GaussLobatto
-from .pseudospectral.radau_pseudospectral import Radau
+from .pseudospectral.radau_pseudospectral import Radau as RadauDeprecated
 from .pseudospectral.birkhoff import Birkhoff
+from .pseudospectral.radau_new import RadauNew as Radau

--- a/dymos/transcriptions/pseudospectral/components/radau_defect_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/radau_defect_comp.py
@@ -1,0 +1,285 @@
+import numpy as np
+import openmdao.api as om
+
+from dymos._options import options as dymos_options
+from dymos.transcriptions.grid_data import GridData
+from dymos.utils.misc import get_rate_units
+
+
+class RadauDefectComp(om.ExplicitComponent):
+    """
+    Class definiton for the Collocationcomp.
+
+    CollocationComp computes the generalized defect of a segment for implicit collocation.
+    The defect is the interpolated state derivative at the collocation nodes minus
+    the computed state derivative at the collocation nodes.
+
+    Parameters
+    ----------
+    **kwargs : dict
+        Dictionary of optional arguments.
+    """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._no_check_partials = not dymos_options['include_check_partials']
+
+    def initialize(self):
+        """Declare component options."""
+        self.options.declare(
+            'grid_data', types=GridData,
+            desc='Container object for grid info')
+
+        self.options.declare(
+            'state_options', types=dict,
+            desc='Dictionary of state names/options for the phase')
+
+        self.options.declare(
+            'time_units', default=None, allow_none=True, types=str,
+            desc='Units of time')
+
+    def configure_io(self, phase):
+        """
+        I/O creation is delayed until configure so we can determine shape and units.
+
+        Parameters
+        ----------
+        phase : Phase
+            The phase in which this component exists.
+        """
+        gd: GridData = self.options['grid_data']
+        num_segs: int = gd.num_segments
+        num_nodes: int = gd.subset_num_nodes['all']
+        num_col_nodes: int = gd.subset_num_nodes['col']
+        time_units: str = self.options['time_units']
+        state_options = self.options['state_options']
+
+        # The radau differentiation matrix
+        _, self._D = self.options['grid_data'].phase_lagrange_matrices('state_disc',
+                                                                       'col',
+                                                                       sparse=True)
+
+        self.add_input('dt_dstau', units=time_units, shape=(num_col_nodes,))
+
+        self.var_names = var_names = {}
+        for state_name in state_options:
+            var_names[state_name] = {
+                'initial_val': f'initial_states:{state_name}',
+                'final_val': f'final_states:{state_name}',
+                'val': f'states:{state_name}',
+                'f_ode': f'f_ode:{state_name}',
+                'rate_defect': f'state_rate_defects:{state_name}',
+                'cnty_defect': f'state_cnty_defects:{state_name}',
+                'initial_defect': f'initial_state_defects:{state_name}',
+                'final_defect': f'final_state_defects:{state_name}'
+            }
+
+        for state_name, options in state_options.items():
+            shape = options['shape']
+            units = options['units']
+
+            rate_units = get_rate_units(units, time_units)
+
+            var_names = self.var_names[state_name]
+
+            self.add_input(name=var_names['initial_val'],
+                           shape=(1,) + shape,
+                           units=units,
+                           desc='Initial value of the state at the start of the phase.')
+
+            self.add_input(name=var_names['final_val'],
+                           shape=(1,) + shape,
+                           units=units,
+                           desc='Final value of the state at the end of the phase.')
+
+            self.add_input(var_names['val'],
+                           shape=(num_nodes,) + shape,
+                           units=units,
+                           desc='state value at all nodes within the phase')
+
+            self.add_input(
+                name=var_names['f_ode'],
+                shape=(num_col_nodes,) + shape,
+                desc=f'Computed derivative of state {state_name} at the collocation nodes',
+                units=rate_units)
+
+            self.add_output(
+                name=var_names['initial_defect'],
+                shape=(1,) + shape,
+                desc=f'Initial value defect of state {state_name}',
+                units=units)
+
+            self.add_output(
+                name=var_names['final_defect'],
+                shape=(1,) + shape,
+                desc=f'Final value defect of state {state_name}',
+                units=units)
+
+            self.add_output(
+                name=var_names['rate_defect'],
+                shape=(num_col_nodes,) + shape,
+                desc=f'Interior defects of state {state_name}',
+                units=units)
+
+            if gd.num_segments > 1 and not gd.compressed:
+                self.add_output(
+                    name=var_names['cnty_defect'],
+                    shape=(num_segs - 1,) + shape,
+                    desc=f'Segment boundary defect of state {state_name}',
+                    units=units)
+
+            if 'defect_ref' in options and options['defect_ref'] is not None:
+                defect_ref = options['defect_ref']
+            elif 'defect_scaler' in options and options['defect_scaler'] is not None:
+                defect_ref = np.divide(1.0, options['defect_scaler'])
+            elif 'ref' in options and options['ref'] is not None:
+                defect_ref = options['ref']
+            elif 'scaler' in options and options['scaler'] is not None:
+                defect_ref = np.divide(1.0, options['scaler'])
+            else:
+                defect_ref = 1.0
+
+            if not np.isscalar(defect_ref):
+                defect_ref = np.asarray(defect_ref)
+                if defect_ref.shape == shape:
+                    defect_ref = np.tile(defect_ref.flatten(), num_col_nodes)
+                else:
+                    raise ValueError('array-valued scaler/ref must length equal to state-size')
+
+            if not options['solve_segments']:
+                self.add_constraint(name=var_names['rate_defect'],
+                                    equals=0.0,
+                                    ref=defect_ref)
+
+                self.add_constraint(name=var_names['initial_defect'],
+                                    equals=0.0,
+                                    ref=defect_ref)
+
+                self.add_constraint(name=var_names['final_defect'],
+                                    equals=0.0,
+                                    ref=defect_ref)
+
+                if gd.num_segments > 1 and not gd.compressed:
+                    self.add_constraint(name=var_names['cnty_defect'],
+                                        equals=0.0,
+                                        ref=defect_ref)
+
+        # Setup partials
+        num_col_nodes = self.options['grid_data'].subset_num_nodes['col']
+        state_options = self.options['state_options']
+
+        for state_name, options in state_options.items():
+            shape = options['shape']
+            size = np.prod(shape)
+
+            r = np.arange(num_col_nodes * size)
+
+            var_names = self.var_names[state_name]
+
+            self.declare_partials(of=var_names['rate_defect'],
+                                  wrt=var_names['f_ode'],
+                                  rows=r, cols=r, val=-1.0)
+
+            c = np.repeat(np.arange(num_col_nodes), size)
+            self.declare_partials(of=var_names['rate_defect'],
+                                  wrt='dt_dstau',
+                                  rows=r, cols=c)
+
+            # The state rate defects wrt the state values at the discretization nodes
+            # are given by the differentiation matrix.
+            r, c = self._D.nonzero()
+            self.declare_partials(of=var_names['rate_defect'],
+                                  wrt=var_names['val'],
+                                  rows=r, cols=c, val=self._D.data)
+
+            # The initial value defect is just an identity matrix at the "top left" corner of the jacobian.
+            ar_size = np.arange(size, dtype=int)
+            self.declare_partials(of=var_names['initial_defect'],
+                                  wrt=var_names['val'],
+                                  rows=ar_size, cols=ar_size, val=-1.0)
+
+            self.declare_partials(of=var_names['initial_defect'],
+                                  wrt=var_names['initial_val'],
+                                  rows=ar_size, cols=ar_size, val=1.0)
+
+            # The final value defect is an identity matrix at the "bottom right" corner of the jacobian.
+            r = np.arange(size, dtype=int)
+            c = np.arange(num_nodes - size, num_nodes, dtype=int)
+            self.declare_partials(of=var_names['final_defect'],
+                                  wrt=var_names['val'],
+                                  rows=r, cols=c, val=-1.0)
+
+            self.declare_partials(of=var_names['final_defect'],
+                                  wrt=var_names['final_val'],
+                                  rows=ar_size, cols=ar_size, val=1.0)
+
+            if gd.num_segments > 1 and not gd.compressed:
+                rs = np.repeat(np.arange(num_segs - 1, dtype=int), 2)
+                cs = gd.subset_node_indices['segment_ends'][1:-1]
+                val = np.tile([-1., 1.], num_segs-1)
+                self.declare_partials(of=var_names['cnty_defect'],
+                                      wrt=var_names['val'], rows=rs, cols=cs, val=val)
+
+    def compute(self, inputs, outputs):
+        """
+        Compute collocation defects.
+
+        Parameters
+        ----------
+        inputs : `Vector`
+            `Vector` containing inputs.
+        outputs : `Vector`
+            `Vector` containing outputs.
+        """
+        gd: GridData = self.options['grid_data']
+        num_disc_nodes: int = gd.subset_num_nodes['state_disc']
+        num_col_nodes: int = gd.subset_num_nodes['col']
+        idxs_se: int = gd.subset_node_indices['segment_ends']
+
+        state_options = self.options['state_options']
+        dt_dstau: np.ndarray = inputs['dt_dstau']
+        D = self._D
+
+        for state_name, state_options in state_options.items():
+            shape = state_options['shape']
+            size = np.prod(shape)
+            var_names = self.var_names[state_name]
+
+            f_ode = inputs[var_names['f_ode']]
+            x = inputs[var_names['val']]
+            x_0 = inputs[var_names['initial_val']]
+            x_f = inputs[var_names['final_val']]
+
+            # The defect is computed as
+            # defect = D @ x - f_ode * dt_dstau  # noqa: ERA001
+            # But scipy.sparse only handles 2D matrices, so we need to force x to be 2D
+            # and then change the product back to the proper shape.
+
+            x_flat = np.reshape(x, newshape=(num_disc_nodes, size))
+            f_approx = np.reshape(D.dot(x_flat), newshape=(num_col_nodes,) + shape)
+
+            outputs[var_names['rate_defect']] = f_approx - (f_ode.T * dt_dstau).T
+            outputs[var_names['initial_defect']] = x_0 - x[0, ...]
+            outputs[var_names['final_defect']] = x_f - x[-1, ...]
+
+            if gd.num_segments > 1 and not gd.compressed:
+                outputs[var_names['cnty_defect']] = x[idxs_se[2::2], ...] - x[idxs_se[1:-2:2], ...]
+
+    def compute_partials(self, inputs, partials):
+        """
+        Compute sub-jacobian parts. The model is assumed to be in an unscaled state.
+
+        Parameters
+        ----------
+        inputs : Vector
+            Unscaled, dimensional input variables read via inputs[key].
+        partials : Jacobian
+            Subjac components written to partials[output_name, input_name].
+        """
+        dt_dstau = inputs['dt_dstau']
+        for state_name, options in self.options['state_options'].items():
+            size = np.prod(options['shape'])
+            var_names = self.var_names[state_name]
+            f_ode = inputs[var_names['f_ode']]
+
+            partials[var_names['rate_defect'], var_names['f_ode']] = -np.repeat(dt_dstau, size)
+            partials[var_names['rate_defect'], 'dt_dstau'] = -f_ode.ravel()

--- a/dymos/transcriptions/pseudospectral/components/radau_iter_group.py
+++ b/dymos/transcriptions/pseudospectral/components/radau_iter_group.py
@@ -1,0 +1,348 @@
+import numpy as np
+import openmdao.api as om
+
+from .input_resids_comp import InputResidsComp
+from .radau_defect_comp import RadauDefectComp
+
+from dymos.transcriptions.grid_data import GridData
+from dymos.phase.options import TimeOptionsDictionary
+
+
+class RadauIterGroup(om.Group):
+    """
+    Class definition for the RadauIterGroup.
+
+    This group allows for iteration of the state variables and initial _or_ final value of the state
+    depending on the direction of the solve.
+
+    Parameters
+    ----------
+    **kwargs : dict
+        Dictionary of optional arguments.
+    """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._implicit_outputs = set()
+
+    def initialize(self):
+        """Declare group options."""
+        self.options.declare('state_options', types=dict,
+                             desc='Dictionary of options for the states.')
+        self.options.declare('time_options', types=TimeOptionsDictionary,
+                             desc='Options for time in the phase.')
+        self.options.declare('grid_data', types=GridData, desc='Container object for grid info.')
+        self.options.declare('ode_class', default=None,
+                             desc='Callable that instantiates the ODE system.',
+                             recordable=False)
+        self.options.declare('ode_init_kwargs', types=dict, default={},
+                             desc='Keyword arguments provided when initializing the ODE System')
+
+    def setup(self):
+        """
+        Define the structure of the RadauIterGroup.
+        """
+        gd = self.options['grid_data']
+        nn = gd.subset_num_nodes['all']
+        state_options = self.options['state_options']
+        time_options = self.options['time_options']
+        ode_class = self.options['ode_class']
+        ode_init_kwargs = self.options['ode_init_kwargs']
+
+        self.add_subsystem('ode_all', subsys=ode_class(num_nodes=nn, **ode_init_kwargs))
+
+        self.add_subsystem('defects',
+                           subsys=RadauDefectComp(grid_data=gd,
+                                                  state_options=state_options,
+                                                  time_units=time_options['units']),
+                           promotes_inputs=['*'], promotes_outputs=['*'])
+
+        if any([opts['solve_segments'] in ('forward', 'backward') for opts in state_options.values()]):
+            self.add_subsystem('states_resids_comp', subsys=InputResidsComp(),
+                               promotes_inputs=['*'], promotes_outputs=['*'])
+
+    def _configure_desvars(self, name, options):
+        state_name = f'states:{name}'
+        initial_state_name = f'initial_states:{name}'
+        final_state_name = f'final_states:{name}'
+        state_rate_name = f'state_rates:{name}'
+
+        solve_segs = options['solve_segments']
+        opt = options['opt']
+
+        num_nodes = self.options['grid_data'].subset_num_nodes['col']
+
+        ib = (None, None) if options['initial_bounds'] is None else options['initial_bounds']
+        fb = (None, None) if options['final_bounds'] is None else options['final_bounds']
+        lower = options['lower']
+        upper = options['upper']
+        scaler = options['scaler']
+        adder = options['adder']
+        ref0 = options['ref0']
+        ref = options['ref']
+        fix_initial = options['fix_initial']
+        fix_final = options['fix_final']
+        input_initial = options['input_initial']
+        input_final = options['input_final']
+        shape = options['shape']
+
+        if solve_segs == 'forward' and fix_final:
+            raise ValueError(f"Option fix_final on state {name} may not "
+                             f"be used with `solve_segments='forward'`.\n Use "
+                             f"a boundary constraint to constrain the final "
+                             f"state value instead.")
+        elif solve_segs == 'backward' and fix_initial:
+            raise ValueError(f"Option fix_final on state {name} may not "
+                             f"be used with `solve_segments='forward'`.\n Use "
+                             f"a boundary constraint to constrain the initial "
+                             f"state value instead.")
+
+        if not np.isscalar(ref0) and ref0 is not None:
+            ref0 = np.asarray(ref0)
+            if ref0.shape == shape:
+                ref0_state = np.tile(ref0.flatten(), num_nodes)
+            else:
+                raise ValueError('array-valued scaler/ref must length equal to state-size')
+        else:
+            ref0_state = ref0
+        if not np.isscalar(ref) and ref is not None:
+            ref = np.asarray(ref)
+            if ref.shape == shape:
+                ref_state = np.tile(ref.flatten(), num_nodes)
+            else:
+                raise ValueError('array-valued scaler/ref must length equal to state-size')
+        else:
+            ref_state = ref
+
+        free_vars = {state_name, initial_state_name, final_state_name}
+
+        if solve_segs == 'forward':
+            implicit_outputs = {state_name, final_state_name}
+        elif solve_segs == 'backward':
+            implicit_outputs = {state_name, initial_state_name}
+        else:
+            implicit_outputs = set()
+
+        free_vars = free_vars - implicit_outputs
+
+        if fix_initial or input_initial:
+            free_vars = free_vars - {initial_state_name}
+        if fix_final or input_final:
+            free_vars = free_vars - {final_state_name}
+
+        if opt:
+            # Add design variables for the remaining free variables
+            if state_name in free_vars:
+                self.add_design_var(name=state_name,
+                                    lower=lower,
+                                    upper=upper,
+                                    scaler=scaler,
+                                    adder=adder,
+                                    ref0=ref0_state,
+                                    ref=ref_state)
+
+            if state_rate_name in free_vars:
+                self.add_design_var(name=state_rate_name,
+                                    scaler=scaler,
+                                    adder=adder,
+                                    ref0=ref0_state,
+                                    ref=ref_state)
+
+            if initial_state_name in free_vars:
+                self.add_design_var(name=initial_state_name,
+                                    lower=ib[0],
+                                    upper=ib[1],
+                                    scaler=scaler,
+                                    adder=adder,
+                                    ref0=ref0,
+                                    ref=ref)
+
+            if final_state_name in free_vars:
+                self.add_design_var(name=final_state_name,
+                                    lower=fb[0],
+                                    upper=fb[1],
+                                    scaler=scaler,
+                                    adder=adder,
+                                    ref0=ref0,
+                                    ref=ref)
+
+        return implicit_outputs
+
+    def configure_io(self, phase):
+        """
+        I/O creation is delayed until configure so that we can determine shape and units for the states.
+
+        Parameters
+        ----------
+        phase : dymos.Phase
+            The phase object to which this transcription instance applies.
+        """
+        defect_comp = self._get_subsystem('defects')
+        defect_comp.configure_io(phase)
+
+        gd = self.options['grid_data']
+        nn = gd.subset_num_nodes['all']
+        nin = gd.subset_num_nodes['state_input']
+        ncn = gd.subset_num_nodes['col']
+        ns = gd.num_segments
+        state_src_idxs = gd.input_maps['state_input_to_disc']
+        col_idxs = gd.subset_node_indices['col']
+
+        state_options = self.options['state_options']
+        states_resids_comp = self._get_subsystem('states_resids_comp')
+
+        self.promotes('defects', inputs=('dt_dstau',),
+                        src_indices=om.slicer[col_idxs, ...],
+                        src_shape=(nn,))
+
+        for name, options in state_options.items():
+            units = options['units']
+            rate_source = options['rate_source']
+            shape = options['shape']
+
+            # TODO: compressed transcription is not currently supported because promoting duplicate
+            # indices currently has a bug in OpenMDAO <= 3.35.0
+            for tgt in options['targets']:
+                self.promotes('ode_all', [(tgt, f'states:{name}')],
+                            #   src_indices=om.slicer[state_src_idxs, ...],
+                              src_shape=(nin,) + shape)
+            self.set_input_defaults(f'states:{name}', val=1.0, units=units, src_shape=(nin,) + shape)
+
+            self.promotes('defects', inputs=(f'states:{name}',),
+                          src_indices=om.slicer[state_src_idxs, ...])
+
+            self._implicit_outputs = self._configure_desvars(name, options)
+
+            if f'states:{name}' in self._implicit_outputs:
+                states_resids_comp.add_output(f'states:{name}',
+                                              shape=(nin,) + shape,
+                                              units=units)
+
+                states_resids_comp.add_input(f'initial_state_defects:{name}', shape=(1,) + shape, units=units)
+                states_resids_comp.add_input(f'final_state_defects:{name}', shape=(1,) + shape, units=units)
+                states_resids_comp.add_input(f'state_rate_defects:{name}', shape=(ncn,) + shape, units=units)
+
+                if ns > 1 and not gd.compressed:
+                    states_resids_comp.add_input(f'state_cnty_defects:{name}',
+                                                 shape=(ns - 1,) + shape,
+                                                 units=units)
+
+            if f'initial_states:{name}' in self._implicit_outputs:
+                # states_resids_comp.add_input(f'initial_state_defects:{name}', shape=(1,) + shape, units=units)
+                states_resids_comp.add_output(f'initial_states:{name}', shape=(1,) + shape, units=units)
+
+            if f'final_states:{name}' in self._implicit_outputs:
+                # states_resids_comp.add_input(f'final_state_defects:{name}', shape=(1,) + shape, units=units)
+                states_resids_comp.add_output(f'final_states:{name}', shape=(1,) + shape, units=units)
+
+            try:
+                rate_source_var = options['rate_source']
+            except RuntimeError:
+                raise ValueError(f"state '{name}' in phase '{phase.name}' was not given a "
+                                 "rate_source")
+
+            # Note the rate source must be shape-compatible with the state
+            var_type = phase.classify_var(rate_source_var)
+
+            if var_type == 'ode':
+                self.connect(f'ode_all.{rate_source}', f'f_ode:{name}',
+                             src_indices=gd.subset_node_indices['col'])
+
+    def _get_rate_source_path(self, state_name, nodes, phase):
+        """
+        Return the rate source location and indices for a given state name.
+
+        Parameters
+        ----------
+        state_name : str
+            Name of the state.
+        nodes : str
+            One of ['col', 'all'].
+        phase : dymos.Phase
+            Phase object containing the rate source.
+
+        Returns
+        -------
+        str
+            Path to the rate source.
+        ndarray
+            Array of source indices.
+
+        """
+        gd = self.grid_data
+        try:
+            var = phase.state_options[state_name]['rate_source']
+        except RuntimeError:
+            raise ValueError(f"state '{state_name}' in phase '{phase.name}' was not given a "
+                             "rate_source")
+
+        # Note the rate source must be shape-compatible with the state
+        var_type = phase.classify_var(var)
+
+        # Determine the path to the variable
+        if var_type == 't':
+            rate_path = 't'
+            node_idxs = gd.subset_node_indices[nodes]
+        elif var_type == 't_phase':
+            rate_path = 't_phase'
+            node_idxs = gd.subset_node_indices[nodes]
+        elif var_type == 'state':
+            rate_path = f'states:{var}'
+            # Find the state_input indices which occur at segment endpoints, and repeat them twice
+            state_input_idxs = gd.subset_node_indices['state_input']
+            repeat_idxs = np.ones_like(state_input_idxs)
+            if gd.compressed:
+                segment_end_idxs = gd.subset_node_indices['segment_ends'][1:-1]
+                # Repeat nodes that are on segment bounds (but not the first or last nodes in the phase)
+                nodes_to_repeat = list(set(state_input_idxs).intersection(segment_end_idxs))
+                # Now find these nodes in the state input indices
+                idxs_of_ntr_in_state_inputs = np.where(np.isin(state_input_idxs, nodes_to_repeat))[0]
+                # All state input nodes are used once, but nodes_to_repeat are used twice
+                repeat_idxs[idxs_of_ntr_in_state_inputs] = 2
+            # Now we have a way of mapping the state input indices to all nodes
+            map_input_node_idxs_to_all = np.repeat(np.arange(gd.subset_num_nodes['state_input'],
+                                                             dtype=int), repeats=repeat_idxs)
+            # Now select the subset of nodes we want to use.
+            node_idxs = map_input_node_idxs_to_all[gd.subset_node_indices[nodes]]
+        elif var_type == 'indep_control':
+            rate_path = f'control_values:{var}'
+            node_idxs = gd.subset_node_indices[nodes]
+        elif var_type == 'input_control':
+            rate_path = f'control_values:{var}'
+            node_idxs = gd.subset_node_indices[nodes]
+        elif var_type == 'control_rate':
+            control_name = var[:-5]
+            rate_path = f'control_rates:{control_name}_rate'
+            node_idxs = gd.subset_node_indices[nodes]
+        elif var_type == 'control_rate2':
+            control_name = var[:-6]
+            rate_path = f'control_rates:{control_name}_rate2'
+            node_idxs = gd.subset_node_indices[nodes]
+        elif var_type == 'indep_polynomial_control':
+            rate_path = f'control_values:{var}'
+            node_idxs = gd.subset_node_indices[nodes]
+        elif var_type == 'input_polynomial_control':
+            rate_path = f'control_values:{var}'
+            node_idxs = gd.subset_node_indices[nodes]
+        elif var_type == 'polynomial_control_rate':
+            control_name = var[:-5]
+            rate_path = f'control_rates:{control_name}_rate'
+            node_idxs = gd.subset_node_indices[nodes]
+        elif var_type == 'polynomial_control_rate2':
+            control_name = var[:-6]
+            rate_path = f'control_rates:{control_name}_rate2'
+            node_idxs = gd.subset_node_indices[nodes]
+        elif var_type == 'parameter':
+            rate_path = f'parameter_vals:{var}'
+            dynamic = not phase.parameter_options[var]['static_target']
+            if dynamic:
+                node_idxs = np.zeros(gd.subset_num_nodes[nodes], dtype=int)
+            else:
+                node_idxs = np.zeros(1, dtype=int)
+        else:
+            # Failed to find variable, assume it is in the ODE
+            rate_path = f'ode_all.{var}'
+            node_idxs = gd.subset_node_indices[nodes]
+
+        src_idxs = om.slicer[node_idxs, ...]
+
+        return rate_path, src_idxs

--- a/dymos/transcriptions/pseudospectral/components/test/test_radau_iter_group.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_radau_iter_group.py
@@ -1,0 +1,92 @@
+import unittest
+
+import numpy as np
+
+import openmdao.api as om
+
+import dymos
+from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
+
+from dymos.utils.misc import GroupWrapperConfig
+from dymos.transcriptions.pseudospectral.components import RadauIterGroup
+from dymos.phase.options import StateOptionsDictionary, TimeOptionsDictionary
+from dymos.transcriptions.grid_data import RadauGrid
+from dymos.utils.testing_utils import _PhaseStub, SimpleODE
+
+
+RadauIterGroup = GroupWrapperConfig(RadauIterGroup, [_PhaseStub()])
+
+
+# @use_tempdirs
+class TestRadauIterGroup(unittest.TestCase):
+
+    def test_solve_segments(self):
+        with dymos.options.temporary(include_check_partials=True):
+            for direction in ['forward', 'backward']:
+                for compressed in [True, False]:
+                    with self.subTest(msg=f'{direction=} {compressed=}'):
+
+                        state_options = {'x': StateOptionsDictionary()}
+
+                        state_options['x']['shape'] = (1,)
+                        state_options['x']['units'] = 's**2'
+                        state_options['x']['targets'] = ['x']
+                        state_options['x']['initial_bounds'] = (None, None)
+                        state_options['x']['final_bounds'] = (None, None)
+                        state_options['x']['solve_segments'] = direction
+                        state_options['x']['rate_source'] = 'x_dot'
+
+                        time_options = TimeOptionsDictionary()
+                        grid_data = RadauGrid(num_segments=10, nodes_per_seg=4, compressed=compressed)
+                        nn = grid_data.subset_num_nodes['all']
+                        ode_class = SimpleODE
+
+                        p = om.Problem()
+                        p.model.add_subsystem('radau', RadauIterGroup(state_options=state_options,
+                                                                      time_options=time_options,
+                                                                      grid_data=grid_data,
+                                                                      ode_class=ode_class))
+
+                        radau = p.model._get_subsystem('radau')
+
+                        radau.nonlinear_solver = om.NewtonSolver(solve_subsystems=True)
+                        radau.linear_solver = om.DirectSolver()
+
+                        p.setup(force_alloc_complex=True)
+
+                        # Instead of using the TimeComp just transform the node segment taus onto [0, 2]
+                        times = grid_data.node_ptau + 1
+
+                        solution = np.reshape(times**2 + 2 * times + 1 - 0.5 * np.exp(times), (nn, 1))
+
+                        # Each segment is of the same length, so dt_dstau is constant.
+                        # dt_dstau is (tf - t0) / 2.0 / num_seg
+                        p.set_val('radau.dt_dstau', (times[-1] / 2.0 / grid_data.num_segments))
+
+                        if direction == 'forward':
+                            p.set_val('radau.initial_states:x', 0.5)
+                        else:
+                            p.set_val('radau.final_states:x', solution[-1])
+
+                        p.set_val('radau.states:x', 0.0)
+                        p.set_val('radau.ode_all.t', times)
+                        p.set_val('radau.ode_all.p', 1.0)
+
+                        p.run_model()
+
+                        x = p.get_val('radau.states:x')
+                        x_0 = p.get_val('radau.initial_states:x')
+                        x_f = p.get_val('radau.final_states:x')
+
+                        idxs = grid_data.subset_node_indices['state_input']
+                        assert_near_equal(solution[idxs], x, tolerance=1.0E-5)
+                        assert_near_equal(solution[np.newaxis, 0], x_0, tolerance=1.0E-7)
+                        assert_near_equal(solution[np.newaxis, -1], x_f, tolerance=1.0E-7)
+
+                        cpd = p.check_partials(method='cs', compact_print=True, out_stream=None)
+                        assert_check_partials(cpd)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/dymos/transcriptions/pseudospectral/radau_new.py
+++ b/dymos/transcriptions/pseudospectral/radau_new.py
@@ -1,0 +1,841 @@
+import numpy as np
+
+import openmdao.api as om
+
+from ..transcription_base import TranscriptionBase
+from ..common import TimeComp, TimeseriesOutputGroup, TimeseriesOutputComp
+from .components import RadauIterGroup
+
+from ..grid_data import RadauGrid
+from dymos.utils.misc import get_rate_units
+from dymos.utils.introspection import get_promoted_vars, get_source_metadata
+from dymos.utils.indexing import get_constraint_flat_idxs, get_src_indices_by_row
+
+
+class RadauNew(TranscriptionBase):
+    """
+    Radau Pseudospectral Transcription.
+
+    Parameters
+    ----------
+    **kwargs : dict
+        Dictionary of optional arguments.
+
+    """
+    def __init__(self, **kwargs):
+        super(RadauNew, self).__init__(**kwargs)
+        self._rhs_source = 'ode_iter_group.ode_all'
+
+    def initialize(self):
+        """
+        Declare transcription options.
+        """
+        self.options.declare('grid', types=(RadauGrid, str),
+                             allow_none=True, default=None,
+                             desc='The grid distribution used to layout the control inputs and provide the default '
+                                  'output nodes. Use either "cgl" or "lgl".')
+
+        self.options.declare('nodes_per_seg', types=int, default=4,
+                             desc='The number of nodes per segment to be used.')
+
+        self.options.declare(name='solve_segments', default=False,
+                             values=(False, 'forward', 'backward'),
+                             desc='Applies \'solve_segments\' behavior to _all_ states in the Phase. '
+                                  'If \'forward\', collocation defects within each '
+                                  'segment are solved with a Newton solver by fixing the initial value in the '
+                                  'phase (if using compressed transcription) or segment (if not using '
+                                  'compressed transcription). This provides a forward shooting (or multiple shooting) '
+                                  'method.  If \'backward\', the final value in the phase or segment is fixed '
+                                  'and a solver finds the other ones to mimic reverse propagation. Set '
+                                  'to False (the default) to explicitly disable the use of a solver to '
+                                  'converge the state time history.')
+
+    def init_grid(self):
+        """
+        Set up the GridData object for the Transcription.
+        """
+        if self.options['compressed']:
+            raise ValueError('Option `compressed` is no longer supported. All transcriptions are now "uncompressed".')
+        self.grid_data = RadauGrid(num_segments=self.options['num_segments'],
+                                   nodes_per_seg=self.options['nodes_per_seg'],
+                                   segment_ends=self.options['segment_ends'],
+                                   compressed=self.options['compressed'])
+
+    def setup_time(self, phase):
+        """
+        Set up the time component.
+
+        Parameters
+        ----------
+        phase : dymos.Phase
+            The phase object to which this transcription instance applies.
+        """
+        grid_data = self.grid_data
+
+        super(RadauNew, self).setup_time(phase)
+
+        time_comp = TimeComp(num_nodes=grid_data.num_nodes, node_ptau=grid_data.node_ptau,
+                             node_dptau_dstau=grid_data.node_dptau_dstau,
+                             units=phase.time_options['units'],
+                             initial_val=phase.time_options['initial_val'],
+                             duration_val=phase.time_options['duration_val'])
+
+        phase.add_subsystem('time', time_comp, promotes_inputs=['*'], promotes_outputs=['*'])
+
+    def configure_time(self, phase):
+        """
+        Configure the inputs/outputs on the time component.
+
+        This method assumes that target introspection has already been performed by the phase and thus
+        options['targets'], options['time_phase_targets'], options['t_initial_targets'],
+        and options['t_duration_targets'] are all correctly populated.
+
+        Parameters
+        ----------
+        phase : dymos.Phase
+            The phase object to which this transcription instance applies.
+        """
+        super(RadauNew, self).configure_time(phase)
+        phase.time.configure_io()
+        options = phase.time_options
+        ode = phase._get_subsystem(self._rhs_source)
+        ode_inputs = get_promoted_vars(ode, iotypes='input')
+
+        # The tuples here are (name, user_specified_targets, dynamic)
+        for name, targets in [('t', options['targets']),
+                              ('t_phase', options['time_phase_targets'])]:
+            if targets:
+                src_idxs = self.grid_data.subset_node_indices['all']
+                phase.connect(name, [f'ode_all.{t}' for t in targets], src_indices=src_idxs,
+                              flat_src_indices=True)
+                src_idxs = om.slicer[[0, -1], ...]
+
+        for name, targets in [('t_initial', options['t_initial_targets']),
+                              ('t_duration', options['t_duration_targets'])]:
+            for t in targets:
+                shape = ode_inputs[t]['shape']
+
+                if shape == (1,):
+                    src_idxs = None
+                    flat_src_idxs = None
+                    src_shape = None
+                else:
+                    src_idxs = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
+                    flat_src_idxs = True
+                    src_shape = (1,)
+
+                phase.promotes('ode_all', inputs=[(t, name)], src_indices=src_idxs,
+                               flat_src_indices=flat_src_idxs, src_shape=src_shape)
+
+            if targets:
+                phase.set_input_defaults(name=name,
+                                         val=np.ones((1,)),
+                                         units=options['units'])
+
+    def setup_states(self, phase):
+        """
+        Set up the states for this transcription.
+
+        In the Radau2 transcription, everything typically done in this
+        method is instead done by the RadauIterGroup.
+
+        Parameters
+        ----------
+        phase : dymos.Phase
+            The phase object to which this transcription instance applies.
+        """
+        if self.options['compressed']:
+            raise ValueError('RadauNew does not support compressed transcription')
+
+        self.any_solved_segs = False
+        self.any_connected_opt_segs = False
+        for options in phase.state_options.values():
+            # Transcription solve_segments overrides state solve_segments if its not set
+            if options['solve_segments'] is None:
+                options['solve_segments'] = self.options['solve_segments']
+
+            if options['solve_segments']:
+                self.any_solved_segs = True
+            elif options['input_initial']:
+                self.any_connected_opt_segs = True
+
+    def configure_controls(self, phase):
+        """
+        Configure the inputs/outputs for the controls.
+
+        Parameters
+        ----------
+        phase : dymos.Phase
+            The phase object to which this transcription instance applies.
+        """
+        super().configure_controls(phase)
+
+        if phase.control_options:
+            phase.control_group.configure_io()
+            phase.promotes('control_group',
+                           any=['*controls:*', '*control_values:*', '*control_rates:*'])
+
+            phase.connect('dt_dstau', 'control_group.dt_dstau')
+
+        for name, options in phase.control_options.items():
+            if options['targets']:
+                phase.connect(f'control_values:{name}', [f'ode_all.{t}' for t in options['targets']])
+
+            if options['rate_targets']:
+                phase.connect(f'control_rates:{name}_rate',
+                              [f'ode_all.{t}' for t in options['rate_targets']])
+
+            if options['rate2_targets']:
+                phase.connect(f'control_rates:{name}_rate2',
+                              [f'ode_all.{t}' for t in options['rate2_targets']])
+
+    def setup_ode(self, phase):
+        """
+        Set up the ode for this transcription.
+
+        Parameters
+        ----------
+        phase : dymos.Phase
+            The phase object to which this transcription instance applies.
+        """
+        ODEClass = phase.options['ode_class']
+        grid_data = self.grid_data
+
+        ode_init_kwargs = phase.options['ode_init_kwargs']
+
+        phase.add_subsystem('ode_iter_group',
+                            subsys=RadauIterGroup(grid_data=grid_data, state_options=phase.state_options,
+                                                  time_options=phase.time_options,
+                                                  ode_class=ODEClass,
+                                                  ode_init_kwargs=ode_init_kwargs),
+                            promotes=['*'])
+
+    def configure_ode(self, phase):
+        """
+        Create connections to the introspected states.
+
+        Parameters
+        ----------
+        phase : dymos.Phase
+            The phase object to which this transcription instance applies.
+        """
+        # phase._get_subsystem('boundary_vals').configure_io(phase)
+        phase._get_subsystem('ode_iter_group').configure_io(phase)
+
+    def setup_defects(self, phase):
+        """
+        Pass setup_defects for this transcription.
+
+        Parameters
+        ----------
+        phase : dymos.Phase
+            The phase object to which this transcription instance applies.
+        """
+        pass
+
+    def configure_defects(self, phase):
+        """
+        Configure the continuity_comp and connect the collocation constraints.
+
+        Parameters
+        ----------
+        phase : dymos.Phase
+            The phase object to which this transcription instance applies.
+        """
+        for name, options in phase.state_options.items():
+            rate_source_type = phase.classify_var(options['rate_source'])
+            rate_src_path = self._get_rate_source_path(name, phase)
+            if rate_source_type not in ('state', 'ode'):
+                phase.connect(rate_src_path, f'f_computed:{name}')
+
+    def setup_duration_balance(self, phase):
+        """
+        Set up the implicit computation of the phase duration.
+
+        Parameters
+        ----------
+        phase : dymos.Phase
+            The phase object to which this transcription instance applies.
+        """
+        pass
+
+    def configure_duration_balance(self, phase):
+        """
+        Configure the implicit computation of the phase duration.
+
+        Parameters
+        ----------
+        phase : dymos.Phase
+            The phase object to which this transcription instance applies.
+        """
+        pass
+
+    def setup_solvers(self, phase):
+        """
+        Set up the solvers.
+
+        Parameters
+        ----------
+        phase : dymos.Phase
+            The phase object to which this transcription instance applies.
+        """
+        pass
+
+    def configure_solvers(self, phase, requires_solvers=None):
+        """
+        Configure the solvers.
+
+        Parameters
+        ----------
+        phase : dymos.Phase
+            The phase object to which this transcription instance applies.
+        requires_solvers : dict[str: bool]
+            A dictionary mapping a string descriptor of a reason why a solver is required,
+            and whether a solver is required.
+        """
+        ode_iter_group = phase._get_subsystem('ode_iter_group')
+        req_solvers = {'implicit outputs': ode_iter_group._implicit_outputs}
+
+        if requires_solvers is not None:
+            req_solvers.update(requires_solvers)
+
+        super().configure_solvers(phase, requires_solvers=req_solvers)
+
+    def configure_timeseries_outputs(self, phase):
+        """
+        Create connections from time series to all post-introspection sources.
+
+        Parameters
+        ----------
+        phase : dymos.Phase
+            The phase object to which this transcription instance applies.
+        """
+        for timeseries_name, timeseries_options in phase._timeseries.items():
+            timeseries_comp = phase._get_subsystem(f'{timeseries_name}.timeseries_comp')
+            ts_inputs_to_promote = []
+            for input_name, src, src_idxs in timeseries_comp._configure_io(timeseries_options):
+                # If the src was added, promote it if it was a state,
+                # or connect it otherwise.
+                if src.startswith('states:'):
+                    state_name = src.split(':')[-1]
+                    ts_inputs_to_promote.append((input_name, f'states:{state_name}'))
+                else:
+                    phase.connect(src_name=src,
+                                  tgt_name=f'{timeseries_name}.{input_name}',
+                                  src_indices=src_idxs)
+            phase.promotes(timeseries_name, inputs=ts_inputs_to_promote)
+
+    def setup_timeseries_outputs(self, phase):
+        """
+        Set up the timeseries for this transcription.
+
+        Parameters
+        ----------
+        phase : dymos.Phase
+            The phase object to which this transcription instance applies.
+        """
+        gd = self.grid_data
+
+        for name, options in phase._timeseries.items():
+            has_expr = False
+            for _, output_options in options['outputs'].items():
+                if output_options['is_expr']:
+                    has_expr = True
+                    break
+
+            if options['transcription'] is None:
+                ogd = None
+            else:
+                ogd = options['transcription'].grid_data
+
+            timeseries_comp = TimeseriesOutputComp(input_grid_data=gd,
+                                                   output_grid_data=ogd,
+                                                   output_subset=options['subset'],
+                                                   time_units=phase.time_options['units'])
+            timeseries_group = TimeseriesOutputGroup(has_expr=has_expr, timeseries_output_comp=timeseries_comp)
+            phase.add_subsystem(name, subsys=timeseries_group)
+
+            phase.connect('dt_dstau', f'{name}.dt_dstau', flat_src_indices=True)
+
+    def _get_constraint_kwargs(self, constraint_type, options, phase):
+        """
+        Given the constraint options provide the keyword arguments for the OpenMDAO add_constraint method.
+
+        Parameters
+        ----------
+        constraint_type : str
+            One of 'initial', 'final', or 'path'.
+        options : dict
+            The constraint options.
+        phase : Phase
+            The dymos phase to which the constraint applies.
+
+        Returns
+        -------
+        con_output : str
+            The phase-relative path being constrained.
+        constraint_kwargs : dict
+            Keyword arguments for the OpenMDAO add_constraint method.
+        """
+        num_nodes = self._get_num_timeseries_nodes()
+
+        constraint_kwargs = {key: options for key, options in options.items()}
+        con_name = constraint_kwargs.pop('constraint_name')
+
+        # Determine the path to the variable which we will be constraining
+        var = con_name if options['is_expr'] else options['name']
+        var_type = phase.classify_var(var)
+
+        # These are the flat indices at a single point in time used
+        # in either initial, final, or path constraints.
+        idxs_in_initial = phase._indices_in_constraints(var, 'initial')
+        idxs_in_final = phase._indices_in_constraints(var, 'final')
+        idxs_in_path = phase._indices_in_constraints(var, 'path')
+
+        size = np.prod(options['shape'], dtype=int)
+
+        flat_idxs = get_constraint_flat_idxs(options)
+
+        # Now we need to convert the indices given by the user at any given point
+        # to flat indices to be given to OpenMDAO as flat indices spanning the phase.
+        if var_type == 'parameter':
+            if any([idxs_in_initial.intersection(idxs_in_final),
+                    idxs_in_initial.intersection(idxs_in_path),
+                    idxs_in_final.intersection(idxs_in_path)]):
+                raise RuntimeError(f'In phase {phase.pathname}, parameter `{var}` is subject to multiple boundary '
+                                   f'or path constraints.\nParameters are single values that do not change in '
+                                   f'time, and may only be used in a single boundary or path constraint.')
+            constraint_kwargs['indices'] = flat_idxs
+        else:
+            if constraint_type == 'initial':
+                constraint_kwargs['indices'] = flat_idxs
+            elif constraint_type == 'final':
+                constraint_kwargs['indices'] = size * (num_nodes - 1) + flat_idxs
+            else:
+                # Path
+                path_idxs = []
+                for i in range(num_nodes):
+                    path_idxs.extend(size * i + flat_idxs)
+
+                constraint_kwargs['indices'] = path_idxs
+
+        alias_map = {'path': 'path_constraint',
+                     'initial': 'initial_boundary_constraint',
+                     'final': 'final_boundary_constraint'}
+
+        str_idxs = '' if options['indices'] is None else f'{options["indices"]}'
+
+        constraint_kwargs['alias'] = f'{phase.pathname}->{alias_map[constraint_type]}->{con_name}{str_idxs}'
+        constraint_kwargs.pop('name')
+        con_path = constraint_kwargs.pop('constraint_path')
+        constraint_kwargs.pop('shape')
+        constraint_kwargs['flat_indices'] = True
+        constraint_kwargs.pop('is_expr')
+
+        return con_path, constraint_kwargs
+
+    def _get_objective_src(self, var, loc, phase, ode_outputs=None):
+        """
+        Return the path to the variable that will be used as the objective.
+
+        Parameters
+        ----------
+        var : str
+            Name of the variable to be used as the objective.
+        loc : str
+            The location of the objective in the phase ['initial', 'final'].
+        phase : dymos.Phase
+            Phase object containing in which the objective resides.
+        ode_outputs : dict or None
+            A dictionary of ODE outputs as returned by get_promoted_vars.
+
+        Returns
+        -------
+        obj_path : str
+            Path to the source.
+        shape : tuple
+            Source shape.
+        units : str
+            Source units.
+        linear : bool
+            True if the objective quantity1 is linear.
+        """
+        time_units = phase.time_options['units']
+        var_type = phase.classify_var(var)
+
+        if ode_outputs is None:
+            ode_outputs = get_promoted_vars(phase._get_subsystem(self._rhs_source), 'output')
+
+        if var_type == 't':
+            shape = (1,)
+            units = time_units
+            linear = True
+            constraint_path = 't'
+        elif var_type == 't_phase':
+            shape = (1,)
+            units = time_units
+            linear = True
+            constraint_path = 't_phase'
+        elif var_type == 'state':
+            shape = phase.state_options[var]['shape']
+            units = phase.state_options[var]['units']
+            linear = False
+            constraint_path = f'ode_all.{var}'
+        elif var_type == 'indep_control':
+            shape = phase.control_options[var]['shape']
+            units = phase.control_options[var]['units']
+            linear = True
+            constraint_path = f'control_values:{var}'
+        elif var_type == 'input_control':
+            shape = phase.control_options[var]['shape']
+            units = phase.control_options[var]['units']
+            linear = False
+            constraint_path = f'control_values:{var}'
+        elif var_type == 'indep_polynomial_control':
+            shape = phase.control_options[var]['shape']
+            units = phase.control_options[var]['units']
+            linear = True
+            constraint_path = f'control_values:{var}'
+        elif var_type == 'input_polynomial_control':
+            shape = phase.control_options[var]['shape']
+            units = phase.control_options[var]['units']
+            linear = False
+            constraint_path = f'control_values:{var}'
+        elif var_type == 'parameter':
+            shape = phase.parameter_options[var]['shape']
+            units = phase.parameter_options[var]['units']
+            linear = True
+            constraint_path = f'parameter_vals:{var}'
+        elif var_type in ('control_rate', 'control_rate2'):
+            control_var = var[:-5] if var_type == 'control_rate' else var[:-6]
+            shape = phase.control_options[control_var]['shape']
+            control_units = phase.control_options[control_var]['units']
+            d = 2 if var_type == 'control_rate2' else 1
+            control_rate_units = get_rate_units(control_units, time_units, deriv=d)
+            units = control_rate_units
+            linear = False
+            constraint_path = f'control_rates:{var}'
+        elif var_type in ('polynomial_control_rate', 'polynomial_control_rate2'):
+            control_var = var[:-5]
+            shape = phase.control_options[control_var]['shape']
+            control_units = phase.control_options[control_var]['units']
+            d = 2 if var_type == 'polynomial_control_rate2' else 1
+            control_rate_units = get_rate_units(control_units, time_units, deriv=d)
+            units = control_rate_units
+            linear = False
+            constraint_path = f'control_rates:{var}'
+        elif var_type == 'timeseries_exec_comp_output':
+            shape = (1,)
+            units = None
+            constraint_path = f'timeseries.timeseries_exec_comp.{var}'
+            linear = False
+        else:
+            # Failed to find variable, assume it is in the ODE. This requires introspection.
+            constraint_path = f'ode_all.{var}'
+            meta = get_source_metadata(ode_outputs, var, user_units=None, user_shape=None)
+            shape = meta['shape']
+            units = meta['units']
+            linear = False
+
+        return constraint_path, shape, units, linear
+
+    def _get_num_timeseries_nodes(self):
+        """
+        Return the number of nodes in the default timeseries for this transcription.
+
+        Returns
+        -------
+        int
+            The number of nodes in the default timeseries for this transcription.
+        """
+        return self.grid_data.num_nodes
+
+    def _get_rate_source_path(self, state_name, phase):
+        """
+        Return the rate source location and indices for a given state name.
+
+        Parameters
+        ----------
+        state_name : str
+            Name of the state.
+        phase : dymos.Phase
+            Phase object containing the rate source.
+
+        Returns
+        -------
+        str
+            Path to the rate source.
+        ndarray
+            Array of source indices.
+        """
+        try:
+            var = phase.state_options[state_name]['rate_source']
+        except RuntimeError:
+            raise ValueError(f"state '{state_name}' in phase '{phase.name}' was not given a "
+                             "rate_source")
+
+        # Note the rate source must be shape-compatible with the state
+        var_type = phase.classify_var(var)
+
+        # Determine the path to the variable
+        if var_type == 't':
+            rate_path = 't'
+        elif var_type == 't_phase':
+            rate_path = 't_phase'
+        elif var_type == 'state':
+            rate_path = f'states:{var}'
+        elif var_type == 'indep_control':
+            rate_path = f'control_values:{var}'
+        elif var_type == 'input_control':
+            rate_path = f'control_values:{var}'
+        elif var_type == 'control_rate':
+            control_name = var[:-5]
+            rate_path = f'control_rates:{control_name}_rate'
+        elif var_type == 'control_rate2':
+            control_name = var[:-6]
+            rate_path = f'control_rates:{control_name}_rate2'
+        elif var_type == 'indep_polynomial_control':
+            rate_path = f'control_values:{var}'
+        elif var_type == 'input_polynomial_control':
+            rate_path = f'control_values:{var}'
+        elif var_type == 'polynomial_control_rate':
+            control_name = var[:-5]
+            rate_path = f'control_rates:{control_name}_rate'
+        elif var_type == 'polynomial_control_rate2':
+            control_name = var[:-6]
+            rate_path = f'control_rates:{control_name}_rate2'
+        elif var_type == 'parameter':
+            rate_path = f'parameter_vals:{var}'
+        else:
+            # Failed to find variable, assume it is in the ODE
+            rate_path = f'ode_all.{var}'
+
+        return rate_path
+
+    def _get_timeseries_var_source(self, var, output_name, phase):
+        """
+        Return the source path and indices for a given variable to be connected to a timeseries.
+
+        Parameters
+        ----------
+        var : str
+            Name of the timeseries variable whose source is desired.
+        output_name : str
+            Name of the timeseries output whose source is desired.
+        phase : dymos.Phase
+            Phase object containing the variable, either as state, time, control, etc., or as an ODE output.
+
+        Returns
+        -------
+        meta : dict
+            Metadata pertaining to the variable at the given path. This dict contains 'src' (the path to the
+            timeseries source), 'src_idxs' (an array of the
+            source indices), 'units' (the units of the source variable), and 'shape' (the shape of the variable at
+            a given node).
+        """
+        gd = self.grid_data
+        var_type = phase.classify_var(var)
+        time_units = phase.time_options['units']
+
+        transcription = phase.options['transcription']
+        ode = transcription._get_ode(phase)
+        ode_outputs = get_promoted_vars(ode, 'output')
+
+        # The default for node_idxs, applies to everything except states and parameters.
+        node_idxs = gd.subset_node_indices['all']
+
+        meta = {}
+
+        # Determine the path to the variable
+        if var_type == 't':
+            path = 't'
+            src_units = time_units
+            src_shape = (1,)
+        elif var_type == 't_phase':
+            path = 't_phase'
+            src_units = time_units
+            src_shape = (1,)
+        elif var_type == 'state':
+            path = f'states:{var}'
+            src_units = phase.state_options[var]['units']
+            src_shape = phase.state_options[var]['shape']
+
+            # Find the state_input indices which occur at segment endpoints, and repeat them twice
+            state_input_idxs = gd.subset_node_indices['state_input']
+            repeat_idxs = np.ones_like(state_input_idxs)
+            if self.options['compressed']:
+                segment_end_idxs = gd.subset_node_indices['segment_ends'][1:-1]
+                # Repeat nodes that are on segment bounds (but not the first or last nodes in the phase)
+                nodes_to_repeat = list(set(state_input_idxs).intersection(set(segment_end_idxs)))
+                # Now find these nodes in the state input indices
+                idxs_of_ntr_in_state_inputs = np.where(np.isin(state_input_idxs, nodes_to_repeat))[0]
+                # All state input nodes are used once, but nodes_to_repeat are used twice
+                repeat_idxs[idxs_of_ntr_in_state_inputs] = 2
+            # Now we have a way of mapping the state input indices to all nodes
+            map_input_node_idxs_to_all = np.repeat(np.arange(gd.subset_num_nodes['state_input'],
+                                                   dtype=int), repeats=repeat_idxs)
+            # Now select the subset of nodes we want to use.
+            node_idxs = map_input_node_idxs_to_all[gd.subset_node_indices['all']]
+        elif var_type in ['indep_control', 'input_control']:
+            path = f'control_values:{var}'
+            src_units = phase.control_options[var]['units']
+            src_shape = phase.control_options[var]['shape']
+        elif var_type == 'control_rate':
+            control_name = var[:-5]
+            path = f'control_rates:{control_name}_rate'
+            control_name = var[:-5]
+            src_units = get_rate_units(phase.control_options[control_name]['units'], time_units, deriv=1)
+            src_shape = phase.control_options[control_name]['shape']
+        elif var_type == 'control_rate2':
+            control_name = var[:-6]
+            path = f'control_rates:{control_name}_rate2'
+            src_units = get_rate_units(phase.control_options[control_name]['units'], time_units, deriv=2)
+            src_shape = phase.control_options[control_name]['shape']
+        elif var_type in ['indep_polynomial_control', 'input_polynomial_control']:
+            path = f'control_values:{var}'
+            src_units = phase.control_options[var]['units']
+            src_shape = phase.control_options[var]['shape']
+        elif var_type == 'polynomial_control_rate':
+            control_name = var[:-5]
+            path = f'control_rates:{control_name}_rate'
+            control = phase.control_options[control_name]
+            src_units = get_rate_units(control['units'], time_units, deriv=1)
+            src_shape = control['shape']
+        elif var_type == 'polynomial_control_rate2':
+            control_name = var[:-6]
+            path = f'control_rates:{control_name}_rate2'
+            control = phase.control_options[control_name]
+            src_units = get_rate_units(control['units'], time_units, deriv=2)
+            src_shape = control['shape']
+        elif var_type == 'parameter':
+            path = f'parameter_vals:{var}'
+            # Timeseries are never a static_target
+            node_idxs = np.zeros(gd.subset_num_nodes['all'], dtype=int)
+            src_units = phase.parameter_options[var]['units']
+            src_shape = phase.parameter_options[var]['shape']
+        else:
+            # Failed to find variable, assume it is in the ODE
+            path = f'ode_all.{var}'
+            meta = get_source_metadata(ode_outputs, src=var)
+            src_shape = meta['shape']
+            src_units = meta['units']
+            src_tags = meta['tags']
+            if 'dymos.static_output' in src_tags:
+                raise RuntimeError(
+                    f'ODE output {var} is tagged with "dymos.static_output" and cannot be a timeseries output.')
+
+        src_idxs = om.slicer[node_idxs, ...]
+
+        meta['src'] = path
+        meta['src_idxs'] = src_idxs
+        meta['units'] = src_units
+        meta['shape'] = src_shape
+
+        return meta
+
+    def get_parameter_connections(self, name, phase):
+        """
+        Return info about a parameter's target connections in the phase.
+
+        Parameters
+        ----------
+        name : str
+            Parameter name.
+        phase : dymos.Phase
+            The phase object to which this transcription instance applies.
+
+        Returns
+        -------
+        list of (paths, indices)
+            A list containing a tuple of target paths and corresponding src_indices to which the
+            given design variable is to be connected.
+        """
+        connection_info = []
+        if name in phase.parameter_options:
+            options = phase.parameter_options[name]
+            for tgt in options['targets']:
+                if tgt in options['static_targets']:
+                    src_idxs = np.squeeze(get_src_indices_by_row([0], options['shape']), axis=0)
+                else:
+                    src_idxs_raw = np.zeros(self.grid_data.subset_num_nodes['all'], dtype=int)
+                    src_idxs = get_src_indices_by_row(src_idxs_raw, options['shape'])
+                    if options['shape'] == (1,):
+                        src_idxs = src_idxs.ravel()
+
+                connection_info.append((f'ode_all.{tgt}', (src_idxs,)))
+
+        return connection_info
+
+    def _requires_continuity_constraints(self, phase):
+        """
+        Test whether state and/or control and/or control rate continuity are required.
+
+        Parameters
+        ----------
+        phase : dymos.Phase
+            The phase to which this transcription applies.
+
+        Returns
+        -------
+        any_state_continuity : bool
+            True if any state continuity is required to be enforced.
+        any_control_continuity : bool
+            True if any control value continuity is required to be enforced.
+        any_control_rate_continuity : bool
+            True if any control rate continuity is required to be enforced.
+
+        """
+        num_seg = self.grid_data.num_segments
+        compressed = self.grid_data.compressed
+
+        any_state_continuity = num_seg > 1 and not compressed
+        any_control_continuity = any([opts['continuity'] for opts in phase.control_options.values()])
+        any_control_continuity = any_control_continuity and num_seg > 1
+        any_rate_continuity = any([opts['rate_continuity'] or opts['rate2_continuity']
+                                   for opts in phase.control_options.values()])
+        any_rate_continuity = any_rate_continuity and num_seg > 1
+
+        return any_state_continuity, any_control_continuity, any_rate_continuity
+
+    def _phase_set_state_val(self, phase, name, vals, time_vals, interpolation_kind):
+        """
+        Provide variable names and values when phase.set_state_vals is called.
+
+        Parameters
+        ----------
+        phase : dymos.Phase
+            The phase to which this transcription applies.
+        name : str
+            The name of the phase variable to be set.
+        vals : ndarray or Sequence or float
+            Array of control/state/parameter values.
+        time_vals : ndarray or Sequence or None
+            Array of integration variable values.
+        interpolation_kind : str
+            Specifies the kind of interpolation, as per the scipy.interpolate package.
+            One of ('linear', 'nearest', 'zero', 'slinear', 'quadratic', 'cubic'
+            where 'zero', 'slinear', 'quadratic' and 'cubic' refer to a spline
+            interpolation of zeroth, first, second or third order) or as an
+            integer specifying the order of the spline interpolator to use.
+            Default is 'linear'.
+
+        Returns
+        -------
+        input_data : dict
+            Dict containing the values that need to be set in the phase
+
+        """
+        input_data = {}
+        if np.isscalar(vals):
+            input_data[f'states:{name}'] = vals
+            input_data[f'initial_states:{name}'] = vals
+            input_data[f'final_states:{name}'] = vals
+        else:
+            interp_vals = phase.interp(name, vals, time_vals,
+                                       nodes='state_input',
+                                       kind=interpolation_kind)
+            input_data[f'states:{name}'] = interp_vals
+            input_data[f'initial_states:{name}'] = vals[0]
+            input_data[f'final_states:{name}'] = vals[-1]
+
+        return input_data


### PR DESCRIPTION
The original Radau transcription can be accessed as RadauDeprecated, but will remain until the new one is thoroughly vetted.

RadauNew removes the need for the StateIndependentsComp which used a complicated hybrid IVC/implicit/explicit component implementation. RadauNew uses the same structure as the Birkhoff transcription, where initial and final values of states in the phase are double-specified...once in the array of state values, and once as initial_states:{name} or final_states:{name}. This provides a better source/target when linking phases together.

An important restriction of the new radau implementation is that it no longer supports compressed transcription.  Continuity constraints are implemented between segments for state and control values.

### Summary

Summary of PR.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
