### PR TITLE
Updated Ubuntu images used by GitHub workflows

### DIFF
--- a/.github/workflows/dymos_docs_workflow.yml
+++ b/.github/workflows/dymos_docs_workflow.yml
@@ -107,6 +107,7 @@ jobs:
             } || {
               echo "Failed to install jaxlib..."
             }
+            python -m pip install jax
           else
             python -m pip install jaxlib==${{ matrix.JAX }} jax==${{ matrix.JAX }}
           fi

--- a/.github/workflows/dymos_docs_workflow.yml
+++ b/.github/workflows/dymos_docs_workflow.yml
@@ -102,8 +102,11 @@ jobs:
           echo "Install jax"
           echo "============================================================="
           if [[ "${{ matrix.JAX }}" == "latest" ]]; then
-            python -m pip install jaxlib || true
-            python -m pip install jax
+            {
+              python -m pip install jaxlib
+            } || {
+              echo "Failed to install jaxlib..."
+            }
           else
             python -m pip install jaxlib==${{ matrix.JAX }} jax==${{ matrix.JAX }}
           fi

--- a/.github/workflows/dymos_docs_workflow.yml
+++ b/.github/workflows/dymos_docs_workflow.yml
@@ -102,7 +102,8 @@ jobs:
           echo "Install jax"
           echo "============================================================="
           if [[ "${{ matrix.JAX }}" == "latest" ]]; then
-            python -m pip install jaxlib jax
+            python -m pip install jaxlib || true
+            python -m pip install jax
           else
             python -m pip install jaxlib==${{ matrix.JAX }} jax==${{ matrix.JAX }}
           fi

--- a/.github/workflows/dymos_docs_workflow.yml
+++ b/.github/workflows/dymos_docs_workflow.yml
@@ -15,7 +15,7 @@ on:
 jobs:
 
   test_ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     timeout-minutes: 90
 

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -77,7 +77,7 @@ run-name:  ${{ inputs.run_name }}
 jobs:
 
   test_ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     timeout-minutes: 90
 

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -241,7 +241,8 @@ jobs:
           echo "Install jax"
           echo "============================================================="
           if [[ "${{ matrix.JAX }}" == "latest" ]]; then
-            python -m pip install jaxlib jax
+            python -m pip install jaxlib || true
+            python -m pip install jax
           else
             python -m pip install jaxlib==${{ matrix.JAX }} jax==${{ matrix.JAX }}
           fi

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -241,7 +241,11 @@ jobs:
           echo "Install jax"
           echo "============================================================="
           if [[ "${{ matrix.JAX }}" == "latest" ]]; then
-            python -m pip install jaxlib || true
+            {
+              python -m pip install jaxlib
+            } || {
+              echo "Failed to install jaxlib..."
+            }
             python -m pip install jax
           else
             python -m pip install jaxlib==${{ matrix.JAX }} jax==${{ matrix.JAX }}


### PR DESCRIPTION
### Summary

GitHub has recently updated their `ubuntu-latest` image to use Ubuntu 24.04.

This has resulted in some incompatibilities with system level libraries in the test workflows, e.g. 
```
symbol lookup error: /lib/x86_64-linux-gnu/libatk-bridge-2.0.so.0: undefined symbol: atk_object_get_help_text
```

This PR reverts the workflows to use the Ubuntu 22.04 image.

Also pip cannot find a matching `jaxlib` for the latest/python 3.13 build, so error handling has been added around that (it does not cause any tests to fail)

But...

I'm seeing a failure in the doc build for `dymos_book/examples/cannonball_implicit_duration/cannonball_implicit_duration.ipynb`:
```
----- stdout -----
NL: NewtonSolver 'NL: Newton' on system 'traj.phases.phase' failed to converge in 10 iterations.

...

----- stdout -----
NL: NewtonSolver 'NL: Newton' on system 'traj.phases.phase': residuals contain 'inf' or 'NaN' after 0 iterations.
----- stderr -----
/tmp/ipykernel_3256/422182017.py:53: RuntimeWarning: overflow encountered in square
  q = 0.5*rho*v**2
/tmp/ipykernel_3256/422182017.py:62: RuntimeWarning: overflow encountered in square
  outputs['ke'] = 0.5*m*v**2
/usr/share/miniconda/envs/test/lib/python3.11/site-packages/openmdao/vectors/default_vector.py:491: RuntimeWarning: invalid value encountered in add
  data[idxs] += val
```

Don't know what to do about that...


### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
