### PR TITLE
Picard control continuity

### DIFF
--- a/dymos/examples/water_rocket/test/test_water_rocket.py
+++ b/dymos/examples/water_rocket/test/test_water_rocket.py
@@ -12,7 +12,6 @@ except ImportError:
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
-from openmdao.utils.general_utils import env_truthy
 
 from dymos.examples.water_rocket.phases import (new_water_rocket_trajectory,
                                                 set_sane_initial_guesses)
@@ -52,11 +51,12 @@ class TestWaterRocketForDocs(unittest.TestCase):
 
         exp_out = traj.simulate(times_per_seg=10)
 
-        if not env_truthy('TESTFLO_RUNNING'):
-            plot_propelled_ascent(p, exp_out)
-            plot_trajectory(p, exp_out)
-            plot_states(p, exp_out)
-            plt.show()
+        # NOTE: only the last figure is shown in the generated docs
+        plot_propelled_ascent(p, exp_out)
+        plot_trajectory(p, exp_out)
+        plot_states(p, exp_out)
+
+        plt.show()
 
         # Check results (tolerance is relative unless value is zero)
         assert_near_equal(summary['Launch angle'].value, 85, 0.01)
@@ -93,11 +93,12 @@ class TestWaterRocketForDocs(unittest.TestCase):
 
         exp_out = traj.simulate(times_per_seg=10)
 
-        if not env_truthy('TESTFLO_RUNNING'):
-            plot_propelled_ascent(p, exp_out)
-            plot_trajectory(p, exp_out)
-            plot_states(p, exp_out)
-            plt.show()
+        # NOTE: only the last figure is shown in the generated docs
+        plot_propelled_ascent(p, exp_out)
+        plot_trajectory(p, exp_out)
+        plot_states(p, exp_out)
+
+        # plt.show()
 
         # Check results (tolerance is relative unless value is zero)
         assert_near_equal(summary['Launch angle'].value, 46, 0.02)


### PR DESCRIPTION
### Summary

Control and control rate continuity were not enforced in PicardShooting.  A component has been added to enforce them (if an optimizer is used).  Nominally, a single high order segment for PicardShooting will work in a lot of cases and not require the enforcement of control continuity.

### Related Issues

- Resolves #1157

### Backwards incompatibilities

None

### New Dependencies

None
