### PR TITLE
Picard shooting initial and final state values bugfix

### DIFF
--- a/dymos/transcriptions/picard_shooting/multiple_shooting_iter_group.py
+++ b/dymos/transcriptions/picard_shooting/multiple_shooting_iter_group.py
@@ -124,8 +124,8 @@ class MultipleShootingIterGroup(om.Group):
             else:
                 self.connect(f'seg_final_states:{state_name}',
                              f'picard_update_comp.seg_final_states:{state_name}')
-                if not fix_initial and not input_initial:
-                    self.add_design_var(name=f'initial_states:{state_name}',
+                if not fix_final and not input_final:
+                    self.add_design_var(name=f'final_states:{state_name}',
                                         lower=fb[0],
                                         upper=fb[1],
                                         scaler=scaler,


### PR DESCRIPTION
### Summary

Currently initial_states:{} and final_states:{} are not added as design variables even when they are not fixed or set as inputs. This produces problems that are infeasible. This PR fixes that by adding them as design variables when appropriate.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
