### PR TITLE
Removed unncessary internal unit conversion from Timeseries and Interleave components.

### DIFF
--- a/dymos/transcriptions/pseudospectral/components/gauss_lobatto_interleave_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/gauss_lobatto_interleave_comp.py
@@ -1,6 +1,5 @@
 import numpy as np
 import openmdao.api as om
-from openmdao.utils.units import unit_conversion
 
 from ...grid_data import GridData
 from ...._options import options as dymos_options
@@ -33,11 +32,6 @@ class GaussLobattoInterleaveComp(om.ExplicitComponent):
         # the corresponding input variable.  This is used to ensure that we don't need to connect
         # the same source to this timeseries multiple times.
         self._sources = {'state_disc': {}, 'col': {}}
-
-        # Used to track conversion factors for instances when one output that relies on an input
-        # from another variable has potentially different units
-        self._units = {}
-        self._conversion_factors = {}
 
     def add_var(self, name, shape, units, disc_src, col_src):
         """
@@ -86,7 +80,6 @@ class GaussLobattoInterleaveComp(om.ExplicitComponent):
         if disc_src in self._sources['state_disc']:
             self._varnames[name]['state_disc'] = self._sources['state_disc'][disc_src]
             self._varnames[name]['col'] = self._sources['col'][col_src]
-            input_units = self._units[self._varnames[name]['state_disc']]
         else:
             self.add_input(
                 name=self._varnames[name]['state_disc'],
@@ -100,7 +93,6 @@ class GaussLobattoInterleaveComp(om.ExplicitComponent):
                 units=units)
             self._sources['state_disc'][disc_src] = self._varnames[name]['state_disc']
             self._sources['col'][col_src] = self._varnames[name]['col']
-            input_units = self._units[self._varnames[name]['state_disc']] = units
             added_source = True
 
         self.add_output(
@@ -113,18 +105,9 @@ class GaussLobattoInterleaveComp(om.ExplicitComponent):
         r = (start_rows[:, np.newaxis] + np.arange(size, dtype=int)).ravel()
         c = np.arange(size * num_disc_nodes, dtype=int)
 
-        # There's a chance that the input for this output was pulled from another variable with
-        # different units, so account for that with a conversion.
-        if input_units is None or units is None:
-            scale = 1.0
-            offset = 0
-        else:
-            scale, offset = unit_conversion(input_units, units)
-        self._conversion_factors[self._varnames[name]['all']] = scale, offset
-
         self.declare_partials(of=self._varnames[name]['all'],
                               wrt=self._varnames[name]['state_disc'],
-                              rows=r, cols=c, val=scale)
+                              rows=r, cols=c, val=1.0)
 
         start_rows = self.options['grid_data'].subset_node_indices['col'] * size
         r = (start_rows[:, np.newaxis] + np.arange(size, dtype=int)).ravel()
@@ -132,7 +115,7 @@ class GaussLobattoInterleaveComp(om.ExplicitComponent):
 
         self.declare_partials(of=self._varnames[name]['all'],
                               wrt=self._varnames[name]['col'],
-                              rows=r, cols=c, val=scale)
+                              rows=r, cols=c, val=1.0)
 
         return added_source
 
@@ -151,8 +134,5 @@ class GaussLobattoInterleaveComp(om.ExplicitComponent):
         col_idxs = self.options['grid_data'].subset_node_indices['col']
 
         for name, varnames in self._varnames.items():
-            scale, offset = self._conversion_factors[self._varnames[name]['all']]
             outputs[varnames['all']][disc_idxs] = inputs[varnames['state_disc']]
             outputs[varnames['all']][col_idxs] = inputs[varnames['col']]
-            outputs[varnames['all']] *= scale
-            outputs[varnames['all']] += offset


### PR DESCRIPTION
### Summary

Some dymos components were doing internal unit conversion unnecessarily in some cases.
It is now removed.

### Related Issues

- Resolves #972 

### Backwards incompatibilities

None

### New Dependencies

None
