### PR TITLE
`add_calc_expr` can now promote variable names.

### DIFF
--- a/docs/dymos_book/features/phases/calc_expressions.ipynb
+++ b/docs/dymos_book/features/phases/calc_expressions.ipynb
@@ -74,6 +74,15 @@
     "\n",
     "If you're not certain of the units of an input variable upon which your calculation relies, you should explicitly provide it via keyword arguments to the `add_calc_expr` call (or one of the associated calls that accepts calculation expressions, mentioned above).\n",
     "\n",
+    "## Variable Name Promotion\n",
+    "\n",
+    "By default, the inputs and outputs of the calculation expressions will be promoted to the top level\n",
+    "of your ODE. In some cases, names of your ODE variables may include colons and thus not be valid variable names for an ExecComp.\n",
+    "\n",
+    "To connect such ODE variable names to your calculation expression, you can promote them by providing a `promote_as` field in the the keyword arguments. Note that this is different from the way things are handled in OpenMDAO.\n",
+    "\n",
+    "In the example below, we promote the valid `ExecComp` variable `k` to a variable name that may not be used in an ExecComp due to the use of a colon: `brachistochrone:check`.\n",
+    "\n",
     "## Example - Adding an additional calculation to the brachistochrone\n",
     "\n",
     "Let's assume that we have a brachistochrone ODE that was provided to us, but for configuration control reasons, we might not want to edit the source code.\n",
@@ -81,7 +90,7 @@
     "Here we're adding a calculation expression for the additional output k, which is the ratio\n",
     "\n",
     "\\begin{align}\n",
-    "    k &= \\frac{sin(\\{theta})}{v}\n",
+    "    k &= \\frac{sin(\\theta)}{v}\n",
     "\\end{align}\n",
     "\n",
     "In the brachistochrone solution, $k$ is approximately constant, and its value is dependent upon the start and end point of the trajectory, as well as the gravitational parameter. In practice, it's value is somewhat large at the start since we're starting with nearly zero velocity."
@@ -123,7 +132,8 @@
     "\n",
     "phase.add_parameter('g', units='m/s**2', opt=False, val=9.80665)\n",
     "\n",
-    "phase.add_calc_expr('k = sin(theta) / v', theta={'units': 'rad'}, v={'units': 'm/s'})\n",
+    "phase.add_calc_expr('k = sin(theta) / v', theta={'units': 'rad'}, v={'units': 'm/s'},\n",
+    "                    k={'promote_as': 'brachistochrone:check'})\n",
     "\n",
     "# Minimize time at the end of the phase\n",
     "phase.add_objective('time', loc='final', scaler=1)\n",
@@ -183,7 +193,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -1754,15 +1754,21 @@ class Phase(om.Group):
             self._calc_exprs[expr] = kwargs
 
         output_name = expr.split('=')[0].strip()
+
+        if output_name in kwargs and 'promote_as' in kwargs[output_name]:
+            prom_output_name = kwargs[output_name]['promote_as']
+        else:
+            prom_output_name = output_name
+
         if add_timeseries and output_name not in self._timeseries['timeseries']['outputs']:
             output = expr.split('=')[0].strip()
             if 'units' in kwargs:
                 units = kwargs['units']
             elif output in kwargs:
-                units = kwargs[output]['units']
+                units = kwargs[output].get('units', None)
             else:
                 units = None
-            self.add_timeseries_output(output_name, units=units)
+            self.add_timeseries_output(prom_output_name, units=units)
 
     def set_time_options(self, units=_unspecified, fix_initial=_unspecified,
                          fix_duration=_unspecified, input_initial=_unspecified,

--- a/dymos/utils/introspection.py
+++ b/dymos/utils/introspection.py
@@ -266,7 +266,10 @@ def configure_parameters_introspection(parameter_options, ode):
                              f"targets is tagged with 'dymos.static_target':\n{static_tagged_targets}")
 
         if is_unspecified(options['units']):
-            options['units'] = _get_common_metadata(targets, metadata_key='units')
+            try:
+                options['units'] = _get_common_metadata(targets, metadata_key='units')
+            except RuntimeError:
+                raise RuntimeError(f'{ode.msginfo}: Unable to find units for parameter {name}')
 
         # Check that all targets have the same shape.
         tgt_shapes = {}

--- a/dymos/utils/introspection.py
+++ b/dymos/utils/introspection.py
@@ -266,10 +266,7 @@ def configure_parameters_introspection(parameter_options, ode):
                              f"targets is tagged with 'dymos.static_target':\n{static_tagged_targets}")
 
         if is_unspecified(options['units']):
-            try:
-                options['units'] = _get_common_metadata(targets, metadata_key='units')
-            except RuntimeError:
-                raise RuntimeError(f'{ode.msginfo}: Unable to find units for parameter {name}')
+            options['units'] = _get_common_metadata(targets, metadata_key='units')
 
         # Check that all targets have the same shape.
         tgt_shapes = {}

--- a/dymos/utils/ode_utils.py
+++ b/dymos/utils/ode_utils.py
@@ -256,6 +256,7 @@ class ODEGroup(om.Group):
                 prom_kwargs['src_indices'] = np.zeros(num_nodes, dtype=int)
             self.promotes('exec_comp', **prom_kwargs)
 
+
 def _make_ode_system(ode_class, num_nodes, ode_init_kwargs=None, calc_exprs=None, parameter_options=None):
     """
     Instantiate the ODE system, optionally including an ExecComp.

--- a/dymos/utils/ode_utils.py
+++ b/dymos/utils/ode_utils.py
@@ -170,7 +170,7 @@ class ODEGroup(om.Group):
 
         self.add_subsystem('user_ode', ode, promotes_inputs=['*'], promotes_outputs=['*'])
         ec = om.ExecComp()
-        self.add_subsystem('exec_comp', ec, promotes_inputs=['*'], promotes_outputs=['*'])
+        self.add_subsystem('exec_comp', ec)
 
     def configure(self):
         """
@@ -181,6 +181,8 @@ class ODEGroup(om.Group):
         seen_kwargs = set()
         parser = ExprParser()
         ec = self._get_subsystem('exec_comp')
+
+        promotes = {}
 
         for expr, expr_kwargs in self._calc_exprs.items():
             common_units = _unspecified
@@ -208,6 +210,10 @@ class ODEGroup(om.Group):
                 if common_units is not _unspecified:
                     _expr_kwargs[output_var]['units'] = common_units
 
+            promotes[output_var] = {'promote_as': output_var}
+            if 'promote_as' in _expr_kwargs[output_var]:
+                promotes[output_var]['promote_as'] = _expr_kwargs[output_var].pop('promote_as')
+
             scalar_src_idxs = []
             param_options = self._parameter_options or {}
             scalar_sources = list(param_options.keys()) + ['t_initial', 't_duration', 't_final']
@@ -230,15 +236,25 @@ class ODEGroup(om.Group):
                     else:
                         _expr_kwargs[exec_var_name]['shape'] = (num_nodes,) + _expr_kwargs[exec_var_name]['shape']
 
+                    promotes[exec_var_name] = {'promote_as': _expr_kwargs[exec_var_name].get('promote_as', exec_var_name),
+                                               'scalar_src_idxs': False}
+                    if 'promote_as' in _expr_kwargs[exec_var_name]:
+                        _expr_kwargs[exec_var_name].pop('promote_as')
+
                     if exec_var_name in scalar_sources:
                         scalar_src_idxs.append(exec_var_name)
+                        promotes[exec_var_name]['scalar_src_idxs'] = True
 
             seen_kwargs |= _expr_kwargs.keys()
-            ec.add_expr(expr, **_expr_kwargs)
-            if scalar_src_idxs:
-                self.promotes('exec_comp', inputs=scalar_src_idxs,
-                              src_indices=np.zeros(num_nodes, dtype=int))
 
+            ec.add_expr(expr, **_expr_kwargs)
+
+        for var, meta in promotes.items():
+            prom_as = [(var, meta['promote_as'])]
+            prom_kwargs = {'any': prom_as}
+            if meta.get('scalar_src_idxs', False):
+                prom_kwargs['src_indices'] = np.zeros(num_nodes, dtype=int)
+            self.promotes('exec_comp', **prom_kwargs)
 
 def _make_ode_system(ode_class, num_nodes, ode_init_kwargs=None, calc_exprs=None, parameter_options=None):
     """


### PR DESCRIPTION
### Summary

Allow `promote_as` as an option in variable metadata that can be used to specify the external name of a variable used in a calculation expression.

### Related Issues

- Resolves #1203 

### Backwards incompatibilities

None

### New Dependencies

None
