### PR TITLE
Fixed a bug involving using state values as state rates in PicardShooting

### DIFF
--- a/dymos/examples/double_integrator/test/test_double_integrator_breakwell.py
+++ b/dymos/examples/double_integrator/test/test_double_integrator_breakwell.py
@@ -75,7 +75,7 @@ def double_integrator_direct_collocation(transcription='gauss-lobatto', compress
     return p
 
 
-# @use_tempdirs
+@use_tempdirs
 class TestBreakwellExample(unittest.TestCase):
 
     @classmethod
@@ -125,11 +125,9 @@ class TestBreakwellExample(unittest.TestCase):
         self._assert_results(p)
 
     def test_ex_double_integrator_picard_shooting(self):
-        from dymos._options import options as dymos_options
-        with dymos_options.temporary(include_check_partials=True):
-            p = double_integrator_direct_collocation('picard-cgl', optimizer='IPOPT')
-            dm.run_problem(p, run_driver=True, simulate=False, make_plots=True)
-            self._assert_results(p)
+        p = double_integrator_direct_collocation('picard-cgl', optimizer='IPOPT')
+        dm.run_problem(p, run_driver=True, simulate=False, make_plots=True)
+        self._assert_results(p)
 
     def test_check_partials(self):
         p = double_integrator_direct_collocation('birkhoff', optimizer='SLSQP')

--- a/dymos/examples/double_integrator/test/test_double_integrator_breakwell.py
+++ b/dymos/examples/double_integrator/test/test_double_integrator_breakwell.py
@@ -36,6 +36,9 @@ def double_integrator_direct_collocation(transcription='gauss-lobatto', compress
         t = dm.Radau(num_segments=30, order=3, compressed=compressed)
     elif transcription == 'birkhoff':
         t = dm.Birkhoff(num_nodes=51)
+    elif transcription.startswith('picard'):
+        grid_type = transcription.split('-')[-1]
+        t = dm.PicardShooting(num_segments=1, nodes_per_seg=50, grid_type=grid_type)
     else:
         raise ValueError('invalid transcription')
 
@@ -72,7 +75,7 @@ def double_integrator_direct_collocation(transcription='gauss-lobatto', compress
     return p
 
 
-@use_tempdirs
+# @use_tempdirs
 class TestBreakwellExample(unittest.TestCase):
 
     @classmethod
@@ -120,6 +123,13 @@ class TestBreakwellExample(unittest.TestCase):
         p = double_integrator_direct_collocation('birkhoff', optimizer='IPOPT')
         dm.run_problem(p)
         self._assert_results(p)
+
+    def test_ex_double_integrator_picard_shooting(self):
+        from dymos._options import options as dymos_options
+        with dymos_options.temporary(include_check_partials=True):
+            p = double_integrator_direct_collocation('picard-cgl', optimizer='IPOPT')
+            dm.run_problem(p, run_driver=True, simulate=False, make_plots=True)
+            self._assert_results(p)
 
     def test_check_partials(self):
         p = double_integrator_direct_collocation('birkhoff', optimizer='SLSQP')

--- a/dymos/examples/ssto/doc/test_doc_ssto_linear_tangent_guidance.py
+++ b/dymos/examples/ssto/doc/test_doc_ssto_linear_tangent_guidance.py
@@ -1,14 +1,5 @@
 import unittest
 
-try:
-    import matplotlib
-    import matplotlib.pyplot as plt
-
-    matplotlib.use('Agg')
-    plt.style.use('ggplot')
-except ImportError:
-    matplotlib = None
-
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
 
@@ -16,14 +7,11 @@ from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 class TestDocSSTOLinearTangentGuidance(unittest.TestCase):
 
     @require_pyoptsparse(optimizer='SLSQP')
-    @unittest.skipIf(matplotlib is None, "This test requires matplotlib")
     def test_doc_ssto_linear_tangent_guidance(self):
         import numpy as np
-        import matplotlib.pyplot as plt
         import openmdao.api as om
         from openmdao.utils.assert_utils import assert_near_equal
         import dymos as dm
-        from dymos.examples.plotting import plot_results
 
         g = 1.61544  # lunar gravity, m/s**2
 
@@ -273,29 +261,12 @@ class TestDocSSTOLinearTangentGuidance(unittest.TestCase):
         phase.set_parameter_val('a_ctrl', -0.01)
         phase.set_parameter_val('b_ctrl', 3.0)
 
-        dm.run_problem(p)
+        dm.run_problem(p, simulate=True)
 
         #
         # Check the results.
         #
         assert_near_equal(p.get_val('traj.phase0.timeseries.time')[-1], 481, tolerance=0.01)
-
-        #
-        # Get the explitly simulated results
-        #
-        exp_out = traj.simulate()
-
-        #
-        # Plot the results
-        #
-        plot_results([('traj.phase0.timeseries.x', 'traj.phase0.timeseries.y',
-                       'range (m)', 'altitude (m)'),
-                      ('traj.phase0.timeseries.time', 'traj.phase0.timeseries.theta',
-                       'range (m)', 'altitude (m)')],
-                     title='Single Stage to Orbit Solution Using Linear Tangent Guidance',
-                     p_sol=p, p_sim=exp_out)
-
-        plt.show()
 
 
 if __name__ == "__main__":

--- a/dymos/transcriptions/picard_shooting/birkhoff_picard_iter_group.py
+++ b/dymos/transcriptions/picard_shooting/birkhoff_picard_iter_group.py
@@ -99,10 +99,12 @@ class BirkhoffPicardIterGroup(om.Group):
                                  "rate_source")
 
             # Note the rate source must be shape-compatible with the state
-            var_type = phase.classify_var(rate_source_var)
+            rate_src_type = phase.classify_var(rate_source_var)
 
-            if var_type == 'ode':
+            if rate_src_type == 'ode':
                 self.connect(f'ode_all.{rate_source}', f'picard_update_comp.f_computed:{name}')
+            elif rate_src_type == 'state':
+                self.connect(f'state_val:{rate_source}', f'picard_update_comp.f_computed:{name}')
 
             promotes = [f'states:{name}']
             if options['solve_segments'] == 'forward':

--- a/dymos/transcriptions/picard_shooting/birkhoff_picard_update_comp.py
+++ b/dymos/transcriptions/picard_shooting/birkhoff_picard_update_comp.py
@@ -100,17 +100,11 @@ class PicardUpdateComp(om.ExplicitComponent):
             rate_units = get_rate_units(units, time_units)
             var_names = self.var_names[state_name]
 
-            rate_source = options['rate_source']
-            rate_source_type = phase.classify_var(rate_source)
-
-            if rate_source_type == 'state':
-                var_names['f_computed'] = f'state_val:{rate_source}'
-            else:
-                self.add_input(
-                    name=var_names['f_computed'],
-                    shape=(num_nodes,) + shape,
-                    desc=f'Computed derivative of state {state_name} at the polynomial nodes',
-                    units=rate_units)
+            self.add_input(
+                name=var_names['f_computed'],
+                shape=(num_nodes,) + shape,
+                desc=f'Computed derivative of state {state_name} at the polynomial nodes',
+                units=rate_units)
 
             self.add_output(
                 name=var_names['x_hat'],

--- a/dymos/transcriptions/pseudospectral/birkhoff.py
+++ b/dymos/transcriptions/pseudospectral/birkhoff.py
@@ -30,6 +30,7 @@ class Birkhoff(TranscriptionBase):
         super(Birkhoff, self).__init__(**kwargs)
         self._rhs_source = 'ode_iter_group.ode_all'
         self._has_boundary_ode = True
+        self._has_initial_final_states = True
 
     def initialize(self):
         """
@@ -401,6 +402,19 @@ class Birkhoff(TranscriptionBase):
                                    f'or path constraints.\nParameters are single values that do not change in '
                                    f'time, and may only be used in a single boundary or path constraint.')
             constraint_kwargs['indices'] = flat_idxs
+        elif var_type == 'state':
+            # For states, Birkhoff uses initial_states:{var} and final_states:{var}
+            if constraint_type in ('initial', 'final'):
+                constraint_kwargs['indices'] = flat_idxs
+            elif constraint_type == 'final':
+                constraint_kwargs['indices'] = flat_idxs
+            else:
+                # Path
+                path_idxs = []
+                for i in range(num_nodes):
+                    path_idxs.extend(size * i + flat_idxs)
+
+                constraint_kwargs['indices'] = path_idxs
         else:
             if constraint_type == 'initial':
                 constraint_kwargs['indices'] = flat_idxs

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -52,6 +52,9 @@ class TranscriptionBase(object):
         # Does this transcription have a separate ODE for the phase boundaries?
         self._has_boundary_ode = False
 
+        # Does this transcription include separate variables for the initial and final states?
+        self._has_initial_final_states = False
+
     def _declare_options(self):
         pass
 

--- a/dymos/utils/introspection.py
+++ b/dymos/utils/introspection.py
@@ -814,6 +814,8 @@ def _configure_constraint_introspection(phase):
         The phase object whose boundary and path constraints are to be introspected.
     """
     has_boundary_ode = phase.options['transcription']._has_boundary_ode
+    has_initial_final_states = phase.options['transcription']._has_boundary_ode or \
+        phase.options['transcription']._has_initial_final_states
 
     for constraint_type, constraints in [('initial', phase._initial_boundary_constraints),
                                          ('final', phase._final_boundary_constraints),
@@ -847,8 +849,10 @@ def _configure_constraint_introspection(phase):
                 state_units = phase.state_options[var]['units']
                 con['shape'] = state_shape
                 con['units'] = state_units if con['units'] is None else con['units']
-                if has_boundary_ode and constraint_type in ('initial', 'final'):
-                    con['constraint_path'] = f'boundary_vals.{var}'
+                if has_initial_final_states and constraint_type == 'initial':
+                    con['constraint_path'] = f'initial_states:{var}'
+                elif has_initial_final_states and constraint_type == 'final':
+                    con['constraint_path'] = f'final_states:{var}'
                 else:
                     con['constraint_path'] = f'timeseries.{prefix}{var}'
 


### PR DESCRIPTION
### Summary

PicardShooting now correctly connects state rates to the f_computed input of the PicardUpdateComp, which allows states to be used as state rates.

Found overlapping constraint indices problems with path + boundary constraints when using PicardShooting.  To fix this, PicardShooting (and Birkhoff) now have a `_has_initial_final_states` property which informs dymos that `initial_states:{name}` or `final_states:{name}` should be used for boundary constraint values.

Changed constraint introspection so that transcriptions with `_has_initial_final_states` use those values for boundary constraints.

### Related Issues

- Resolves #1186 

### Backwards incompatibilities

None

### New Dependencies

None
