### PR TITLE
Added ability to automatically create parameters for unconnected ODE inputs.

### DIFF
--- a/dymos/phase/phase.py
+++ b/dymos/phase/phase.py
@@ -25,7 +25,7 @@ from ..transcriptions import ExplicitShooting, GaussLobatto, Radau
 from ..utils.indexing import get_constraint_flat_idxs
 from ..utils.introspection import configure_time_introspection, _configure_constraint_introspection, \
     configure_controls_introspection, configure_parameters_introspection, \
-    configure_timeseries_output_introspection, classify_var
+    configure_timeseries_output_introspection, classify_var, auto_add_parameters
 from ..utils.misc import _unspecified, create_subprob
 from ..utils.lgl import lgl
 
@@ -198,6 +198,8 @@ class Phase(om.Group):
                              desc='Options for each control in this phase.')
         self.options.declare('boundary_balance_options', types=dict, default={},
                              desc='Options specifying boundary conditions to be satisfied with a solver.')
+        self.options.declare('auto_add_parameters', types=bool, default=True,
+                             desc='If True, add any otherwise-unconnected ODE inputs add non-optimal parameters.')
 
     @property
     def time_options(self):
@@ -2268,6 +2270,9 @@ class Phase(om.Group):
         # If this phase exists within a Trajectory, the trajectory will finalize them during setup.
         transcription = self.options['transcription']
         ode = transcription._get_ode(self)
+
+        if self.options['auto_add_parameters']:
+            auto_add_parameters(ode, self)
 
         configure_time_introspection(self.time_options, ode)
 

--- a/dymos/utils/introspection.py
+++ b/dymos/utils/introspection.py
@@ -200,7 +200,15 @@ def auto_add_parameters(ode, phase):
     # Add the remaining unconnected inputs as parameters
     for inp in unconn_inputs:
         if '.' in inp:
-            name = inp.split('.')[-1]
+            # Handle parameters nested in the ODE
+            parts = inp.split('.')
+            # Handle duplicate names at different branches of the ODE
+            for i in range(-1, -len(parts), -1):
+                name = '_'.join(inp.split('.')[i:])
+                if name not in phase.parameter_options:
+                    break
+            else:
+                name = '_'.join(parts)
             phase.add_parameter(name, opt=False, targets=[inp])
         else:
             phase.add_parameter(inp, opt=False)


### PR DESCRIPTION
### Summary

Added new option to Phase: `auto_add_parameters`

This currently defaults to `False` as it is still experimental.

If it is True, then Dymos will determine those inputs in the ODE that are not otherwise connected via promotion or manual connections, and create corresponding parameters for them.

If an unconnected input is not promoted to the top of the ODE, the corresponding parameter name will just be the name of the variable itself. For example, a variable at a path `'aircraft.wing.mass'` within the ODE hierarchy will just have the parameter name `'mass'`.

If two variables within the ODE share the same local name, dymos will work backwards through the dotted path and replace dots with underscores, until a unique name is found.

For instance, if the ODE contained paths: `'aircraft.wing.mass'` and `'aircraft.landing_gear.mass'`, the added parameters would have names `'wing_mass'` and `'landing_gear_mass'`, respectively.

### Related Issues

- Resolves #878 

### Backwards incompatibilities

None

### New Dependencies

None
