### PR TITLE
Publish docs to openmdao.org on release event

### DIFF
--- a/.github/workflows/dymos_docs_workflow.yml
+++ b/.github/workflows/dymos_docs_workflow.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [ master, develop ]
 
+  # Trigger on release, to publish release versioned docs to openmdao.org
+  release:
+    types: [published]
+
   # Trigger via workflow_dispatch event
   workflow_dispatch:
 
@@ -262,8 +266,7 @@ jobs:
 
       - name: Publish docs to github.io
         if: |
-          github.event_name == 'push' && github.ref == 'refs/heads/master' &&
-          matrix.PUBLISH_DOCS == '1'
+          github.event_name == 'push' && matrix.PUBLISH_DOCS == '1'
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -275,7 +278,7 @@ jobs:
 
       - name: Publish docs to openmdao.org
         if: |
-          github.event_name == 'push' && github.ref == 'refs/heads/master' &&
+          (github.event_name == 'push' || github.event_name == 'release') &&
           matrix.PUBLISH_DOCS == '1'
         env:
           DOCS_LOCATION: ${{ secrets.DOCS_LOCATION }}


### PR DESCRIPTION
### Summary

Added triggering of the docs workflow via the publish event.

The docs workflow only publishes to openmdao.org if a tag exists on the commit where the workflow is run, however the release process only tags the repo after CI has completed.  In the past, we have simply re-run the docs workflow after the tag has been applied to push the docs to the web site.

With this PR, re-running of the docs workflow at the commit where the tag is applied is accomplished by triggering it on the GitHub `release` event, automating the process.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
