### PR TITLE
Removed version checks that involve OM versions before minimum supported version.

### DIFF
--- a/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_aircraft_cruise.py
@@ -7,7 +7,6 @@ from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
-from dymos.utils.misc import om_version
 from dymos.examples.aircraft_steady_flight.aircraft_ode import AircraftODE
 
 optimizer = os.environ.get('DYMOS_DEFAULT_OPT', 'SLSQP')
@@ -297,10 +296,7 @@ class TestAircraftCruise(unittest.TestCase):
         assert_near_equal(range, tas*time, tolerance=1.0E-4)
         assert_near_equal(mass_fuel[-1, ...], 0.0, tolerance=1.0E-4)
 
-        if om_version()[0] > (3, 34, 2):
-            sim_out_dir = traj.sim_prob.get_outputs_dir()
-        else:
-            sim_out_dir = pathlib.Path.cwd()
+        sim_out_dir = traj.sim_prob.get_outputs_dir()
         case = om.CaseReader(sim_out_dir / 'dymos_simulation.db').get_case('final')
 
         time = case.get_val('traj.phase0.timeseries.time')

--- a/dymos/examples/aircraft_steady_flight/test/test_ex_aircraft_steady_flight.py
+++ b/dymos/examples/aircraft_steady_flight/test/test_ex_aircraft_steady_flight.py
@@ -6,7 +6,6 @@ from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 import dymos as dm
 from dymos.utils.lgl import lgl
-from dymos.utils.misc import om_version
 from dymos.examples.aircraft_steady_flight.aircraft_ode import AircraftODE
 
 
@@ -130,7 +129,6 @@ class TestExSteadyAircraftFlight(unittest.TestCase):
                           726.85, tolerance=1.0E-2)
 
     @require_pyoptsparse(optimizer='IPOPT')
-    @unittest.skipIf(om_version()[0] < (3, 32, 2), 'Test requires OpenMDAO 3.32.2 or later')
     def test_ex_aircraft_steady_flight_opt_birkhoff(self):
 
         tx = dm.Birkhoff(num_nodes=50, grid_type='cgl',

--- a/dymos/examples/balanced_field/doc/test_doc_balanced_field_length.py
+++ b/dymos/examples/balanced_field/doc/test_doc_balanced_field_length.py
@@ -3,8 +3,6 @@ import unittest
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from openmdao.utils.assert_utils import assert_near_equal
 
-from dymos.utils.misc import om_version
-
 
 SHOW_PLOTS = True
 
@@ -242,11 +240,8 @@ class TestBalancedFieldLengthForDocs(unittest.TestCase):
 
         dm.run_problem(p, run_driver=True, simulate=True, make_plots=True)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol = om.CaseReader(sol_db).get_case('final')
         sim = om.CaseReader(sim_db).get_case('final')

--- a/dymos/examples/balanced_field/test/test_balanced_field_func_comp.py
+++ b/dymos/examples/balanced_field/test/test_balanced_field_func_comp.py
@@ -2,7 +2,6 @@ import unittest
 
 import openmdao.api as om
 import openmdao.func_api as omf
-from dymos.utils.misc import om_version
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 import dymos as dm
@@ -135,10 +134,7 @@ def wrap_ode_func(num_nodes, mode, grad_method='jax', jax_jit=True):
     meta.declare_coloring('*', method=grad_method)
     meta.declare_partials(of='*', wrt='*', method=grad_method)
 
-    if om_version()[0] > (3, 35, 0):
-        return om.ExplicitFuncComp(meta, derivs_method=grad_method, use_jit=jax_jit)
-    else:
-        return om.ExplicitFuncComp(meta, use_jax=grad_method == 'jax', use_jit=jax_jit)
+    return om.ExplicitFuncComp(meta, derivs_method=grad_method, use_jit=jax_jit)
 
 
 @use_tempdirs

--- a/dymos/examples/balanced_field/test/test_balanced_field_length.py
+++ b/dymos/examples/balanced_field/test/test_balanced_field_length.py
@@ -11,7 +11,6 @@ from openmdao.utils.assert_utils import assert_near_equal
 import dymos as dm
 from dymos.examples.balanced_field.balanced_field_ode import BalancedFieldODEComp
 from dymos.examples.balanced_field.balanced_field_length import make_balanced_field_length_problem
-from dymos.utils.misc import om_version
 
 
 @use_tempdirs
@@ -31,9 +30,7 @@ class TestBalancedFieldLengthRestart(unittest.TestCase):
         p = make_balanced_field_length_problem(ode_class=BalancedFieldODEComp, tx=dm.Radau(num_segments=3))
         dm.run_problem(p, run_driver=True, simulate=False)
 
-        sol_db = 'dymos_solution.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
 
         sol_results = om.CaseReader(sol_db).get_case('final')
 
@@ -41,11 +38,8 @@ class TestBalancedFieldLengthRestart(unittest.TestCase):
 
         dm.run_problem(p, run_driver=True, simulate=True, restart=sol_db)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol_results = om.CaseReader(sol_db).get_case('final')
         sim_results = om.CaseReader(sim_db).get_case('final')
@@ -63,11 +57,8 @@ class TestBalancedFieldLengthRestart(unittest.TestCase):
         p = make_balanced_field_length_problem(ode_class=BalancedFieldODEComp, tx=dm.Radau(num_segments=3))
         dm.run_problem(p, run_driver=True, simulate=True)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol_results = om.CaseReader(sol_db).get_case('final')
 

--- a/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_static_gravity.py
+++ b/dymos/examples/brachistochrone/doc/test_doc_brachistochrone_static_gravity.py
@@ -12,7 +12,6 @@ except ImportError:
 
 
 from openmdao.utils.testing_utils import use_tempdirs
-from dymos.utils.misc import om_version
 
 
 @use_tempdirs
@@ -144,9 +143,8 @@ class TestBrachistochroneStaticGravity(unittest.TestCase):
                           tolerance=1.0E-3)
 
         # Load the explicitly simulated trajectory
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
+
         exp_out = om.CaseReader(sim_db).get_case('final')
 
         # Extract the timeseries from the implicit solution and the explicit simulation

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_callable_ode_class.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_callable_ode_class.py
@@ -5,7 +5,6 @@ import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from openmdao.utils.assert_utils import assert_near_equal
 import dymos as dm
-from dymos.utils.misc import om_version
 
 
 @use_tempdirs
@@ -95,11 +94,8 @@ class TestBrachExecCompODE(unittest.TestCase):
         return p
 
     def run_asserts(self, c):
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = c.get_outputs_dir() / sol_db
-            sim_db = c.model.traj0.sim_prob.get_outputs_dir() / sim_db
+        sol_db = c.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = c.model.traj0.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         for db in [sol_db, sim_db]:
             c = om.CaseReader(db).get_case('final')
@@ -319,11 +315,8 @@ class TestBrachCallableODE(unittest.TestCase):
         return p
 
     def run_asserts(self, c):
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = c.get_outputs_dir() / sol_db
-            sim_db = c.model.traj0.sim_prob.get_outputs_dir() / sim_db
+        sol_db = c.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = c.model.traj0.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         for db in (sol_db, sim_db):
             c = om.CaseReader(db).get_case('final')

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_control_rate_targets.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_control_rate_targets.py
@@ -9,7 +9,6 @@ except ImportError:
 
 import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs
-from dymos.utils.misc import om_version
 from dymos.utils.testing_utils import assert_timeseries_near_equal
 from dymos.utils.misc import _unspecified
 
@@ -195,11 +194,8 @@ class TestBrachistochroneControlRateTargets(unittest.TestCase):
                         # Solve for the optimal trajectory
                         dm.run_problem(p, simulate=True, make_plots=True)
 
-                        sol_db = 'dymos_solution.db'
-                        sim_db = 'dymos_simulation.db'
-                        if om_version()[0] > (3, 34, 2):
-                            sol_db = p.get_outputs_dir() / sol_db
-                            sim_db = traj.sim_prob.get_outputs_dir() / sim_db
+                        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+                        sim_db = traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
                         sol_case = om.CaseReader(sol_db).get_case('final')
                         sim_case = om.CaseReader(sim_db).get_case('final')

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_implicit_recorder.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_implicit_recorder.py
@@ -7,7 +7,6 @@ except ImportError:
     matplotlib = None
 
 from openmdao.utils.testing_utils import use_tempdirs
-from dymos.utils.misc import om_version
 
 
 @use_tempdirs
@@ -67,9 +66,7 @@ class TestBrachistochroneRecordingExample(unittest.TestCase):
         # Test the results
         assert_near_equal(p.get_val('phase0.timeseries.time')[-1], 1.8016, tolerance=1.0E-3)
 
-        sol_db = 'dymos_solution.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
         case = om.CaseReader(sol_db).get_case('final')
 
         assert_near_equal(p['phase0.control_values:theta'],

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_control.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_integrated_control.py
@@ -8,7 +8,6 @@ from openmdao.components.interp_util.interp import InterpND
 from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
-from dymos.utils.misc import om_version
 
 
 class BrachistochroneODE(om.ExplicitComponent):
@@ -210,11 +209,8 @@ class TestBrachistochroneIntegratedControl(unittest.TestCase):
         # Solve for the optimal trajectory
         dm.run_problem(p, simulate=True, make_plots=True)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol_case = om.CaseReader(sol_db).get_case('final')
         sim_case = om.CaseReader(sim_db).get_case('final')

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_simulate_options.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_simulate_options.py
@@ -5,8 +5,6 @@ import numpy as np
 import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs
 
-from dymos.utils.misc import om_version
-
 
 class BrachistochroneODE(om.ExplicitComponent):
 
@@ -146,9 +144,7 @@ class TestBrachistochroneSimulate(unittest.TestCase):
                 # Run the driver to simulate the problem
                 dm.run_problem(p, run_driver=False, simulate=True)
 
-                sim_db = 'dymos_simulation.db'
-                if om_version()[0] > (3, 34, 2):
-                    sim_db = traj.sim_prob.get_outputs_dir() / sim_db
+                sim_db = traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
                 sim = om.CaseReader(sim_db).get_case('final')
                 t = sim.get_val('traj.phase0.timeseries.time')
@@ -163,9 +159,7 @@ class TestBrachistochroneSimulate(unittest.TestCase):
 
                 dm.run_problem(p, run_driver=False, simulate=True, simulate_kwargs={'times_per_seg': 7})
 
-                sim_db = 'dymos_simulation.db'
-                if om_version()[0] > (3, 34, 2):
-                    sim_db = traj.sim_prob.get_outputs_dir() / sim_db
+                sim_db = traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
                 sim = om.CaseReader(sim_db).get_case('final')
                 t = sim.get_val('traj.phase0.timeseries.time')

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_subprob_reports.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_subprob_reports.py
@@ -13,7 +13,6 @@ from openmdao.visualization.scaling_viewer.scaling_report import _default_scalin
 
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
-from dymos.utils.misc import om_version
 
 
 def setup_model_radau(do_reports, probname):
@@ -136,7 +135,6 @@ class TestSubproblemReportToggle(unittest.TestCase):
         if self.testflo_running is not None:
             os.environ['TESTFLO_RUNNING'] = self.testflo_running
 
-    @unittest.skipIf(om_version()[0] <= (3, 34, 2), 'Requires OpenMDAO version later than 3.34.2')
     @hooks_active
     def test_no_sim_reports(self):
         p = setup_model_radau(do_reports=False, probname='test_no_sim_reports')
@@ -148,7 +146,6 @@ class TestSubproblemReportToggle(unittest.TestCase):
 
         self.assertFalse(sim_reports_dir.exists())
 
-    @unittest.skipIf(om_version()[0] <= (3, 34, 2), 'Requires OpenMDAO version later than 3.34.2')
     @hooks_active
     def test_make_sim_reports(self):
         p = setup_model_radau(do_reports=True, probname='test_make_sim_reports')
@@ -162,7 +159,6 @@ class TestSubproblemReportToggle(unittest.TestCase):
         self.assertTrue(sim_reports_dir.exists())
         self.assertTrue((sim_reports_dir / self.n2_filename).exists())
 
-    @unittest.skipIf(om_version()[0] <= (3, 34, 2), 'Requires OpenMDAO version later than 3.34.2')
     @hooks_active
     def test_explicitshooting_no_subprob_reports(self):
         p = setup_model_shooting(do_reports=False,
@@ -178,7 +174,6 @@ class TestSubproblemReportToggle(unittest.TestCase):
         self.assertIn(self.n2_filename, main_reports)
         self.assertIn(self.scaling_filename, main_reports)
 
-    @unittest.skipIf(om_version()[0] <= (3, 34, 2), 'Requires OpenMDAO version later than 3.34.2')
     @hooks_active
     def test_explicitshooting_make_subprob_reports(self):
         p = setup_model_shooting(do_reports=True,

--- a/dymos/examples/brachistochrone/test/test_brachistochrone_timeseries_feedback.py
+++ b/dymos/examples/brachistochrone/test/test_brachistochrone_timeseries_feedback.py
@@ -6,8 +6,6 @@ import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.assert_utils import assert_near_equal
 
-from dymos.utils.misc import om_version
-
 
 class BrachistochroneODE(om.ExplicitComponent):
 
@@ -150,11 +148,8 @@ class TestBrachistochroneTimeseriesFeedback(unittest.TestCase):
         # Run the driver to solve the problem
         dm.run_problem(p, run_driver=True, simulate=True)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol_case = om.CaseReader(sol_db).get_case('final')
         sim_case = om.CaseReader(sim_db).get_case('final')

--- a/dymos/examples/brachistochrone/test/test_simulate_units.py
+++ b/dymos/examples/brachistochrone/test/test_simulate_units.py
@@ -8,7 +8,6 @@ from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneOD
 
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.assert_utils import assert_near_equal
-from dymos.utils.misc import om_version
 
 
 @use_tempdirs
@@ -86,11 +85,8 @@ class TestBrachistochroneSimulate_units(unittest.TestCase):
         # Run the driver to solve the problem
         dm.run_problem(p, simulate=True)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol_case = om.CaseReader(sol_db).get_case('final')
         sim_case = om.CaseReader(sim_db).get_case('final')

--- a/dymos/examples/brachistochrone/test/test_state_rate_introspection.py
+++ b/dymos/examples/brachistochrone/test/test_state_rate_introspection.py
@@ -7,7 +7,6 @@ from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
-from dymos.utils.misc import om_version
 from dymos.utils.testing_utils import assert_timeseries_near_equal
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -87,11 +86,8 @@ class TestIntegrateControl(unittest.TestCase):
         # Run the driver to solve the problem
         dm.run_problem(p, simulate=True, make_plots=False)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol = om.CaseReader(sol_db).get_case('final')
         sim = om.CaseReader(sim_db).get_case('final')
@@ -197,11 +193,8 @@ class TestIntegrateControl(unittest.TestCase):
         # Run the driver to solve the problem
         dm.run_problem(p, simulate=True, make_plots=False)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol = om.CaseReader(sol_db).get_case('final')
         sim = om.CaseReader(sim_db).get_case('final')
@@ -320,11 +313,8 @@ class TestIntegrateControl(unittest.TestCase):
         dm.run_problem(p, simulate=True, make_plots=False, simulate_kwargs={'atol': 1.0E-9, 'rtol': 1.0E-9,
                                                                             'times_per_seg': 10})
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol = om.CaseReader(sol_db).get_case('final')
         sim = om.CaseReader(sim_db).get_case('final')
@@ -450,11 +440,8 @@ class TestIntegratePolynomialControl(unittest.TestCase):
         # Run the driver to solve the problem
         dm.run_problem(p, simulate=True, make_plots=True)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol = om.CaseReader(sol_db).get_case('final')
         sim = om.CaseReader(sim_db).get_case('final')
@@ -563,11 +550,8 @@ class TestIntegratePolynomialControl(unittest.TestCase):
         dm.run_problem(p, simulate=True, make_plots=False,
                        simulate_kwargs={'times_per_seg': 10})
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol = om.CaseReader(sol_db).get_case('final')
         sim = om.CaseReader(sim_db).get_case('final')
@@ -686,11 +670,8 @@ class TestIntegratePolynomialControl(unittest.TestCase):
         # Run the driver to solve the problem
         dm.run_problem(p, simulate=True, make_plots=True)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol = om.CaseReader(sol_db).get_case('final')
         sim = om.CaseReader(sim_db).get_case('final')

--- a/dymos/examples/brachistochrone/test/test_static_outputs.py
+++ b/dymos/examples/brachistochrone/test/test_static_outputs.py
@@ -7,7 +7,6 @@ import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs
 
 import dymos as dm
-from dymos.utils.misc import om_version
 
 
 class BrachODEStaticOutput(om.ExplicitComponent):
@@ -138,13 +137,10 @@ class TestStaticODEOutput(unittest.TestCase):
         # Run the driver to solve the problem
         dm.run_problem(p, simulate=True, make_plots=False)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sim_db
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
-        sol = om.CaseReader(sim_db).get_case('final')
+        sol = om.CaseReader(sol_db).get_case('final')
         sim = om.CaseReader(sim_db).get_case('final')
 
         with self.assertRaises(expected_exception=KeyError) as e:

--- a/dymos/examples/brachistochrone/test/test_timeseries_units.py
+++ b/dymos/examples/brachistochrone/test/test_timeseries_units.py
@@ -4,7 +4,6 @@ import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from openmdao.utils.assert_utils import assert_near_equal
 import dymos as dm
-from dymos.utils.misc import om_version
 
 
 @use_tempdirs
@@ -91,11 +90,8 @@ class TestTimeseriesUnits(unittest.TestCase):
 
         dm.run_problem(p, run_driver=run_driver, simulate=True)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = p.model.traj0.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = p.model.traj0.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol_case = om.CaseReader(sol_db).get_case('final')
         sim_case = om.CaseReader(sim_db).get_case('final')

--- a/dymos/examples/cannonball/test/test_cannonball_matrix_state.py
+++ b/dymos/examples/cannonball/test/test_cannonball_matrix_state.py
@@ -4,7 +4,6 @@ import dymos as dm
 import unittest
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
-from dymos.utils.misc import om_version
 
 
 class ODEComp(om.ExplicitComponent):
@@ -75,13 +74,7 @@ class TestCannonballMatrixState(unittest.TestCase):
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 1], 0.0, tolerance=1E-5)
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 0], 20.3873598, tolerance=1E-5)
 
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
-
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         c = om.CaseReader(sim_db).get_case('final')
 
@@ -101,13 +94,7 @@ class TestCannonballMatrixState(unittest.TestCase):
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 1], 0.0, tolerance=1E-5)
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 0], 20.3873598, tolerance=1E-5)
 
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
-
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         c = om.CaseReader(sim_db).get_case('final')
 
@@ -127,13 +114,7 @@ class TestCannonballMatrixState(unittest.TestCase):
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 1], 0.0, tolerance=1E-5)
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 0], 20.3873598, tolerance=1E-5)
 
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
-
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         c = om.CaseReader(sim_db).get_case('final')
 
@@ -153,13 +134,7 @@ class TestCannonballMatrixState(unittest.TestCase):
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 1], 0.0, tolerance=1E-5)
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 0], 20.3873598, tolerance=1E-5)
 
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
-
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         c = om.CaseReader(sim_db).get_case('final')
 
@@ -180,9 +155,7 @@ class TestCannonballMatrixState(unittest.TestCase):
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 1], 0.0, tolerance=1E-5)
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 0], 20.3873598, tolerance=1E-5)
 
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         c = om.CaseReader(sim_db).get_case('final')
 
@@ -202,9 +175,7 @@ class TestCannonballMatrixState(unittest.TestCase):
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 1], 0.0, tolerance=1E-5)
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 0], 20.3873598, tolerance=1E-5)
 
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         c = om.CaseReader(sim_db).get_case('final')
 
@@ -257,9 +228,7 @@ class TestCannonballMatrixStateExplicitShape(unittest.TestCase):
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 1], 0.0, tolerance=1E-5)
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 0], 20.3873598, tolerance=1E-5)
 
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         c = om.CaseReader(sim_db).get_case('final')
 
@@ -278,9 +247,7 @@ class TestCannonballMatrixStateExplicitShape(unittest.TestCase):
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 1], 0.0, tolerance=1E-5)
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 0], 20.3873598, tolerance=1E-5)
 
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         c = om.CaseReader(sim_db).get_case('final')
 
@@ -300,9 +267,7 @@ class TestCannonballMatrixStateExplicitShape(unittest.TestCase):
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 1], 0.0, tolerance=1E-5)
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 0], 20.3873598, tolerance=1E-5)
 
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         c = om.CaseReader(sim_db).get_case('final')
 
@@ -321,9 +286,7 @@ class TestCannonballMatrixStateExplicitShape(unittest.TestCase):
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 1], 0.0, tolerance=1E-5)
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 0], 20.3873598, tolerance=1E-5)
 
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         c = om.CaseReader(sim_db).get_case('final')
 
@@ -377,9 +340,7 @@ class TestCannonballMatrixStateNonFlatIndices(unittest.TestCase):
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 1], 0.0, tolerance=1E-5)
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 0], 20.3873598, tolerance=1E-5)
 
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         c = om.CaseReader(sim_db).get_case('final')
 
@@ -398,9 +359,7 @@ class TestCannonballMatrixStateNonFlatIndices(unittest.TestCase):
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 1], 0.0, tolerance=1E-5)
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 0], 20.3873598, tolerance=1E-5)
 
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         c = om.CaseReader(sim_db).get_case('final')
 
@@ -420,9 +379,7 @@ class TestCannonballMatrixStateNonFlatIndices(unittest.TestCase):
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 1], 0.0, tolerance=1E-5)
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 0], 20.3873598, tolerance=1E-5)
 
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         c = om.CaseReader(sim_db).get_case('final')
 
@@ -441,9 +398,7 @@ class TestCannonballMatrixStateNonFlatIndices(unittest.TestCase):
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 1], 0.0, tolerance=1E-5)
         assert_near_equal(p.get_val('traj.phase.timeseries.z')[-1, 0, 0], 20.3873598, tolerance=1E-5)
 
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         c = om.CaseReader(sim_db).get_case('final')
 

--- a/dymos/examples/cannonball/test/test_load_case_missing_phase.py
+++ b/dymos/examples/cannonball/test/test_load_case_missing_phase.py
@@ -9,7 +9,6 @@ import openmdao.api as om
 import dymos as dm
 from dymos.examples.cannonball.size_comp import CannonballSizeComp
 from dymos.examples.cannonball.cannonball_ode import CannonballODE
-from dymos.utils.misc import om_version
 
 
 @use_tempdirs
@@ -166,16 +165,11 @@ class TestTwoPhaseCannonballLoadCase(unittest.TestCase):
         descent.set_state_val('v', [150, 200])
         descent.set_state_val('gam', [0, -45], units='deg')
 
-        sol_db = 'dymos_solution.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p_ascent_only.get_outputs_dir() / sol_db
+        sol_db = p_ascent_only.get_outputs_dir() / 'dymos_solution.db'
 
         case = om.CaseReader(sol_db).get_case('final')
 
-        if om_version()[0] < (3, 26, 1):
-            dm.load_case(p, previous_solution=case)
-        else:
-            p.load_case(case)
+        p.load_case(case)
 
         p.run_model()
 

--- a/dymos/examples/double_integrator/test/test_double_integrator_timeseries_units.py
+++ b/dymos/examples/double_integrator/test/test_double_integrator_timeseries_units.py
@@ -8,7 +8,6 @@ from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 import dymos as dm
 from dymos.examples.double_integrator.double_integrator_ode import DoubleIntegratorODE
 from dymos.utils.testing_utils import assert_timeseries_near_equal
-from dymos.utils.misc import om_version
 
 
 @require_pyoptsparse(optimizer='SLSQP')
@@ -79,11 +78,8 @@ class TestDoubleIntegratorExample(unittest.TestCase):
     def test_timeseries_units_gl(self):
         p = double_integrator_direct_collocation(dm.GaussLobatto, compressed=True)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol_case = om.CaseReader(sol_db).get_case('final')
         sim_case = om.CaseReader(sim_db).get_case('final')
@@ -100,11 +96,8 @@ class TestDoubleIntegratorExample(unittest.TestCase):
     def test_timeseries_units_radau(self):
         p = double_integrator_direct_collocation(dm.Radau, compressed=True)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol_case = om.CaseReader(sol_db).get_case('final')
         sim_case = om.CaseReader(sim_db).get_case('final')

--- a/dymos/examples/finite_burn_orbit_raise/finite_burn_orbit_raise_problem.py
+++ b/dymos/examples/finite_burn_orbit_raise/finite_burn_orbit_raise_problem.py
@@ -4,7 +4,6 @@ import openmdao.api as om
 
 import dymos as dm
 from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
-from dymos.utils.misc import om_version
 
 
 def make_traj(transcription='gauss-lobatto', transcription_order=3, compressed=False,
@@ -311,11 +310,8 @@ if __name__ == '__main__':  # pragma: no cover
                                      compressed=False, optimizer=optimizer, simulate=True,
                                      connected=CONNECTED, show_output=False)
 
-    sol_db = 'dymos_solution.db'
-    sim_db = 'dymos_simulation.db'
-    if om_version()[0] > (3, 34, 2):
-        sol_db = p.get_outputs_dir() / sol_db
-        sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+    sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+    sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
     sol_case = om.CaseReader(sol_db).get_case('final')
     sim_case = om.CaseReader(sim_db).get_case('final')

--- a/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise_mpi.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_ex_two_burn_orbit_raise_mpi.py
@@ -6,7 +6,6 @@ from openmdao.utils.mpi import MPI
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 from dymos.examples.finite_burn_orbit_raise.finite_burn_orbit_raise_problem import two_burn_orbit_raise_problem
-from dymos.utils.misc import om_version
 
 
 @require_pyoptsparse(optimizer='IPOPT')
@@ -24,11 +23,8 @@ class TestExampleTwoBurnOrbitRaiseMPI(unittest.TestCase):
                                          compressed=False, optimizer=optimizer, simulate=True,
                                          connected=CONNECTED, show_output=False)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol_case = om.CaseReader(sol_db).get_case('final')
         sim_case = om.CaseReader(sim_db).get_case('final')
@@ -49,11 +45,8 @@ class TestExampleTwoBurnOrbitRaiseMPI(unittest.TestCase):
                                          compressed=False, optimizer=optimizer, simulate=True,
                                          connected=CONNECTED, show_output=False)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol_case = om.CaseReader(sol_db).get_case('final')
         sim_case = om.CaseReader(sim_db).get_case('final')

--- a/dymos/examples/finite_burn_orbit_raise/test/test_multi_phase_restart.py
+++ b/dymos/examples/finite_burn_orbit_raise/test/test_multi_phase_restart.py
@@ -7,7 +7,6 @@ from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from openmdao.utils.mpi import MPI, multi_proc_exception_check
 
 from dymos.examples.finite_burn_orbit_raise.finite_burn_orbit_raise_problem import two_burn_orbit_raise_problem
-from dymos.utils.misc import om_version
 from dymos.utils.testing_utils import assert_cases_equal
 
 
@@ -30,11 +29,8 @@ class TestExampleTwoBurnOrbitRaiseConnectedRestart(unittest.TestCase):
                 assert_near_equal(p.get_val('traj.burn2.states:deltav')[0], 0.3995,
                                   tolerance=4.0E-3)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sim_case1 = om.CaseReader(sim_db).get_case('final')
 
@@ -46,9 +42,7 @@ class TestExampleTwoBurnOrbitRaiseConnectedRestart(unittest.TestCase):
 
         p.run_model()
 
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sim_case2 = om.CaseReader(sim_db).get_case('final')
 
@@ -61,11 +55,8 @@ class TestExampleTwoBurnOrbitRaiseConnectedRestart(unittest.TestCase):
         p = two_burn_orbit_raise_problem(transcription='radau', transcription_order=3,
                                          compressed=False, optimizer=optimizer, show_output=False)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sim_case1 = om.CaseReader(sim_db).get_case('final')
 
@@ -74,14 +65,12 @@ class TestExampleTwoBurnOrbitRaiseConnectedRestart(unittest.TestCase):
                 assert_near_equal(p.get_val('traj.burn2.states:deltav')[-1], 0.3995,
                                   tolerance=2.0E-3)
 
-        # Run again without an actual optimzier
+        # Run again without an optimzier
         two_burn_orbit_raise_problem(transcription='radau', transcription_order=3,
                                      compressed=False, optimizer=optimizer, run_driver=False,
                                      show_output=False, restart=sol_db)
 
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sim_case2 = om.CaseReader(sim_db).get_case('final')
 
@@ -126,11 +115,8 @@ class TestExampleTwoBurnOrbitRaiseConnected(unittest.TestCase):
                 assert_near_equal(p.get_val('traj.burn2.states:deltav')[0], 0.3995,
                                   tolerance=4.0E-3)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         case1 = om.CaseReader(sol_db).get_case('final')
         sim_case1 = om.CaseReader(sim_db).get_case('final')
@@ -142,11 +128,8 @@ class TestExampleTwoBurnOrbitRaiseConnected(unittest.TestCase):
                                          connected=True, solution_record_file='dymos_solution2.db',
                                          simulation_record_file='dymos_simulation2.db')
 
-        sol_db = 'dymos_solution2.db'
-        sim_db = 'dymos_simulation2.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution2.db'
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation2.db'
 
         case2 = om.CaseReader(sol_db).get_case('final')
         sim_case2 = om.CaseReader(sim_db).get_case('final')
@@ -168,11 +151,8 @@ class TestExampleTwoBurnOrbitRaiseConnected(unittest.TestCase):
                 assert_near_equal(p.get_val('traj.burn2.states:deltav')[0], 0.3995,
                                   tolerance=4.0E-3)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         case1 = om.CaseReader(sol_db).get_case('final')
         sim_case1 = om.CaseReader(sim_db).get_case('final')
@@ -184,11 +164,8 @@ class TestExampleTwoBurnOrbitRaiseConnected(unittest.TestCase):
                                           connected=True, solution_record_file='dymos_solution2.db',
                                           simulation_record_file='dymos_simulation2.db')
 
-        sol_db = 'dymos_solution2.db'
-        sim_db = 'dymos_simulation2.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p2.get_outputs_dir() / sol_db
-            sim_db = p2.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p2.get_outputs_dir() / 'dymos_solution2.db'
+        sim_db = p2.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation2.db'
 
         case2 = om.CaseReader(sol_db).get_case('final')
         sim_case2 = om.CaseReader(sim_db).get_case('final')

--- a/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
+++ b/dymos/examples/min_time_climb/test/test_ex_min_time_climb.py
@@ -16,7 +16,6 @@ from dymos.utils.introspection import get_promoted_vars
 
 import dymos as dm
 from dymos.examples.min_time_climb.min_time_climb_ode import MinTimeClimbODE
-from dymos.utils.misc import om_version
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse, set_env_vars_context
 
 
@@ -179,14 +178,11 @@ class TestMinTimeClimb(unittest.TestCase):
         ts = {k: v for k, v in output_dict.items() if 'timeseries.' in k}
         self.assertTrue('traj.phase0.timeseries.mach_rate' in ts)
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         case = om.CaseReader(sol_db).get_case('final')
-        sim_case = om.CaseReader(sol_db).get_case('final')
+        sim_case = om.CaseReader(sim_db).get_case('final')
 
         time = case[f'traj.phase0.timeseries.{time_name}'][:, 0]
         mach = case['traj.phase0.timeseries.mach'][:, 0]
@@ -281,7 +277,6 @@ class TestMinTimeClimb(unittest.TestCase):
         self._test_mach_rate(p, plot=False)
 
     @require_pyoptsparse(optimizer='IPOPT')
-    @unittest.skipIf(om_version()[0] < (3, 32, 2), 'Test requires OpenMDAO 3.32.2 or later')
     def test_results_birkhoff(self):
         NUM_SEG = 1
         ORDER = 30

--- a/dymos/examples/shuttle_reentry/test/test_reentry.py
+++ b/dymos/examples/shuttle_reentry/test/test_reentry.py
@@ -8,7 +8,7 @@ from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 from dymos.examples.shuttle_reentry.shuttle_ode import ShuttleODE
-from dymos.utils.misc import om_version
+
 
 # Expected results from Betts
 expected_results = {'constrained': {'time': 2198.67, 'theta': 30.6255},
@@ -263,12 +263,8 @@ class TestReentry(unittest.TestCase):
 
         dm.run_problem(p, simulate=True)
 
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / 'dymos_solution.db'
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
-        else:
-            sol_db = 'dymos_solution.db'
-            sim_db = 'dymos_simulation.db'
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol = om.CaseReader(sol_db).get_case('final')
         sim = om.CaseReader(sim_db).get_case('final')

--- a/dymos/examples/vanderpol/doc/test_doc_vanderpol.py
+++ b/dymos/examples/vanderpol/doc/test_doc_vanderpol.py
@@ -3,7 +3,6 @@ import unittest
 
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.mpi import MPI
-from dymos.utils.misc import om_version
 
 
 @use_tempdirs
@@ -22,7 +21,6 @@ class TestVanderpolForDocs(unittest.TestCase):
 
         dm.run_problem(p, run_driver=False, simulate=True, make_plots=True)
 
-    @unittest.skipIf(om_version()[0] < (3, 29, 0), 'Test requires OpenMDAO 3.29.0 or later')
     def test_vanderpol_for_docs_optimize(self):
         import dymos as dm
         from dymos.examples.vanderpol.vanderpol_dymos import vanderpol
@@ -33,7 +31,6 @@ class TestVanderpolForDocs(unittest.TestCase):
 
         dm.run_problem(p, simulate=True, make_plots=True)
 
-    @unittest.skipIf(om_version()[0] < (3, 29, 0), 'Test requires OpenMDAO 3.29.0 or later')
     def test_vanderpol_for_docs_optimize_refine(self):
         import dymos as dm
         from dymos.examples.vanderpol.vanderpol_dymos import vanderpol
@@ -59,7 +56,6 @@ class TestVanderpolForDocs(unittest.TestCase):
 class TestVanderpolDelayMPI(unittest.TestCase):
     N_PROCS = 2
 
-    @unittest.skipIf(om_version()[0] < (3, 29, 0), 'Test requires OpenMDAO 3.29.0 or later')
     def test_vanderpol_delay_mpi(self):
         import openmdao.api as om
         import dymos as dm

--- a/dymos/examples/vanderpol/test/test_vanderpol.py
+++ b/dymos/examples/vanderpol/test/test_vanderpol.py
@@ -7,7 +7,6 @@ from openmdao.utils.mpi import MPI
 
 import dymos as dm
 from dymos.examples.vanderpol.vanderpol_dymos import vanderpol
-from dymos.utils.misc import om_version
 
 
 @use_tempdirs
@@ -17,7 +16,6 @@ class TestVanderpolExample(unittest.TestCase):
         p = vanderpol(transcription='gauss-lobatto', num_segments=75)
         p.run_model()
 
-    @unittest.skipIf(om_version()[0] < (3, 29, 0), 'Test requires OpenMDAO 3.29.0 or later')
     @require_pyoptsparse(optimizer='IPOPT')
     def test_vanderpol_simulate_true(self):
         p = vanderpol(transcription='radau-ps', num_segments=30, transcription_order=3,
@@ -25,7 +23,6 @@ class TestVanderpolExample(unittest.TestCase):
 
         dm.run_problem(p, run_driver=True, simulate=True)
 
-    @unittest.skipIf(om_version()[0] < (3, 29, 0), 'Test requires OpenMDAO 3.29.0 or later')
     def test_vanderpol_optimal(self):
         p = vanderpol(transcription='gauss-lobatto', num_segments=75)
         dm.run_problem(p)  # find optimal control solution to stop oscillation
@@ -36,7 +33,6 @@ class TestVanderpolExample(unittest.TestCase):
         assert_almost_equal(p.get_val('traj.phase0.states:x1')[-1, ...], np.zeros(1))
         assert_almost_equal(p.get_val('traj.phase0.controls:u')[-1, ...], np.zeros(1), decimal=3)
 
-    @unittest.skipIf(om_version()[0] < (3, 29, 0), 'Test requires OpenMDAO 3.29.0 or later')
     def test_vanderpol_optimal_grid_refinement(self):
         # enabling grid refinement gives a faster and better solution with fewer segments
         p = vanderpol(transcription='gauss-lobatto', num_segments=15)
@@ -56,7 +52,6 @@ class TestVanderpolExampleMPI(unittest.TestCase):
 
     N_PROCS = 4
 
-    @unittest.skipIf(om_version()[0] < (3, 29, 0), 'Test requires OpenMDAO 3.29.0 or later')
     @require_pyoptsparse(optimizer='IPOPT')
     @unittest.skipUnless(MPI, 'this test requires MPI')
     def test_vanderpol_optimal_mpi(self):

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -26,7 +26,7 @@ from ..utils.indexing import get_constraint_flat_idxs
 from ..utils.introspection import configure_time_introspection, _configure_constraint_introspection, \
     configure_controls_introspection, configure_parameters_introspection, \
     configure_timeseries_output_introspection, classify_var
-from ..utils.misc import _unspecified, create_subprob, om_version
+from ..utils.misc import _unspecified, create_subprob
 from ..utils.lgl import lgl
 
 
@@ -2671,10 +2671,7 @@ class Phase(om.Group):
             rec = om.SqliteRecorder(record_file)
             sim_prob.add_recorder(rec)
 
-        if om_version()[0] <= (3, 42, 2):
-            sim_prob.setup(check=True)
-        else:
-            sim_prob.setup(check=True, parent=self)
+        sim_prob.setup(check=True, parent=self)
         sim_prob.final_setup()
 
         sim_phase.set_vals_from_phase(from_phase=self)

--- a/dymos/phase/test/test_add_boundary_constraint.py
+++ b/dymos/phase/test/test_add_boundary_constraint.py
@@ -5,7 +5,6 @@ import numpy as np
 import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from openmdao.utils.assert_utils import assert_near_equal
-from dymos.utils.misc import om_version
 
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_vector_states_ode import BrachistochroneVectorStatesODE

--- a/dymos/phase/test/test_analytic_phase.py
+++ b/dymos/phase/test/test_analytic_phase.py
@@ -6,7 +6,6 @@ import dymos as dm
 
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
-from dymos.utils.misc import om_version
 
 
 class SimpleIVPSolution(om.ExplicitComponent):
@@ -307,9 +306,7 @@ class TestAnalyticPhaseSimpleResults(unittest.TestCase):
         p.set_val('traj.phase.t_duration', 1.0, units='s')
         p.set_val('traj.phase.parameters:y0', 0.6, units='unitless')
 
-        sol_db = 'dymos_solution.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
 
         # Load the previous case and rerun
         dm.run_problem(p, simulate=False, restart=sol_db)

--- a/dymos/run_problem.py
+++ b/dymos/run_problem.py
@@ -6,7 +6,6 @@ import openmdao.api as om
 from openmdao.recorders.case import Case
 from ._options import options as dymos_options
 from dymos.trajectory.trajectory import Trajectory
-from dymos.utils.misc import om_version
 from dymos.visualization.timeseries_plots import timeseries_plots
 
 from .grid_refinement.refinement import _refine_iter
@@ -84,11 +83,7 @@ def run_problem(problem, refine_method='hp', refine_iteration_limit=0, run_drive
     problem.final_setup()
 
     if restart is not None:
-        if om_version()[0] < (3, 27, 1):
-            from dymos.load_case import load_case
-            load_case(problem, case, deprecation_warning=False)
-        else:
-            problem.load_case(case)
+        problem.load_case(case)
 
     for traj in problem.model.system_iter(include_self=True, recurse=True, typ=Trajectory):
         traj._check_phase_graph()
@@ -122,24 +117,20 @@ def run_problem(problem, refine_method='hp', refine_iteration_limit=0, run_drive
                 sims[subsys.pathname] = sim_prob
 
     if make_plots:
-        if om_version()[0] > (3, 34, 2):
-            outputs_dir = problem.get_outputs_dir()
-            if os.sep in str(solution_record_file):
-                _sol_record_file = solution_record_file
-            else:
-                _sol_record_file = outputs_dir / solution_record_file
-
-            if simulate:
-                sim_outputs_dir = list(sims.values())[0].get_outputs_dir()
-                if os.sep in str(simulation_record_file):
-                    _sim_record_file = simulation_record_file
-                else:
-                    _sim_record_file = sim_outputs_dir / simulation_record_file
-            else:
-                _sim_record_file = None
-        else:
+        outputs_dir = problem.get_outputs_dir()
+        if os.sep in str(solution_record_file):
             _sol_record_file = solution_record_file
-            _sim_record_file = None if not simulate else simulation_record_file
+        else:
+            _sol_record_file = outputs_dir / solution_record_file
+
+        if simulate:
+            sim_outputs_dir = list(sims.values())[0].get_outputs_dir()
+            if os.sep in str(simulation_record_file):
+                _sim_record_file = simulation_record_file
+            else:
+                _sim_record_file = sim_outputs_dir / simulation_record_file
+        else:
+            _sim_record_file = None
 
         _plot_kwargs = plot_kwargs if plot_kwargs is not None else {}
 

--- a/dymos/test/test_load_case.py
+++ b/dymos/test/test_load_case.py
@@ -4,7 +4,6 @@ import unittest
 from openmdao.utils.testing_utils import use_tempdirs
 import openmdao.api as om
 import dymos as dm
-from dymos.utils.misc import om_version
 
 
 def setup_problem(trans=dm.GaussLobatto(num_segments=10), polynomial_control=False,
@@ -69,10 +68,7 @@ class TestLoadCase(unittest.TestCase):
         dm.run_problem(p)
 
         # Load the solution
-        if om_version()[0] > (3, 34, 2):
-            sol_file = p.get_outputs_dir() / 'dymos_solution.db'
-        else:
-            sol_file = 'dymos_solution.db'
+        sol_file = p.get_outputs_dir() / 'dymos_solution.db'
 
         case = om.CaseReader(sol_file).get_case('final')
 
@@ -102,10 +98,7 @@ class TestLoadCase(unittest.TestCase):
         dm.run_problem(p)
 
         # Load the solution
-        if om_version()[0] > (3, 34, 2):
-            sol_file = p.get_outputs_dir() / 'dymos_solution.db'
-        else:
-            sol_file = 'dymos_solution.db'
+        sol_file = p.get_outputs_dir() / 'dymos_solution.db'
 
         case = om.CaseReader(sol_file).get_case('final')
 
@@ -134,10 +127,7 @@ class TestLoadCase(unittest.TestCase):
         dm.run_problem(p)
 
         # Load the solution
-        if om_version()[0] > (3, 34, 2):
-            sol_file = p.get_outputs_dir() / 'dymos_solution.db'
-        else:
-            sol_file = 'dymos_solution.db'
+        sol_file = p.get_outputs_dir() / 'dymos_solution.db'
 
         case = om.CaseReader(sol_file).get_case('final')
 
@@ -175,10 +165,7 @@ class TestLoadCase(unittest.TestCase):
         dm.run_problem(p)
 
         # Load the solution
-        if om_version()[0] > (3, 34, 2):
-            sol_file = p.get_outputs_dir() / 'dymos_solution.db'
-        else:
-            sol_file = 'dymos_solution.db'
+        sol_file = p.get_outputs_dir() / 'dymos_solution.db'
 
         case = om.CaseReader(sol_file).get_case('final')
 
@@ -219,10 +206,7 @@ class TestLoadCase(unittest.TestCase):
         dm.run_problem(p)
 
         # Load the solution
-        if om_version()[0] > (3, 34, 2):
-            sol_file = p.get_outputs_dir() / 'dymos_solution.db'
-        else:
-            sol_file = 'dymos_solution.db'
+        sol_file = p.get_outputs_dir() / 'dymos_solution.db'
 
         case = om.CaseReader(sol_file).get_case('final')
 
@@ -300,10 +284,7 @@ class TestLoadCase(unittest.TestCase):
         dm.run_problem(p)
 
         # Load the solution
-        if om_version()[0] > (3, 34, 2):
-            sol_file = p.get_outputs_dir() / 'dymos_solution.db'
-        else:
-            sol_file = 'dymos_solution.db'
+        sol_file = p.get_outputs_dir() / 'dymos_solution.db'
 
         case = om.CaseReader(sol_file).get_case('final')
 
@@ -331,10 +312,7 @@ class TestLoadCase(unittest.TestCase):
         dm.run_problem(p)
 
         # Load the solution
-        if om_version()[0] > (3, 34, 2):
-            sol_file = p.get_outputs_dir() / 'dymos_solution.db'
-        else:
-            sol_file = 'dymos_solution.db'
+        sol_file = p.get_outputs_dir() / 'dymos_solution.db'
 
         case = om.CaseReader(sol_file).get_case('final')
 
@@ -357,10 +335,7 @@ class TestLoadCase(unittest.TestCase):
         dm.run_problem(p)
 
         # Load the solution
-        if om_version()[0] > (3, 34, 2):
-            sol_file = p.get_outputs_dir() / 'dymos_solution.db'
-        else:
-            sol_file = 'dymos_solution.db'
+        sol_file = p.get_outputs_dir() / 'dymos_solution.db'
 
         case = om.CaseReader(sol_file).get_case('final')
 

--- a/dymos/test/test_run_problem.py
+++ b/dymos/test/test_run_problem.py
@@ -20,7 +20,6 @@ import dymos as dm
 from dymos.examples.hyper_sensitive.hyper_sensitive_ode import HyperSensitiveODE
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 from dymos.examples.brachistochrone.brachistochrone_vector_states_ode import BrachistochroneVectorStatesODE
-from dymos.utils.misc import om_version
 from dymos.utils.testing_utils import _get_reports_dir
 
 _, optimizer = set_pyoptsparse_opt('IPOPT', fallback=True)
@@ -265,11 +264,8 @@ class TestRunProblem(unittest.TestCase):
         dm.run_problem(p, simulate=True, simulate_kwargs={'times_per_seg': 100})
 
         # Assert the results are what we expect.
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol_case = om.CaseReader(sol_db).get_case('final')
         sim_case = om.CaseReader(sim_db).get_case('final')
@@ -381,11 +377,8 @@ class TestRunProblem(unittest.TestCase):
 
         dm.run_problem(p, refine_iteration_limit=20)
 
-        sol_db = 'dymos_solution.db'
-        driver_db = 'brach_driver_rec.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            driver_db = p.get_outputs_dir() / driver_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        driver_db = p.get_outputs_dir() / 'brach_driver_rec.db'
 
         self.assertTrue(os.path.exists(sol_db))
         # Assert the results are what we expect.
@@ -440,11 +433,8 @@ class TestRunProblem(unittest.TestCase):
 
         dm.run_problem(p, refine_iteration_limit=20, case_prefix='brach_test')
 
-        sol_db = 'dymos_solution.db'
-        driver_db = 'brach_driver_rec.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            driver_db = p.get_outputs_dir() / driver_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        driver_db = p.get_outputs_dir() / 'brach_driver_rec.db'
 
         self.assertTrue(os.path.exists(sol_db))
         # Assert the results are what we expect.
@@ -537,9 +527,7 @@ class TestRunProblem(unittest.TestCase):
 
         dm.run_problem(p, simulate=True)
 
-        sol_db = 'dymos_solution.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
 
         self.assertTrue(os.path.exists(sol_db))
 
@@ -560,18 +548,14 @@ class TestRunProblem(unittest.TestCase):
         dm.run_problem(p, run_driver=False, simulate=True)
 
         # Run the model
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         # create a new problem for restart to simulate a different command line execution
         q = vanderpol(transcription='gauss-lobatto', num_segments=75)
 
         run_problem(q, run_driver=False, simulate=False, restart=sim_db)
 
-        sol_db2 = 'dymos_solution.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db2 = q.get_outputs_dir() / sol_db2
+        sol_db2 = q.get_outputs_dir() / 'dymos_solution.db'
         s = om.CaseReader(sol_db2).get_case('final')
 
         # get_val returns data for duplicate time points; remove them before interpolating
@@ -614,15 +598,11 @@ class TestRunProblem(unittest.TestCase):
         q = vanderpol(transcription='gauss-lobatto', num_segments=75)
 
         # Run the model
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         run_problem(q, run_driver=False, simulate=False, restart=sim_db)
 
-        sol_db2 = 'dymos_solution.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db2 = q.get_outputs_dir() / sol_db2
+        sol_db2 = q.get_outputs_dir() / 'dymos_solution.db'
         s = om.CaseReader(sol_db2).get_case('final')
 
         # get_val returns data for duplicate time points; remove them before interpolating
@@ -773,8 +753,7 @@ class TestRunProblemPlotting(unittest.TestCase):
         sim_db = 'simulation_record_file.db'
         dm.run_problem(self.p, simulate=True, simulation_record_file=sim_db)
 
-        if om_version()[0] > (3, 34, 2):
-            sim_db = self.p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sim_db = self.p.model.traj.sim_prob.get_outputs_dir() / sim_db
 
         self.assertTrue(os.path.exists(sim_db))
 
@@ -782,8 +761,7 @@ class TestRunProblemPlotting(unittest.TestCase):
         sol_db = 'solution_record_file.db'
         dm.run_problem(self.p, solution_record_file=sol_db)
 
-        if om_version()[0] > (3, 34, 2):
-            sol_db = self.p.get_outputs_dir() / sol_db
+        sol_db = self.p.get_outputs_dir() / sol_db
 
         self.assertTrue(os.path.exists(sol_db))
 
@@ -889,11 +867,8 @@ class TestSimulateArrayParam(unittest.TestCase):
         dm.run_problem(p, simulate=True)
 
         # Test the results
-        sol_db = 'dymos_solution.db'
-        sim_db = 'dymos_simulation.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = p.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = p.model.traj.sim_prob.get_outputs_dir() / 'dymos_simulation.db'
 
         sol_results = om.CaseReader(sol_db).get_case('final')
         sim_results = om.CaseReader(sim_db).get_case('final')

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -18,8 +18,7 @@ from .phase_linkage_comp import PhaseLinkageComp
 from ..phase.analytic_phase import AnalyticPhase
 from ..phase.options import TrajParameterOptionsDictionary
 from ..transcriptions.common import ParameterComp
-from ..utils.misc import create_subprob, get_rate_units, om_version, \
-    _unspecified, _none_or_unspecified
+from ..utils.misc import create_subprob, get_rate_units, _unspecified, _none_or_unspecified
 from ..utils.introspection import get_source_metadata, _get_common_metadata
 
 
@@ -1383,10 +1382,7 @@ class Trajectory(om.Group):
             # fault of the user.
             warnings.filterwarnings(action='ignore', category=om.UnusedOptionWarning)
             warnings.filterwarnings(action='ignore', category=om.SetupWarning)
-            if om_version()[0] <= (3, 34, 2):
-                sim_prob.setup(check=False)
-            else:
-                sim_prob.setup(check=False, parent=self)
+            sim_prob.setup(check=False, parent=self)
             sim_prob.final_setup()
 
         # Assign trajectory parameter values

--- a/dymos/transcriptions/explicit_shooting/ode_integration_comp.py
+++ b/dymos/transcriptions/explicit_shooting/ode_integration_comp.py
@@ -6,7 +6,7 @@ import openmdao.api as om
 from ..._options import options as dymos_options
 
 from .ode_evaluation_group import ODEEvaluationGroup
-from dymos.utils.misc import create_subprob, om_version
+from dymos.utils.misc import create_subprob
 
 
 class ODEIntegrationComp(om.ExplicitComponent):
@@ -120,10 +120,7 @@ class ODEIntegrationComp(om.ExplicitComponent):
         # Support model options
         p.model_options = self._problem_meta['model_options']
 
-        if om_version()[0] <= (3, 34, 2):
-            p.setup(check=None)
-        else:
-            p.setup(check=None, parent=self)
+        p.setup(check=None, parent=self)
         p.final_setup()
 
     def _set_segment_index(self, idx):

--- a/dymos/utils/test/test_testing_utils.py
+++ b/dymos/utils/test/test_testing_utils.py
@@ -5,7 +5,6 @@ import numpy as np
 import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs
 
-from dymos.utils.misc import om_version
 from dymos.utils.testing_utils import assert_cases_equal, assert_timeseries_near_equal
 
 
@@ -357,11 +356,8 @@ class TestAssertCasesEqual(unittest.TestCase):
         p2.record('final')
         p2.cleanup()
 
-        p1_db = 'p1.db'
-        p2_db = 'p2.db'
-        if om_version()[0] > (3, 34, 2):
-            p1_db = p1.get_outputs_dir() / p1_db
-            p2_db = p2.get_outputs_dir() / p2_db
+        p1_db = p1.get_outputs_dir() / 'p1.db'
+        p2_db = p2.get_outputs_dir() / 'p2.db'
 
         c1 = om.CaseReader(p1_db).get_case('final')
         c2 = om.CaseReader(p2_db).get_case('final')
@@ -403,11 +399,8 @@ class TestAssertCasesEqual(unittest.TestCase):
         p2.record('final')
         p2.cleanup()
 
-        p1_db = 'p1.db'
-        p2_db = 'p2.db'
-        if om_version()[0] > (3, 34, 2):
-            p1_db = p1.get_outputs_dir() / p1_db
-            p2_db = p2.get_outputs_dir() / p2_db
+        p1_db = p1.get_outputs_dir() / 'p1.db'
+        p2_db = p2.get_outputs_dir() / 'p2.db'
 
         c1 = om.CaseReader(p1_db).get_case('final')
         c2 = om.CaseReader(p2_db).get_case('final')
@@ -441,11 +434,8 @@ class TestAssertCasesEqual(unittest.TestCase):
         p2.record('final')
         p2.cleanup()
 
-        p1_db = 'p1.db'
-        p2_db = 'p2.db'
-        if om_version()[0] > (3, 34, 2):
-            p1_db = p1.get_outputs_dir() / p1_db
-            p2_db = p2.get_outputs_dir() / p2_db
+        p1_db = p1.get_outputs_dir() / 'p1.db'
+        p2_db = p2.get_outputs_dir() / 'p2.db'
 
         c1 = om.CaseReader(p1_db).get_case('final')
         c2 = om.CaseReader(p2_db).get_case('final')
@@ -486,11 +476,8 @@ class TestAssertCasesEqual(unittest.TestCase):
         p2.record('final')
         p2.cleanup()
 
-        p1_db = 'p1.db'
-        p2_db = 'p2.db'
-        if om_version()[0] > (3, 34, 2):
-            p1_db = p1.get_outputs_dir() / p1_db
-            p2_db = p2.get_outputs_dir() / p2_db
+        p1_db = p1.get_outputs_dir() / 'p1.db'
+        p2_db = p2.get_outputs_dir() / 'p2.db'
 
         c1 = om.CaseReader(p1_db).get_case('final')
         c2 = om.CaseReader(p2_db).get_case('final')

--- a/dymos/visualization/test/test_timeseries_plots.py
+++ b/dymos/visualization/test/test_timeseries_plots.py
@@ -16,7 +16,6 @@ from dymos.examples.finite_burn_orbit_raise.finite_burn_eom import FiniteBurnODE
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 from dymos.examples.battery_multibranch.battery_multibranch_ode import BatteryODE
 from dymos.utils.lgl import lgl
-from dymos.utils.misc import om_version
 from dymos.utils.testing_utils import _get_reports_dir
 from dymos.visualization.timeseries_plots import timeseries_plots
 
@@ -88,9 +87,7 @@ class TestTimeSeriesPlotsBasics(unittest.TestCase):
         with dm.options.temporary(plots='matplotlib'):
             dm.run_problem(self.p, make_plots=False)
 
-            sol_db = 'dymos_solution.db'
-            if om_version()[0] > (3, 34, 2):
-                sol_db = self.p.get_outputs_dir() / sol_db
+            sol_db = self.p.get_outputs_dir() / 'dymos_solution.db'
 
             timeseries_plots(sol_db, problem=self.p)
             plot_dir = pathlib.Path(_get_reports_dir(self.p)).joinpath('plots')
@@ -110,9 +107,7 @@ class TestTimeSeriesPlotsBasics(unittest.TestCase):
         # records to the default file 'dymos_simulation.db'
         dm.run_problem(self.p, make_plots=False, solution_record_file='solution_record_file.db')
 
-        sol_db = 'solution_record_file.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = self.p.get_outputs_dir() / sol_db
+        sol_db = self.p.get_outputs_dir() / 'solution_record_file.db'
 
         timeseries_plots(sol_db, problem=self.p)
         plot_dir = pathlib.Path(_get_reports_dir(self.p)).joinpath('plots')
@@ -134,11 +129,8 @@ class TestTimeSeriesPlotsBasics(unittest.TestCase):
         dm.run_problem(self.p, simulate=True, make_plots=False,
                        simulation_record_file='simulation_record_file.db')
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'simulation_record_file.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = self.p.get_outputs_dir() / sol_db
-            sim_db = self.p.model.traj0.sim_prob.get_outputs_dir() / sim_db
+        sol_db = self.p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = self.p.model.traj0.sim_prob.get_outputs_dir() / 'simulation_record_file.db'
 
         timeseries_plots(sol_db,
                          simulation_record_file=sim_db,
@@ -162,9 +154,7 @@ class TestTimeSeriesPlotsBasics(unittest.TestCase):
 
         dm.run_problem(self.p, make_plots=False)
 
-        sol_db = 'dymos_solution.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = self.p.get_outputs_dir() / sol_db
+        sol_db = self.p.get_outputs_dir() / 'dymos_solution.db'
 
         plot_dir = pathlib.Path(_get_reports_dir(self.p)).joinpath("test_plot_dir").resolve()
         timeseries_plots(sol_db, plot_dir=plot_dir)
@@ -318,11 +308,8 @@ class TestTimeSeriesPlotsMultiPhase(unittest.TestCase):
         dm.run_problem(p, simulate=True, make_plots=False,
                        simulation_record_file='simulation_record_file.db')
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'simulation_record_file.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = self.p.get_outputs_dir() / sol_db
-            sim_db = self.p.model.sim_prob.get_outputs_dir() / sim_db
+        sol_db = self.p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = self.p.model.sim_prob.get_outputs_dir() / 'simulation_record_file.db'
 
         timeseries_plots(sol_db,
                          simulation_record_file=sim_db,
@@ -420,11 +407,8 @@ class TestTimeSeriesPlotsMultiPhase(unittest.TestCase):
         dm.run_problem(prob, simulate=True, make_plots=False,
                        simulation_record_file='simulation_record_file.db')
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'simulation_record_file.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = prob.get_outputs_dir() / sol_db
-            sim_db = prob.model.traj.sim_prob.get_outputs_dir() / sim_db
+        sol_db = prob.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = prob.model.traj.sim_prob.get_outputs_dir() / 'simulation_record_file.db'
 
         plot_dir = pathlib.Path(_get_reports_dir(prob)).joinpath("plots")
 
@@ -576,11 +560,8 @@ class TestTimeSeriesPlotsMultiPhase(unittest.TestCase):
         dm.run_problem(p, simulate=True, make_plots=False,
                        simulation_record_file='simulation_record_file.db')
 
-        sol_db = 'dymos_solution.db'
-        sim_db = 'simulation_record_file.db'
-        if om_version()[0] > (3, 34, 2):
-            sol_db = p.get_outputs_dir() / sol_db
-            sim_db = p.model.sim_prob.get_outputs_dir() / sim_db
+        sol_db = p.get_outputs_dir() / 'dymos_solution.db'
+        sim_db = p.model.sim_prob.get_outputs_dir() / 'simulation_record_file.db'
 
         timeseries_plots(sol_db, sim_db, problem=p)
         plot_dir = pathlib.Path(_get_reports_dir(p)).joinpath("plots")


### PR DESCRIPTION
### Summary

There were many checks in dymos for versions of OpenMDAO prior to the minimum supported 3.36.0.
Since these checks are no longer relevant, they have been removed.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
