### PR TITLE
Quieted plots and IPOPT output in a few tests when testflo is running.

### DIFF
--- a/dymos/examples/shuttle_reentry/test/test_reentry.py
+++ b/dymos/examples/shuttle_reentry/test/test_reentry.py
@@ -212,7 +212,7 @@ class TestReentry(unittest.TestCase):
         p.driver.declare_coloring(tol=1.0E-12)
         p.driver.options['optimizer'] = 'IPOPT'
         p.driver.opt_settings['alpha_for_y'] = 'safer-min-dual-infeas'
-        p.driver.opt_settings['print_level'] = 5
+        p.driver.opt_settings['print_level'] = 0
         p.driver.opt_settings['nlp_scaling_method'] = 'gradient-based'
         p.driver.opt_settings['mu_strategy'] = 'monotone'
         p.driver.opt_settings['bound_mult_init_method'] = 'mu-based'

--- a/dymos/examples/water_rocket/test/test_water_rocket.py
+++ b/dymos/examples/water_rocket/test/test_water_rocket.py
@@ -12,6 +12,7 @@ except ImportError:
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.general_utils import env_truthy
 
 from dymos.examples.water_rocket.phases import (new_water_rocket_trajectory,
                                                 set_sane_initial_guesses)
@@ -51,12 +52,11 @@ class TestWaterRocketForDocs(unittest.TestCase):
 
         exp_out = traj.simulate(times_per_seg=10)
 
-        # NOTE: only the last figure is shown in the generated docs
-        plot_propelled_ascent(p, exp_out)
-        plot_trajectory(p, exp_out)
-        plot_states(p, exp_out)
-
-        plt.show()
+        if not env_truthy('TESTFLO_RUNNING'):
+            plot_propelled_ascent(p, exp_out)
+            plot_trajectory(p, exp_out)
+            plot_states(p, exp_out)
+            plt.show()
 
         # Check results (tolerance is relative unless value is zero)
         assert_near_equal(summary['Launch angle'].value, 85, 0.01)
@@ -93,12 +93,11 @@ class TestWaterRocketForDocs(unittest.TestCase):
 
         exp_out = traj.simulate(times_per_seg=10)
 
-        # NOTE: only the last figure is shown in the generated docs
-        plot_propelled_ascent(p, exp_out)
-        plot_trajectory(p, exp_out)
-        plot_states(p, exp_out)
-
-        # plt.show()
+        if not env_truthy('TESTFLO_RUNNING'):
+            plot_propelled_ascent(p, exp_out)
+            plot_trajectory(p, exp_out)
+            plot_states(p, exp_out)
+            plt.show()
 
         # Check results (tolerance is relative unless value is zero)
         assert_near_equal(summary['Launch angle'].value, 46, 0.02)


### PR DESCRIPTION
### Summary

A few tests were showing plots or verbosely printing IPOPT output during tests.  This has been resolved.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
