### PR TITLE
Trajectory.configure_parameters will not add parameters to phases if they already exist

### DIFF
--- a/dymos/trajectory/test/test_multi_setup.py
+++ b/dymos/trajectory/test/test_multi_setup.py
@@ -1,0 +1,38 @@
+import unittest
+import numpy as np
+
+import openmdao.api as om
+from openmdao.utils.testing_utils import require_pyoptsparse
+
+import dymos as dm
+from dymos.utils.misc import om_version
+from dymos.examples.balanced_field.balanced_field_ode import BalancedFieldODEComp
+
+
+class TestMultiSetup(unittest.TestCase):
+
+    def test_call_setup_twice(self):
+
+        ode_class = BalancedFieldODEComp
+        tx = dm.Radau(num_segments=2, order=3, compressed=True)
+
+        p = om.Problem()
+
+        # First Phase: Brake release to V1 - both engines operable
+        br_to_v1 = dm.Phase(ode_class=ode_class, transcription=tx,
+                            ode_init_kwargs={'mode': 'runway'})
+
+        # Instantiate the trajectory and add phases
+        traj = dm.Trajectory()
+        p.model.add_subsystem('traj', traj)
+        traj.add_phase('br_to_v1', br_to_v1)
+        all_phases = ['br_to_v1']
+
+        # Add parameters common to multiple phases to the trajectory
+        traj.add_parameter('m', val=174200., opt=False, units='lbm',
+                        desc='aircraft mass',
+                        targets={phase: ['m'] for phase in all_phases})
+
+        p.setup()
+        p.setup()  # This fails in dymos 1.13.2-dev
+        p.final_setup()

--- a/dymos/trajectory/trajectory.py
+++ b/dymos/trajectory/trajectory.py
@@ -358,7 +358,10 @@ class Trajectory(om.Group):
                                   'targets': tgts[phase_name]}
 
                         if not self.options['sim_mode']:
-                            phs.add_parameter(name, **kwargs)
+                            if name not in phs.parameter_options:
+                                phs.add_parameter(name, **kwargs)
+                            else:
+                                phs.set_parameter_options(name, **kwargs)
 
     def _setup_linkages(self):
 


### PR DESCRIPTION
### Summary

The ability to run setup multiple times on a trajectory object was broken if it has parameters.
This fix makes it so that the trajectory setup process does not add the parameter to a given phase if it already exists within that phase.

### Related Issues

- Resolves #1190 

### Backwards incompatibilities

None

### New Dependencies

None
