### PR TITLE
Added a PyPi release workflow

### DIFF
--- a/.github/workflows/dymos_release_workflow.yml
+++ b/.github/workflows/dymos_release_workflow.yml
@@ -1,0 +1,42 @@
+# Publish release to PyPi
+
+name: Dymos Release
+
+on:
+  # Trigger on release, to publish release packages to PyPI
+  release:
+    types: [published]
+
+  # Trigger via workflow_dispatch event (manual trigger FOR TESTING ONLY)
+  workflow_dispatch:
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: deps
+        run: python -m pip install -U hatch
+
+      - name: build
+        run: hatch build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # this is just for testing, remove for flight:
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/dymos_release_workflow.yml
+++ b/.github/workflows/dymos_release_workflow.yml
@@ -7,9 +7,6 @@ on:
   release:
     types: [published]
 
-  # Trigger via workflow_dispatch event (manual trigger FOR TESTING ONLY)
-  workflow_dispatch:
-
 jobs:
   pypi-publish:
     name: Upload release to PyPI
@@ -37,6 +34,3 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        # this is just for testing, remove for flight:
-        with:
-          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/dymos_release_workflow.yml
+++ b/.github/workflows/dymos_release_workflow.yml
@@ -12,11 +12,9 @@ jobs:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
 
-    # Specifying a GitHub environment is optional, but strongly encouraged
     environment: release
 
     permissions:
-      # IMPORTANT: this permission is mandatory for Trusted Publishing
       id-token: write
 
     steps:

--- a/.github/workflows/dymos_tests_workflow.yml
+++ b/.github/workflows/dymos_tests_workflow.yml
@@ -1,8 +1,5 @@
 # Run Tests
 
-# Matrix Options
-# DOCS: 2-Build and publish, 1-build only, 0-no docs
-
 name: Dymos Tests
 
 on:

--- a/dymos/__init__.py
+++ b/dymos/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.13.1-dev'
+__version__ = '1.13.1-dev'
 
 
 from .phase import Phase, AnalyticPhase


### PR DESCRIPTION
### Summary

Added a workflow to automate publishing to PyPi on a `release` event via [trusted publishing](https://docs.pypi.org/trusted-publishers/).

Also, corrected the version, which was set to 3.13.1-dev after the last release instead of `1.13.1-dev`.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
