### PR TITLE
Trajectory results report plots now plot vector variables, respect the x_name argument, and avoid noisy plots when values are nearly constant.

### DIFF
--- a/dymos/examples/brachistochrone/test/ex_brachistochrone_vector_states.py
+++ b/dymos/examples/brachistochrone/test/ex_brachistochrone_vector_states.py
@@ -7,7 +7,8 @@ from dymos.examples.brachistochrone.brachistochrone_vector_states_ode \
 def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, transcription_order=3,
                              grid_type='lgl', compressed=True, optimizer='SLSQP',
                              dynamic_simul_derivs=True, force_alloc_complex=False,
-                             solve_segments=False, run_driver=True):
+                             solve_segments=False, run_driver=True, simulate=False,
+                             make_plots=False):
     p = om.Problem(model=om.Group())
 
     if optimizer == 'SNOPT':
@@ -78,9 +79,11 @@ def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, tran
     phase.set_state_val('v', [0, 9.9])
     phase.set_control_val('theta', [5, 100])
     phase.set_parameter_val('g', 9.80665)
-    p.run_model()
-    if run_driver:
-        p.run_driver()
+
+    dm.run_problem(p,
+                   run_driver=run_driver,
+                   simulate=simulate,
+                   make_plots=make_plots)
 
     return p
 

--- a/dymos/examples/brachistochrone/test/test_ex_brachistochrone_vector_states.py
+++ b/dymos/examples/brachistochrone/test/test_ex_brachistochrone_vector_states.py
@@ -6,11 +6,6 @@ from numpy.testing import assert_almost_equal
 
 import sys
 
-try:
-    sys.modules.pop('bokeh')
-except:
-    pass
-
 from openmdao.utils.general_utils import set_pyoptsparse_opt, printoptions
 from openmdao.utils.testing_utils import use_tempdirs, set_env_vars_context
 from openmdao.utils.tests.test_hooks import hooks_active

--- a/dymos/examples/brachistochrone/test/test_ex_brachistochrone_vector_states.py
+++ b/dymos/examples/brachistochrone/test/test_ex_brachistochrone_vector_states.py
@@ -15,7 +15,7 @@ bokeh_available = importlib.util.find_spec('bokeh') is not None
 OPT, OPTIMIZER = set_pyoptsparse_opt('SNOPT')
 
 
-# @use_tempdirs
+@use_tempdirs
 class TestBrachistochroneVectorStatesExample(unittest.TestCase):
 
     def assert_results(self, p):

--- a/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise_bokeh_plots.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise_bokeh_plots.py
@@ -13,7 +13,6 @@ from openmdao.utils.testing_utils import require_pyoptsparse
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.utils.testing_utils import use_tempdirs, set_env_vars_context
 
-
 import dymos as dm
 from dymos.examples.finite_burn_orbit_raise.finite_burn_orbit_raise_problem import two_burn_orbit_raise_problem
 from dymos.utils.testing_utils import _get_reports_dir

--- a/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
+++ b/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
@@ -341,7 +341,7 @@ class TestMinTimeClimbWithReports(TestMinTimeClimb):
             self.assertIn(label, html_data)
 
     @require_pyoptsparse(optimizer='IPOPT')
-    @skipIf(not bokeh_available, 'bokeh is not available')
+    @unittest.skipIf(not bokeh_available, 'bokeh is not available')
     def test_results_gauss_lobatto_renamed_time(self):
         with set_env_vars_context(OPENMDAO_REPORTS='1'):
             with dm.options.temporary(plots='bokeh'):
@@ -363,7 +363,7 @@ class TestMinTimeClimbWithReports(TestMinTimeClimb):
                 self._test_traj_results_report(p)
 
     @require_pyoptsparse(optimizer='IPOPT')
-    @skipIf(not bokeh_available, 'bokeh is not available')
+    @unittest.skipIf(not bokeh_available, 'bokeh is not available')
     def test_results_radau_renamed_time(self):
         with set_env_vars_context(OPENMDAO_REPORTS='1'):
             with dm.options.temporary(plots='bokeh'):

--- a/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
+++ b/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
@@ -144,7 +144,7 @@ def min_time_climb(optimizer='SLSQP', num_seg=3, transcription='gauss-lobatto',
     return p
 
 
-# @use_tempdirs
+@use_tempdirs
 class TestMinTimeClimb(unittest.TestCase):
 
     def _test_results(self, p, time_name='time'):

--- a/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
+++ b/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import unittest
 import numpy as np
@@ -17,6 +18,9 @@ import dymos as dm
 from dymos.examples.min_time_climb.min_time_climb_ode import MinTimeClimbODE
 from dymos.utils.misc import om_version
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse, set_env_vars_context
+
+
+bokeh_available = importlib.util.find_spec('bokeh') is not None
 
 
 def min_time_climb(optimizer='SLSQP', num_seg=3, transcription='gauss-lobatto',
@@ -337,6 +341,7 @@ class TestMinTimeClimbWithReports(TestMinTimeClimb):
             self.assertIn(label, html_data)
 
     @require_pyoptsparse(optimizer='IPOPT')
+    @skipIf(not bokeh_available, 'bokeh is not available')
     def test_results_gauss_lobatto_renamed_time(self):
         with set_env_vars_context(OPENMDAO_REPORTS='1'):
             with dm.options.temporary(plots='bokeh'):
@@ -358,6 +363,7 @@ class TestMinTimeClimbWithReports(TestMinTimeClimb):
                 self._test_traj_results_report(p)
 
     @require_pyoptsparse(optimizer='IPOPT')
+    @skipIf(not bokeh_available, 'bokeh is not available')
     def test_results_radau_renamed_time(self):
         with set_env_vars_context(OPENMDAO_REPORTS='1'):
             with dm.options.temporary(plots='bokeh'):

--- a/dymos/run_problem.py
+++ b/dymos/run_problem.py
@@ -122,7 +122,6 @@ def run_problem(problem, refine_method='hp', refine_iteration_limit=0, run_drive
                 sims[subsys.pathname] = sim_prob
 
     if make_plots:
-
         if om_version()[0] > (3, 34, 2):
             outputs_dir = problem.get_outputs_dir()
             if os.sep in str(solution_record_file):

--- a/dymos/run_problem.py
+++ b/dymos/run_problem.py
@@ -142,13 +142,15 @@ def run_problem(problem, refine_method='hp', refine_iteration_limit=0, run_drive
             _sol_record_file = solution_record_file
             _sim_record_file = None if not simulate else simulation_record_file
 
+        _plot_kwargs = plot_kwargs if plot_kwargs is not None else {}
+
         if dymos_options['plots'] == 'bokeh':
             from dymos.visualization.timeseries.bokeh_timeseries_report import make_timeseries_report
             make_timeseries_report(prob=problem,
                                    solution_record_file=_sol_record_file,
-                                   simulation_record_file=_sim_record_file)
+                                   simulation_record_file=_sim_record_file,
+                                   **_plot_kwargs)
         else:
-            _plot_kwargs = plot_kwargs if plot_kwargs is not None else {}
             plots_dir = problem.get_reports_dir() / 'plots'
             timeseries_plots(_sol_record_file,
                              simulation_record_file=_sim_record_file,

--- a/dymos/test/test_pycodestyle.py
+++ b/dymos/test/test_pycodestyle.py
@@ -41,22 +41,19 @@ def _get_tracked_python_files(git_root):
 
     Parameters
     ----------
-    git_root : _type_
-        _description_
-    file_list : _type_
-        _description_
-    suffix : str, optional
-        _description_, by default '.py'
+    git_root : str or Path
+        The root directory of the git repository.
 
     Returns
     -------
-    _type_
-        _description_
+    set
+        Python files in the given git directory that a tracked by git.
     """
-    file_list = _discover_python_files(git_root)
+    _git_root = str(git_root)
+    file_list = _discover_python_files(_git_root)
     untracked_set = set(
         subprocess.run(
-            ['git', 'ls-files', git_root, '--exclude-standard', '--others'],
+            ['git', 'ls-files', _git_root, '--exclude-standard', '--others'],
             stdout=subprocess.PIPE,
             text=True
         ).stdout.splitlines()

--- a/dymos/test/test_pycodestyle.py
+++ b/dymos/test/test_pycodestyle.py
@@ -1,4 +1,6 @@
 import os
+import pathlib
+import subprocess
 import sys
 import unittest
 
@@ -33,6 +35,36 @@ def _discover_python_files(path):
     return python_files
 
 
+def _get_tracked_python_files(git_root):
+    """
+    Given a git root directory
+
+    Parameters
+    ----------
+    git_root : _type_
+        _description_
+    file_list : _type_
+        _description_
+    suffix : str, optional
+        _description_, by default '.py'
+
+    Returns
+    -------
+    _type_
+        _description_
+    """
+    file_list = _discover_python_files(git_root)
+    untracked_set = set(
+        subprocess.run(
+            ['git', 'ls-files', git_root, '--exclude-standard', '--others'],
+            stdout=subprocess.PIPE,
+            text=True
+        ).stdout.splitlines()
+    )
+    untracked_set = {str(pathlib.Path(f).absolute()) for f in untracked_set if f.endswith('.py')}
+    return set(file_list) - untracked_set
+
+
 @unittest.skipIf(pycodestyle is None, "This test requires pycodestyle")
 class TestPyCodeStyle(unittest.TestCase):
 
@@ -46,6 +78,8 @@ class TestPyCodeStyle(unittest.TestCase):
         """
         dymos_path = os.path.split(dymos.__file__)[0]
         pyfiles = _discover_python_files(dymos_path)
+
+        files_to_check = _get_tracked_python_files(dymos_path)
 
         style = pycodestyle.StyleGuide(ignore=['E226',  # missing whitespace around arithmetic operator
                                                'E241',  # multiple spaces after ','
@@ -65,7 +99,7 @@ class TestPyCodeStyle(unittest.TestCase):
         try:
             sys.stdout = buff_out = StringIO()
             sys.stdout = buff_err = StringIO()
-            report = style.check_files(pyfiles)
+            report = style.check_files(files_to_check)
         finally:
             sys.stdout = save_out
             sys.stderr = save_err

--- a/dymos/visualization/timeseries/bokeh_timeseries_report.py
+++ b/dymos/visualization/timeseries/bokeh_timeseries_report.py
@@ -386,20 +386,21 @@ def _gather_system_options(model, options, sys_cls=None, rank=0,):
 
     return system_options
 
+
 def _new_figure(x_name, y_name, x_units, y_units, margin, x_range=None):
     fig_kwargs = {'x_range': x_range} if x_range is not None else {}
 
     tool_tips = [(f'{x_name}', f'@{x_name}'), (f'{y_name}', f'@{y_name}')]
 
     fig = figure(tools='pan,box_zoom,xwheel_zoom,hover,undo,reset,save',
-                    tooltips=tool_tips,
-                    x_axis_label=f'{x_name} ({x_units})',
-                    y_axis_label=f'{y_name} ({y_units})',
-                    toolbar_location='above',
-                    sizing_mode='stretch_both',
-                    min_height=250, max_height=300,
-                    margin=margin,
-                    **fig_kwargs)
+                 tooltips=tool_tips,
+                 x_axis_label=f'{x_name} ({x_units})',
+                 y_axis_label=f'{y_name} ({y_units})',
+                 toolbar_location='above',
+                 sizing_mode='stretch_both',
+                 min_height=250, max_height=300,
+                 margin=margin,
+                 **fig_kwargs)
     fig.xaxis.axis_label_text_font_size = '10pt'
     fig.yaxis.axis_label_text_font_size = '10pt'
     fig.toolbar.autohide = True
@@ -526,7 +527,7 @@ def make_timeseries_report(prob, solution_record_file=None, simulation_record_fi
                                 fig_legend_data = legend_data_per_figure[var_name_with_idxs] = []
                             if sol_data:
                                 sol_plot = fig.scatter(x=x_name, y=_source, source=sol_source,
-                                                      color=color, size=5)
+                                                       color=color, size=5)
                                 sol_plot.tags.extend(['sol', f'phase:{phase_name}'])
                                 legend_items.append(sol_plot)
                             if sim_data:
@@ -544,7 +545,7 @@ def make_timeseries_report(prob, solution_record_file=None, simulation_record_fi
             for var_name_with_idxs, fig in figures.items():
                 legend_data = legend_data_per_figure[var_name_with_idxs]
                 legend = Legend(items=legend_data, location='center', label_text_font_size='8pt',
-                                            orientation='vertical')
+                                orientation='vertical')
                 fig.add_layout(legend, 'right')
 
             # Since we're putting figures in two columns, make sure we have an even number of things to put in the layout.

--- a/dymos/visualization/timeseries/bokeh_timeseries_report.py
+++ b/dymos/visualization/timeseries/bokeh_timeseries_report.py
@@ -501,7 +501,7 @@ def make_timeseries_report(prob, solution_record_file=None, simulation_record_fi
                                 # Bokeh ColumnDataSource doesn't allow special characters in keys,
                                 # but we want the y_axis label to show the indices of the columns
                                 # being plotted as 'varname[i,j,k]'.
-                                sources[f'{var_name}[{str_idxs}]'] = s = f'{var_name}_{str_idxs.replace(",","_")}'
+                                sources[f'{var_name}[{str_idxs}]'] = s = f'{var_name}_{str_idxs.replace(",", "_")}'
                                 sol_data_column = sol_data[var_name][:, *idxs]
                                 sol_data[s] = sol_data_column
                                 sim_data_column = sim_data[var_name][:, *idxs]

--- a/dymos/visualization/timeseries/bokeh_timeseries_report.py
+++ b/dymos/visualization/timeseries/bokeh_timeseries_report.py
@@ -502,9 +502,9 @@ def make_timeseries_report(prob, solution_record_file=None, simulation_record_fi
                                 # but we want the y_axis label to show the indices of the columns
                                 # being plotted as 'varname[i,j,k]'.
                                 sources[f'{var_name}[{str_idxs}]'] = s = f'{var_name}_{str_idxs.replace(",", "_")}'
-                                sol_data_column = sol_data[var_name][:, *idxs]
+                                sol_data_column = sol_data[var_name][(slice(None), *idxs)]
                                 sol_data[s] = sol_data_column
-                                sim_data_column = sim_data[var_name][:, *idxs]
+                                sim_data_column = sim_data[var_name][(slice(None), *idxs)]
                                 sim_data[s] = sim_data_column
                         else:
                             sources = {var_name: var_name}
@@ -598,6 +598,5 @@ def make_timeseries_report(prob, solution_record_file=None, simulation_record_fi
                                                          phase_select=phase_select)))
 
             # Save
-
             save(report_layout, filename=report_path, title=f'trajectory results for {traj_path}',
                  resources=bokeh_resources.INLINE)

--- a/dymos/visualization/timeseries/bokeh_timeseries_report.py
+++ b/dymos/visualization/timeseries/bokeh_timeseries_report.py
@@ -525,12 +525,12 @@ def make_timeseries_report(prob, solution_record_file=None, simulation_record_fi
                                 figures[var_name_with_idxs] = fig
                                 fig_legend_data = legend_data_per_figure[var_name_with_idxs] = []
                             if sol_data:
-                                sol_plot = fig.scatter(x='time', y=_source, source=sol_source,
+                                sol_plot = fig.scatter(x=x_name, y=_source, source=sol_source,
                                                       color=color, size=5)
                                 sol_plot.tags.extend(['sol', f'phase:{phase_name}'])
                                 legend_items.append(sol_plot)
                             if sim_data:
-                                sim_plot = fig.line(x='time', y=_source, source=sim_source, color=color)
+                                sim_plot = fig.line(x=x_name, y=_source, source=sim_source, color=color)
                                 sim_plot.tags.extend(['sim', f'phase:{phase_name}'])
                                 legend_items.append(sim_plot)
                             fig_legend_data.append((phase_name, legend_items))


### PR DESCRIPTION
### Summary

The bokeh traj results report created by run_problem was not respecting plot_kwargs.  This is now fixed, allowing users to specify the name of the time-like variable when phases rename the time-like variable.

Vectorized states, controls, and parameters were previously not being plotted correctly in the traj results report.

For example, in the brachistochrone vector states test, `pos` is a 2-vector holding both x and y states.
Previously, these weren't plotted correctly because Bokeh's ColumnDataSource seems to prefer a single column of data for each variable name.

<img width="567" alt="Screenshot 2024-12-04 at 1 12 33 PM" src="https://github.com/user-attachments/assets/5af89e13-fd9b-4ebe-af7c-7807bdc104f8">

Now the report will include a new figure for each element in the vector, with the axis labeled correctly.

<img width="1127" alt="Screenshot 2024-12-04 at 1 15 48 PM" src="https://github.com/user-attachments/assets/832bf47b-d8cf-43bb-a1d2-3a4ed40264a2">

Finally, in some cases, machine precision variation in otherwise-constant data would show up as noisy.
The y-range of the plots has now had its `min_interval` set to `1.0E-12` so that. machine-precision variation, typically on the order of 1E-16, appears constant.

### Related Issues

- Resolves #999 
- Resolves #1051 

### Backwards incompatibilities

None

### New Dependencies

None
