### PR TITLE
Bump version to 1.15.2-dev for next dev cycle.

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "1.15.1"
+current_version = "1.15.2-dev"
 commit = true
 tag = false
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\-(?P<release>[a-z]+))?"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,7 @@ body:
     attributes:
       label: Dymos Version
       description: What version of Dymos is being used.
-      placeholder: "1.15.1"
+      placeholder: "1.15.2-dev"
     validations:
       required: true
   - type: textarea

--- a/dymos/__init__.py
+++ b/dymos/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.15.1'
+__version__ = '1.15.2-dev'
 
 
 from openmdao.utils.general_utils import env_truthy as _env_truthy


### PR DESCRIPTION
### Summary

None

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
