### PR TITLE
Bump version: 1.12.1-dev → 1.13.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.12.1-dev
+current_version = 1.13.0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,7 @@ body:
     attributes:
       label: Dymos Version
       description: What version of Dymos is being used.
-      placeholder: "1.12.1-dev"
+      placeholder: "1.13.0"
     validations:
       required: true
   - type: textarea

--- a/dymos/__init__.py
+++ b/dymos/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.12.1-dev'
+__version__ = '1.13.0'
 
 
 from .phase import Phase, AnalyticPhase


### PR DESCRIPTION
### Summary

Version 1.13.0 of dymos.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
