### PR TITLE
Added support for using `model_options` when simulate=True.

### DIFF
--- a/dymos/run_problem.py
+++ b/dymos/run_problem.py
@@ -114,6 +114,8 @@ def run_problem(problem, refine_method='hp', refine_iteration_limit=0, run_drive
         if 'case_prefix' in _simulate_kwargs:
             raise ValueError('Key "case_prefix" was found in simulate_kwargs but should instead by provided by the '
                              'argument "case_prefix", not part of the simulate_kwargs dictionary.')
+        _simulate_kwargs['model_options'] = problem.model_options
+
         for subsys in problem.model.system_iter(include_self=True, recurse=True):
             if isinstance(subsys, Trajectory):
                 sim_prob = subsys.simulate(record_file=simulation_record_file,

--- a/dymos/run_problem.py
+++ b/dymos/run_problem.py
@@ -114,8 +114,6 @@ def run_problem(problem, refine_method='hp', refine_iteration_limit=0, run_drive
         if 'case_prefix' in _simulate_kwargs:
             raise ValueError('Key "case_prefix" was found in simulate_kwargs but should instead by provided by the '
                              'argument "case_prefix", not part of the simulate_kwargs dictionary.')
-        _simulate_kwargs['model_options'] = problem.model_options
-
         for subsys in problem.model.system_iter(include_self=True, recurse=True):
             if isinstance(subsys, Trajectory):
                 sim_prob = subsys.simulate(record_file=simulation_record_file,

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -1307,7 +1307,7 @@ class Trajectory(om.Group):
 
     def simulate(self, times_per_seg=_unspecified, method=_unspecified, atol=_unspecified, rtol=_unspecified,
                  first_step=_unspecified, max_step=_unspecified, record_file=None, case_prefix=None,
-                 reset_iter_counts=True, reports=False, interpolant='cubic'):
+                 reset_iter_counts=True, reports=False, interpolant='cubic', model_options=None):
         """
         Simulate the Trajectory using scipy.integrate.solve_ivp.
 
@@ -1337,6 +1337,8 @@ class Trajectory(om.Group):
             Reports setting for the subproblems run under simualate.
         interpolant : str
             The interpolation method to be used for the controls in the simulation phase.
+        model_options : dict or None
+            Dictionary of options to be passed into the trajectory simulation problem.
 
         Returns
         -------
@@ -1373,6 +1375,8 @@ class Trajectory(om.Group):
             sim_prob.add_recorder(rec)
             # record_outputs is needed to capture the timeseries outputs
             sim_prob.recording_options['record_outputs'] = True
+
+        sim_prob.model_options = model_options
 
         with warnings.catch_warnings():
             # Some timeseries options are duplicated (expression options may be provide duplicate shape)

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -1307,7 +1307,7 @@ class Trajectory(om.Group):
 
     def simulate(self, times_per_seg=_unspecified, method=_unspecified, atol=_unspecified, rtol=_unspecified,
                  first_step=_unspecified, max_step=_unspecified, record_file=None, case_prefix=None,
-                 reset_iter_counts=True, reports=False, interpolant='cubic', model_options=None):
+                 reset_iter_counts=True, reports=False, interpolant='cubic'):
         """
         Simulate the Trajectory using scipy.integrate.solve_ivp.
 
@@ -1337,8 +1337,6 @@ class Trajectory(om.Group):
             Reports setting for the subproblems run under simualate.
         interpolant : str
             The interpolation method to be used for the controls in the simulation phase.
-        model_options : dict or None
-            Dictionary of options to be passed into the trajectory simulation problem.
 
         Returns
         -------
@@ -1376,7 +1374,8 @@ class Trajectory(om.Group):
             # record_outputs is needed to capture the timeseries outputs
             sim_prob.recording_options['record_outputs'] = True
 
-        sim_prob.model_options = model_options
+        # Support model options
+        sim_prob.model_options = self._problem_meta['model_options']
 
         with warnings.catch_warnings():
             # Some timeseries options are duplicated (expression options may be provide duplicate shape)

--- a/dymos/transcriptions/explicit_shooting/ode_integration_comp.py
+++ b/dymos/transcriptions/explicit_shooting/ode_integration_comp.py
@@ -117,6 +117,9 @@ class ODEIntegrationComp(om.ExplicitComponent):
                               promotes_inputs=['*'],
                               promotes_outputs=['*'])
 
+        # Support model options
+        p.model_options = self._problem_meta['model_options']
+
         if om_version()[0] <= (3, 34, 2):
             p.setup(check=None)
         else:


### PR DESCRIPTION
### Summary

Whenever options were set using the model_options feature, those values were not being propagate into the simulated trajectory. This adds the missing propagation (though unfortunately it uses an underscored object in openmdao.)

### Related Issues

- Resolves #1163

### Backwards incompatibilities

None

### New Dependencies

None
