### PR TITLE
New Radau: Part 1

### DIFF
--- a/dymos/examples/goddard_rocket_problem/test/test_goddard_rocket_problem.py
+++ b/dymos/examples/goddard_rocket_problem/test/test_goddard_rocket_problem.py
@@ -3,12 +3,6 @@ import dymos as dm
 import unittest
 import os
 
-try:
-    import matplotlib  # noqa: F401
-    SHOW_PLOTS = True
-except ImportError:
-    SHOW_PLOTS = False
-
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 
@@ -78,48 +72,11 @@ class TestGoddardRocketProblem(unittest.TestCase):
     def test_goddard_rocket_problem_lgl(self):
         p = goddard_rocket_direct_collocation(grid_type='lgl')
         dm.run_problem(p)
-        if SHOW_PLOTS:
-            t = p.get_val('traj.phase0.timeseries.time')
-            h = p.get_val('traj.phase0.timeseries.h')
-            v = p.get_val('traj.phase0.timeseries.v')
-            m = p.get_val('traj.phase0.timeseries.m')
-            T = p.get_val('traj.phase0.timeseries.T')
-
-            import matplotlib.pyplot as plt
-            fig, axs = plt.subplots(2, 2)
-            axs[0, 0].plot(t, h)
-            axs[0, 0].set_xlabel('time (s)')
-            axs[0, 0].set_ylabel('altitude (ft)')
-            axs[0, 1].plot(t, v)
-            axs[0, 1].set_xlabel('time (s)')
-            axs[0, 1].set_ylabel('velocity (ft/s)')
-            axs[1, 0].plot(t, m)
-            axs[1, 0].set_xlabel('time (s)')
-            axs[1, 0].set_ylabel('mass (slug)')
-            axs[1, 1].plot(t, T)
-            axs[1, 1].set_xlabel('time (s)')
-            axs[1, 1].set_ylabel('thrust (lb)')
-            plt.show()
-
         self._assert_results(p)
 
     def test_goddard_rocket_problem_cgl(self):
         p = goddard_rocket_direct_collocation(grid_type='cgl')
         dm.run_problem(p)
-        if SHOW_PLOTS:
-            t = p.get_val('traj.phase0.timeseries.time')
-            h = p.get_val('traj.phase0.timeseries.h')
-            v = p.get_val('traj.phase0.timeseries.v')
-            m = p.get_val('traj.phase0.timeseries.m')
-            T = p.get_val('traj.phase0.timeseries.T')
-
-            import matplotlib.pyplot as plt
-            fig, axs = plt.subplots(2, 2)
-            axs[0, 0].plot(t, h)
-            axs[0, 1].plot(t, v)
-            axs[1, 0].plot(t, m)
-            axs[1, 1].plot(t, T)
-            plt.show()
         self._assert_results(p)
 
     def test_check_partials(self):

--- a/dymos/examples/hyper_sensitive/test/test_hyper_sensitive.py
+++ b/dymos/examples/hyper_sensitive/test/test_hyper_sensitive.py
@@ -29,7 +29,7 @@ class TestHyperSensitive(unittest.TestCase):
 
         p = om.Problem(model=om.Group())
 
-        p.driver = om.pyOptSparseDriver()
+        p.driver = om.pyOptSparseDriver(print_results=False)
         p.driver.declare_coloring()
         p.driver.options['optimizer'] = optimizer
 
@@ -113,15 +113,15 @@ class TestHyperSensitive(unittest.TestCase):
 
         assert_near_equal(p.get_val('traj.phase0.timeseries.u')[0],
                           ui,
-                          tolerance=5e-6)
+                          tolerance=1e-4)
 
         assert_near_equal(p.get_val('traj.phase0.timeseries.u')[-1],
                           uf,
-                          tolerance=5e-6)
+                          tolerance=1e-4)
 
         assert_near_equal(p.get_val('traj.phase0.timeseries.xL')[-1],
                           J,
-                          tolerance=1e-6)
+                          tolerance=1e-4)
 
     @require_pyoptsparse(optimizer='IPOPT')
     def test_hyper_sensitive_birkhoff(self):

--- a/dymos/grid_refinement/hp_adaptive/hp_adaptive.py
+++ b/dymos/grid_refinement/hp_adaptive/hp_adaptive.py
@@ -458,7 +458,7 @@ class HPAdaptive:
                         b = a @ x[state_name][left_end_idxs[k]:left_end_idxs[k + 1]]
                         for i in range(seg_size[gd.transcription] - 1, phase.refine_options['min_order'], -1):
                             state_error = np.abs(b[i]) / beta[state_name]
-                            if state_error < refine_tol:
+                            if np.any(state_error < refine_tol):
                                 if gd.transcription == 'gauss-lobatto':
                                     if new_order_state[state_name] < i - 2 <= refine_min_order:
                                         new_order_state[state_name] = i - 2

--- a/dymos/grid_refinement/test/test_grid_refinement.py
+++ b/dymos/grid_refinement/test/test_grid_refinement.py
@@ -124,13 +124,11 @@ class TestGridRefinement(unittest.TestCase):
         #
         # Set the initial values
         #
-        p['traj.phase0.t_initial'] = 0.0
-        p['traj.phase0.t_duration'] = 1.0
-
-        p.set_val('traj.phase0.states:x', phase.interp('x', ys=[0, 0]))
-        p.set_val('traj.phase0.states:v', phase.interp('v', ys=[1, -1]))
-        p.set_val('traj.phase0.states:J', phase.interp('J', ys=[0, 1]))
-        p.set_val('traj.phase0.controls:u', np.sin(phase.interp('u', ys=[0, 0])))
+        phase.set_time_val(initial=0.0, duration=1.0)
+        phase.set_state_val('x', [0, 0])
+        phase.set_state_val('v', [-1, 1])
+        phase.set_state_val('J', [0, 1])
+        phase.set_control_val('u', [0, 0])
 
         #
         # Solve for the optimal trajectory
@@ -142,4 +140,8 @@ class TestGridRefinement(unittest.TestCase):
         seg_orders = p.model.traj.phases.phase0.options['transcription'].grid_data.transcription_order
 
         self.assertGreaterEqual(num_seg, 5)
-        self.assertGreater(sum(seg_orders), 5 * 3)
+        self.assertGreaterEqual(sum(seg_orders), 5 * 3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/dymos/phase/test/test_implicit_duration.py
+++ b/dymos/phase/test/test_implicit_duration.py
@@ -117,9 +117,8 @@ class TestImplicitDuration(unittest.TestCase):
 
         p.setup()
 
-        p.set_val('traj.phase.t_initial', 0)
-        p.set_val('traj.phase.t_duration', 7)
-        p.set_val('traj.phase.states:z', phase.interp('z', [[[0, 0], [10, 10]], [[10, 0], [10, -10]]]))
+        phase.set_time_val(initial=0, duration=7.)
+        phase.set_state_val('z', [[[0, 0], [10, 10]], [[10, 0], [10, -10]]])
 
         return p
 

--- a/dymos/phase/test/test_simulate.py
+++ b/dymos/phase/test/test_simulate.py
@@ -77,14 +77,13 @@ class TestSimulateShapedParams(unittest.TestCase):
 
         p.setup(mode='auto', check=['unconnected_inputs'], force_alloc_complex=True)
 
-        p.set_val('hop0.main_phase.t_initial', 0.0)
-        p.set_val('hop0.main_phase.t_duration', 10)
-        p.set_val('hop0.main_phase.controls:Thrust', val=-3400, indices=om.slicer[:, 0])
-        p.set_val('hop0.main_phase.states:impulse',  main_phase.interp('impulse', [0, 0]))
+        main_phase.set_time_val(initial=0.0, duration=10.0)
+        main_phase.set_control_val('Thrust', [-3400, -3400])
+        main_phase.set_state_val('impulse', [0, 0])
 
         p.run_driver()
 
-        assert_near_equal(p.get_val('hop0.main_phase.timeseries.impulse')[-1, 0], -7836.66666, tolerance=1.0E-4)
+        assert_near_equal(p.get_val('hop0.main_phase.timeseries.impulse')[-1, 0], -7836.66666, tolerance=1.0E-3)
 
         try:
             hop0.simulate()
@@ -121,19 +120,12 @@ class TestSimulateShapedParams(unittest.TestCase):
 
         p.setup(mode='auto', check=['unconnected_inputs'], force_alloc_complex=True)
 
-        p.set_val('hop0.main_phase.t_initial', 0.0)
-        p.set_val('hop0.main_phase.t_duration', 10)
-        p.set_val('hop0.main_phase.controls:Thrust', val=-3400, indices=om.slicer[:, 0])
-        p.set_val('hop0.main_phase.states:impulse',  main_phase.interp('impulse', [0, 0]))
+        main_phase.set_time_val(initial=0.0, duration=10.0)
+        main_phase.set_control_val('Thrust', [-3400, -3400])
+        main_phase.set_state_val('impulse', [0, 0])
 
-        p.run_driver()
-
+        dm.run_problem(p, run_driver=True, simulate=True, make_plots=False)
         assert_near_equal(p.get_val('hop0.main_phase.timeseries.impulse')[-1, 0], -7836.66666, tolerance=1.0E-4)
-
-        try:
-            hop0.simulate()
-        except Exception:
-            self.fail('Simulate did not correctly complete.')
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/test/test_run_problem.py
+++ b/dymos/test/test_run_problem.py
@@ -52,7 +52,7 @@ class TestRunProblem(unittest.TestCase):
         phase0.set_time_options(fix_initial=True, fix_duration=True)
         phase0.add_state('x', fix_initial=True, fix_final=False, rate_source='x_dot', targets=['x'])
         phase0.add_state('xL', fix_initial=True, fix_final=False, rate_source='L', targets=['xL'])
-        phase0.add_control('u', opt=True, targets=['u'], rate_continuity=False)
+        phase0.add_control('u', opt=True, targets=['u'], continuity=True, rate_continuity=True)
 
         phase0.add_boundary_constraint('x', loc='final', equals=1)
 
@@ -64,12 +64,12 @@ class TestRunProblem(unittest.TestCase):
 
         tf = 20.0
 
-        p.set_val('traj.phase0.states:x', phase0.interp('x', [1.5, 1]))
-        p.set_val('traj.phase0.states:xL', phase0.interp('xL', [0, 1]))
-        p.set_val('traj.phase0.t_initial', 0)
-        p.set_val('traj.phase0.t_duration', tf)
-        p.set_val('traj.phase0.controls:u', phase0.interp('u', [-0.6, 2.4]))
-        dm.run_problem(p, refine_method='hp', refine_iteration_limit=10)
+        phase0.set_time_val(initial=0.0, duration=tf)
+        phase0.set_state_val('x', [1.5, 1])
+        phase0.set_state_val('xL', [0, 1])
+        phase0.set_control_val('u', [-0.6, 2.4])
+
+        dm.run_problem(p, refine_method='hp', refine_iteration_limit=10, make_plots=True)
 
         sqrt_two = np.sqrt(2)
         val = sqrt_two * tf
@@ -131,11 +131,11 @@ class TestRunProblem(unittest.TestCase):
 
         tf = 20.0
 
-        p.set_val('traj.phase0.states:x', phase0.interp('x', [1.5, 1]))
-        p.set_val('traj.phase0.states:xL', phase0.interp('xL', [0, 1]))
-        p.set_val('traj.phase0.t_initial', 0)
-        p.set_val('traj.phase0.t_duration', tf)
-        p.set_val('traj.phase0.controls:u', phase0.interp('u', [-0.6, 2.4]))
+        phase0.set_time_val(initial=0.0, duration=tf)
+        phase0.set_state_val('x', [1.5, 1])
+        phase0.set_state_val('xL', [0, 1])
+        phase0.set_control_val('u', [-0.6, 2.4])
+
         dm.run_problem(p, refine_method='ph', refine_iteration_limit=10)
 
         sqrt_two = np.sqrt(2)
@@ -461,13 +461,14 @@ class TestRunProblem(unittest.TestCase):
 
         phase.set_time_options(fix_initial=True, duration_bounds=(.5, 10))
 
-        phase.add_state('pos', fix_initial=True, fix_final=[True, False])
+        phase.add_state('pos', fix_initial=True)
         phase.add_state('v', fix_initial=True, fix_final=False)
 
         phase.add_control('theta', units='deg', rate_continuity=False, lower=0.01, upper=179.9)
 
         phase.add_parameter('g', units='m/s**2', opt=False, val=9.80665)
 
+        phase.add_boundary_constraint('pos', loc='final', equals=10, indices=[0])
         phase.add_boundary_constraint('pos', loc='final', equals=5, indices=[1])
 
         # Minimize time at the end of the phase

--- a/dymos/trajectory/test/test_link_phases.py
+++ b/dymos/trajectory/test/test_link_phases.py
@@ -87,8 +87,8 @@ class TestPhaseLinkageComp(unittest.TestCase):
         v0 = p.get_val('traj.phase0.states:v')[-1]
         v1 = p.get_val('traj.phase1.states:v')[0]
 
-        assert_near_equal(h0, h1)
-        assert_near_equal(v0, v1)
+        assert_near_equal(h0, h1, tolerance=1.0E-9)
+        assert_near_equal(v0, v1, tolerance=1.0E-9)
 
     def test_link_phases_all_vars_unconnected(self):
         p = self.make_problem(link_all_vars=True, connected=False)
@@ -99,8 +99,8 @@ class TestPhaseLinkageComp(unittest.TestCase):
         v0 = p.get_val('traj.phase0.states:v')[-1]
         v1 = p.get_val('traj.phase1.states:v')[0]
 
-        assert_near_equal(h0, h1)
-        assert_near_equal(v0, v1)
+        assert_near_equal(h0, h1, tolerance=1.0E-9)
+        assert_near_equal(v0, v1, tolerance=1.0E-9)
 
     def test_link_phases_specified_vars_connected(self):
         p = self.make_problem(connected=True)
@@ -111,8 +111,8 @@ class TestPhaseLinkageComp(unittest.TestCase):
         v0 = p.get_val('traj.phase0.states:v')[-1]
         v1 = p.get_val('traj.phase1.states:v')[0]
 
-        assert_near_equal(h0, h1)
-        assert_near_equal(v0, v1)
+        assert_near_equal(h0, h1, tolerance=1.0E-9)
+        assert_near_equal(v0, v1, tolerance=1.0E-9)
 
     def test_link_phases_all_vars_connected(self):
         p = self.make_problem(link_all_vars=True, connected=True)
@@ -123,5 +123,5 @@ class TestPhaseLinkageComp(unittest.TestCase):
         v0 = p.get_val('traj.phase0.states:v')[-1]
         v1 = p.get_val('traj.phase1.states:v')[0]
 
-        assert_near_equal(h0, h1)
-        assert_near_equal(v0, v1)
+        assert_near_equal(h0, h1, tolerance=1.0E-9)
+        assert_near_equal(v0, v1, tolerance=1.0E-9)

--- a/dymos/trajectory/test/test_trajectory_parameters.py
+++ b/dymos/trajectory/test/test_trajectory_parameters.py
@@ -321,6 +321,7 @@ class TestPhaseParameterPromotion(unittest.TestCase):
                 p.driver = om.pyOptSparseDriver()
                 OPT, OPTIMIZER = set_pyoptsparse_opt(optimizer, fallback=True)
                 p.driver.options['optimizer'] = OPTIMIZER
+                p.driver.options['print_results'] = False
                 p.driver.declare_coloring()
 
                 if transcription == 'gauss-lobatto':
@@ -348,8 +349,8 @@ class TestPhaseParameterPromotion(unittest.TestCase):
                 phase.add_state('v', fix_initial=True, fix_final=False, solve_segments=False,
                                 units='m/s', rate_source='vdot', targets=['v'])
 
-                phase.add_control('theta', continuity=True, rate_continuity=True,
-                                  units='deg', lower=0.01, upper=179.9, targets=['theta'])
+                phase.add_control('theta', rate_continuity=True,
+                                  units='deg', targets=['theta'])
 
                 phase.add_parameter('g', units='m/s**2', val=9.80665, targets=['g'])
 
@@ -361,16 +362,15 @@ class TestPhaseParameterPromotion(unittest.TestCase):
                 p.model.linear_solver = om.DirectSolver()
                 p.setup(check=True)
 
-                p.set_val('traj.t_initial', 0.0)
-                p.set_val('traj.t_duration', 2.0)
+                phase.set_time_val(initial=0.0, duration=2.0)
 
-                p.set_val('traj.phase0.states:x', phase.interp('x', ys=[0, 10]))
-                p.set_val('traj.phase0.states:y', phase.interp('y', ys=[10, 5]))
-                p.set_val('traj.phase0.states:v', phase.interp('v', ys=[0, 9.9]))
-                p.set_val('traj.phase0.controls:theta', phase.interp('theta', ys=[5, 100]))
+                phase.set_state_val('x', [0, 10])
+                phase.set_state_val('y', [10, 5])
+                phase.set_state_val('v', [0, 9.9])
+                phase.set_control_val('theta', [5, 100])
                 p.set_val('traj.parameters:g', 9.80665)
 
-                p.run_driver()
+                dm.run_problem(p, make_plots=True)
 
                 assert_near_equal(p['traj.t_duration'], 1.8016, tolerance=1.0E-4)
 

--- a/dymos/transcriptions/analytic/analytic.py
+++ b/dymos/transcriptions/analytic/analytic.py
@@ -6,7 +6,7 @@ from ...utils.introspection import configure_analytic_states_introspection, get_
     get_source_metadata, configure_analytic_states_discovery
 from ...utils.indexing import get_src_indices_by_row
 from ...utils.ode_utils import _make_ode_system
-from ..grid_data import GridData
+from ..grid_data import GaussLobattoGrid
 from ..common import TimeComp, TimeseriesOutputComp
 
 
@@ -30,11 +30,10 @@ class Analytic(TranscriptionBase):
         """
         Setup the GridData object for the Transcription.
         """
-        self.grid_data = GridData(num_segments=1,
-                                  transcription='gauss-lobatto',
-                                  transcription_order=self.options['order'],
-                                  segment_ends=self.options['segment_ends'],
-                                  compressed=self.options['compressed'])
+        self.grid_data = GaussLobattoGrid(num_segments=1,
+                                          nodes_per_seg=self.options['order'],
+                                          segment_ends=self.options['segment_ends'],
+                                          compressed=self.options['compressed'])
 
     def setup_time(self, phase):
         """

--- a/dymos/transcriptions/common/test/test_time_comp.py
+++ b/dymos/transcriptions/common/test/test_time_comp.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_almost_equal
 import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs
 
-from dymos.transcriptions.grid_data import GridData
+from dymos.transcriptions.grid_data import GaussLobattoGrid, RadauGrid
 from dymos.transcriptions.common import TimeComp
 
 from dymos.utils.misc import CompWrapperConfig
@@ -28,10 +28,9 @@ class TestTimeComp(unittest.TestCase):
 
     def test_results_gauss_lobatto(self):
 
-        gd = GridData(num_segments=3,
-                      transcription_order=[5, 3, 3],
-                      segment_ends=_segends,
-                      transcription='gauss-lobatto')
+        gd = GaussLobattoGrid(num_segments=3,
+                              nodes_per_seg=[5, 3, 3],
+                              segment_ends=_segends)
 
         p = om.Problem(model=om.Group())
 
@@ -83,10 +82,9 @@ class TestTimeComp(unittest.TestCase):
 
     def test_results_radau(self):
 
-        gd = GridData(num_segments=3,
-                      transcription_order=[5, 3, 3],
-                      segment_ends=_segends,
-                      transcription='radau-ps')
+        gd = RadauGrid(num_segments=3,
+                       nodes_per_seg=[5+1, 3+1, 3+1],
+                       segment_ends=_segends)
 
         p = om.Problem(model=om.Group())
 

--- a/dymos/transcriptions/explicit_shooting/test/test_ode_integration_comp.py
+++ b/dymos/transcriptions/explicit_shooting/test/test_ode_integration_comp.py
@@ -17,7 +17,7 @@ from dymos.utils.testing_utils import SimpleODE
 
 class TestODEIntegrationComp(unittest.TestCase):
 
-    @unittest.skipIf(om_version()[0] >= (3, 36, 0) or om_version()[0] < (3, 37, 0),
+    @unittest.skipIf(om_version()[0] >= (3, 36, 0) and om_version()[0] < (3, 37, 0),
                      reason='Test skipped due to an issue in OpenMDAO 3.36.x')
     def test_integrate_scalar_ode(self):
         dymos_options['include_check_partials'] = True
@@ -26,12 +26,12 @@ class TestODEIntegrationComp(unittest.TestCase):
             with self.subTest('input_grid_data = output_grid_data'
                               if ogd_eq_igd else 'input_grid_data != output_grid_data'):
 
-                input_grid_data = GridData(num_segments=1, transcription='gauss-lobatto', transcription_order=3)
+                input_grid_data = dm.GaussLobattoGrid(num_segments=1, nodes_per_seg=3)
 
                 if ogd_eq_igd:
                     output_grid_data = input_grid_data
                 else:
-                    output_grid_data = GridData(num_segments=1, transcription='uniform', transcription_order=10)
+                    output_grid_data = dm.UniformGrid(num_segments=1, nodes_per_seg=10)
 
                 time_options = TimeOptionsDictionary()
 
@@ -83,14 +83,13 @@ class TestODEIntegrationComp(unittest.TestCase):
 
         dymos_options['include_check_partials'] = False
 
-    @unittest.skipIf(om_version()[0] >= (3, 36, 0) or om_version()[0] < (3, 37, 0),
+    @unittest.skipIf(om_version()[0] >= (3, 36, 0) and om_version()[0] < (3, 37, 0),
                      reason='Test skipped due to an issue in OpenMDAO 3.36.x')
     def test_integrate_with_controls(self):
 
         dymos_options['include_check_partials'] = True
 
-        gd = dm.transcriptions.grid_data.GridData(num_segments=5, transcription='gauss-lobatto',
-                                                  transcription_order=3, compressed=True)
+        gd = dm.GaussLobattoGrid(num_segments=5, nodes_per_seg=3, compressed=True)
 
         time_options = dm.phase.options.TimeOptionsDictionary()
 
@@ -165,14 +164,13 @@ class TestODEIntegrationComp(unittest.TestCase):
             cpd = p.check_partials(compact_print=False, method='fd')
             assert_check_partials(cpd, atol=1.0E-4, rtol=1.0E-4)
 
-    @unittest.skipIf(om_version()[0] >= (3, 36, 0) or om_version()[0] < (3, 37, 0),
+    @unittest.skipIf(om_version()[0] >= (3, 36, 0) and om_version()[0] < (3, 37, 0),
                      reason='Test skipped due to an issue in OpenMDAO 3.36.x')
     def test_integrate_with_polynomial_controls(self):
 
         dymos_options['include_check_partials'] = True
 
-        gd = dm.transcriptions.grid_data.GridData(num_segments=5, transcription='gauss-lobatto',
-                                                  transcription_order=3, compressed=True)
+        gd = dm.GaussLobattoGrid(num_segments=5, nodes_per_seg=3, compressed=True)
 
         time_options = dm.phase.options.TimeOptionsDictionary()
 

--- a/dymos/transcriptions/explicit_shooting/test/test_tau_comp.py
+++ b/dymos/transcriptions/explicit_shooting/test/test_tau_comp.py
@@ -12,8 +12,7 @@ from dymos.transcriptions.explicit_shooting.tau_comp import TauComp
 class TestTauComp(unittest.TestCase):
 
     def test_eval(self):
-        grid_data = dm.transcriptions.grid_data.GridData(num_segments=3, transcription='gauss-lobatto',
-                                                         transcription_order=3)
+        grid_data = dm.GaussLobattoGrid(num_segments=3, nodes_per_seg=3)
 
         p = om.Problem()
         tau_comp = p.model.add_subsystem('tau_comp', TauComp(grid_data=grid_data, time_units='s'))
@@ -39,8 +38,7 @@ class TestTauComp(unittest.TestCase):
         assert_check_partials(cpd)
 
     def test_eval_vectorized(self):
-        grid_data = dm.transcriptions.grid_data.GridData(num_segments=3, transcription='gauss-lobatto',
-                                                         transcription_order=3)
+        grid_data = dm.GaussLobattoGrid(num_segments=3, nodes_per_seg=3)
 
         p = om.Problem()
         tau_comp = p.model.add_subsystem('tau_comp', TauComp(vec_size=4, grid_data=grid_data, time_units='s'))

--- a/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_opt.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_opt.py
@@ -21,9 +21,9 @@ class TestCollocationComp(unittest.TestCase):
         dm.options['include_check_partials'] = True
         transcription = 'gauss-lobatto'
 
-        gd = GridData(
-            num_segments=4, segment_ends=np.array([0., 2., 4., 5., 12.]),
-            transcription=transcription, transcription_order=3)
+        gd = dm.GaussLobattoGrid(num_segments=4,
+                                 segment_ends=np.array([0., 2., 4., 5., 12.]),
+                                 nodes_per_seg=3)
 
         self.p = om.Problem(model=om.Group())
 

--- a/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_solver.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_solver.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 
 import openmdao.api as om
+from openmdao.utils.general_utils import env_truthy
 from openmdao.utils.testing_utils import use_tempdirs
 
 
@@ -11,6 +12,9 @@ from openmdao.utils.testing_utils import use_tempdirs
 import dymos as dm
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 from dymos.examples.brachistochrone.test.ex_brachistochrone import brachistochrone_min_time as brach
+
+
+_DYMOS_2 = env_truthy('DYMOS_2')
 
 
 @use_tempdirs
@@ -138,6 +142,7 @@ class TestCollocationBalanceIndex(unittest.TestCase):
         self.assertSetEqual(set(state_indeps_comp.state_idx_map['x']['solver']), {1, 2, 4, 5})
         self.assertSetEqual(set(state_indeps_comp.state_idx_map['x']['indep']), {0, 3})
 
+    @unittest.skipIf(_DYMOS_2, 'Test invalid for updated Radau transcription')
     def test_3_radau(self):
         """
         Test one 3rd order radau segment indices
@@ -157,6 +162,7 @@ class TestCollocationBalanceIndex(unittest.TestCase):
         self.assertSetEqual(set(state_indeps_comp.state_idx_map['x']['solver']), {1, 2, 3})
         self.assertSetEqual(set(state_indeps_comp.state_idx_map['x']['indep']), {0})
 
+    @unittest.skipIf(_DYMOS_2, 'Test invalid for updated Radau transcription')
     def test_5_radau(self):
         """
         Test one 5th order radau segment indices
@@ -176,6 +182,7 @@ class TestCollocationBalanceIndex(unittest.TestCase):
         self.assertSetEqual(set(state_indeps_comp.state_idx_map['x']['solver']), {1, 2, 3, 4, 5})
         self.assertSetEqual(set(state_indeps_comp.state_idx_map['x']['indep']), {0})
 
+    @unittest.skipIf(_DYMOS_2, 'Test invalid for updated Radau transcription')
     def test_3_radau_compressed(self):
         """
         Test one 3rd order radau segment indices
@@ -195,6 +202,7 @@ class TestCollocationBalanceIndex(unittest.TestCase):
         self.assertSetEqual(set(state_indeps_comp.state_idx_map['x']['solver']), {1, 2, 3, 4, 5, 6})
         self.assertSetEqual(set(state_indeps_comp.state_idx_map['x']['indep']), {0})
 
+    @unittest.skipIf(_DYMOS_2, 'Test invalid for updated Radau transcription')
     def test_5_radau_compressed(self):
         """
         Test two 5th order radau segment indices
@@ -214,6 +222,7 @@ class TestCollocationBalanceIndex(unittest.TestCase):
         self.assertSetEqual(set(state_indeps_comp.state_idx_map['x']['solver']), {1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
         self.assertSetEqual(set(state_indeps_comp.state_idx_map['x']['indep']), {0})
 
+    @unittest.skipIf(_DYMOS_2, 'Test invalid for updated Radau transcription')
     def test_3_radau_uncompressed(self):
         """
         Test one 3rd order radau segment indices
@@ -233,6 +242,7 @@ class TestCollocationBalanceIndex(unittest.TestCase):
         self.assertSetEqual(set(state_indeps_comp.state_idx_map['x']['solver']), {1, 2, 3, 5, 6, 7})
         self.assertSetEqual(set(state_indeps_comp.state_idx_map['x']['indep']), {0, 4})
 
+    @unittest.skipIf(_DYMOS_2, 'Test invalid for updated Radau transcription')
     def test_5_radau_uncompressed(self):
         """
         Test two 5th order radau segment indices
@@ -267,7 +277,7 @@ class TestCollocationBalanceApplyNL(unittest.TestCase):
             t = dm.GaussLobatto(num_segments=num_segments,
                                 order=transcription_order,
                                 compressed=compressed,)
-        elif transcription == 'radau-ps':
+        else:
             t = dm.Radau(num_segments=num_segments,
                          order=transcription_order,
                          compressed=compressed)
@@ -324,6 +334,7 @@ class TestCollocationBalanceApplyNL(unittest.TestCase):
         assert_almost_equal(resids['states:x'], expected)
         assert_almost_equal(resids['states:v'], expected)
 
+    @unittest.skipIf(_DYMOS_2, 'Test invalid for updated Radau transcription')
     def test_apply_nonlinear_radau(self):
         dm.options['include_check_partials'] = True
         p = self.make_prob(transcription='radau-ps', num_segments=3, transcription_order=3,
@@ -360,6 +371,7 @@ class TestCollocationBalanceApplyNL(unittest.TestCase):
         data = cpd['traj0.phases.phase0.indep_states']
         assert_partials(data)
 
+    @unittest.skipIf(_DYMOS_2, 'Test invalid for updated Radau transcription')
     def test_partials_radau(self):
         dm.options['include_check_partials'] = True
         p = self.make_prob(transcription='radau-ps', num_segments=3, transcription_order=3,

--- a/dymos/transcriptions/pseudospectral/gauss_lobatto.py
+++ b/dymos/transcriptions/pseudospectral/gauss_lobatto.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 
 import numpy as np
 import openmdao.api as om
@@ -9,7 +10,7 @@ from ...utils.misc import get_rate_units
 from ...utils.introspection import get_promoted_vars, get_targets, get_source_metadata
 from ...utils.indexing import get_src_indices_by_row
 from ...utils.ode_utils import _make_ode_system
-from ..grid_data import GridData, make_subset_map
+from ..grid_data import make_subset_map, GaussLobattoGrid
 
 
 class GaussLobatto(PseudospectralBase):
@@ -48,11 +49,15 @@ class GaussLobatto(PseudospectralBase):
         if np.any(self.options['order'] % 2 == 0):
             raise ValueError('A Gauss-Lobatto scheme must use an odd order for state interpolation.')
 
-        self.grid_data = GridData(num_segments=self.options['num_segments'],
-                                  transcription='gauss-lobatto',
-                                  transcription_order=self.options['order'],
-                                  segment_ends=self.options['segment_ends'],
-                                  compressed=self.options['compressed'])
+        self.grid_data = GaussLobattoGrid(num_segments=self.options['num_segments'],
+                                          nodes_per_seg=self.options['order'],
+                                          segment_ends=self.options['segment_ends'],
+                                          compressed=self.options['compressed'])
+
+    def _get_refinement_error_transcription(self):
+        new_tx = deepcopy(self)
+        new_tx.options['order'] = np.asarray(new_tx.options['order'], dtype=int) + 2
+        return new_tx
 
     def configure_time(self, phase):
         """

--- a/dymos/transcriptions/transcription_base.py
+++ b/dymos/transcriptions/transcription_base.py
@@ -32,7 +32,7 @@ class TranscriptionBase(object):
         self.options.declare('segment_ends', default=None, types=(Sequence, np.ndarray),
                              allow_none=True, desc='Locations of segment ends or None for equally '
                              'spaced segments')
-        self.options.declare('order', default=3, types=(int, Sequence, np.ndarray),
+        self.options.declare('order', default=3, types=(int, np.integer, Sequence, np.ndarray),
                              desc='Order of the state transcription. The order of the control '
                                   'transcription is `order - 1`.')
         self.options.declare('compressed', default=True, types=bool,
@@ -69,6 +69,13 @@ class TranscriptionBase(object):
         Setup the GridData object for the Transcription.
         """
         raise NotImplementedError(f'Transcription {self.__class__.__name__} does not implement method init_grid.')
+
+    def _get_refinement_error_transcription(self):
+        """
+        Create a new transcriptoin instance to be used for error estimation.
+        This is usually a matter of increasing the order (number of nodes per segment).
+        """
+        raise NotImplementedError(f'{self.__class__.__name__} does not implement _get_refinement_error_transcription.')
 
     def setup_time(self, phase):
         """
@@ -799,3 +806,21 @@ class TranscriptionBase(object):
         """
         raise NotImplementedError(f'Transcription {self.__class__.__name__} does not implement method '
                                   '_get_num_timeseries_nodes.')
+
+    def _get_linkage_source_ode(self, promoted=False):
+        """
+        Returns the path of the ODE system providing sources for linkage constraints.
+
+        Nominally this is the _rhs_source but will need to be overridden in transcriptions
+        with boundary ODEs or ODEs that are in a promoted path.
+
+        Parameters
+        ----------
+        promoted : bool
+            If True, return the promoted name of the system from the context of the Phase.
+            Otherwise, return the full path of the system from the context of the Phase.
+        """
+        if promoted:
+            return self._rhs_source.split('.')[-1]
+        else:
+            return self._rhs_source


### PR DESCRIPTION
### Summary

Some preliminary work for the new Radau transcription.

This is mostly tests that have changed without any dependence on the infrastructure for the new radau method.

There are a few changes to the control interpolation component for better derivatives, and some new utility functions that will be used by the new transcription.
Transcriptions now invoke their own specific grid implementations, and GridData is used as a base class.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
