### PR TITLE
Use OPENMDAO_CHECK_ALL_PARTIALS instead of dymos option for testing library partials.

### DIFF
--- a/dymos/_options.py
+++ b/dymos/_options.py
@@ -16,7 +16,9 @@ def _removed_option(name, value):
 
 
 options.declare('include_check_partials', default=_icp_default, types=bool,
-                desc='If True, include dymos components when checking partials.')
+                desc='If True, include dymos components when checking partials.',
+                deprecation='Option `include_check_partials is deprecated. '
+                'Use OPENMDAO_CHECK_ALL_PARTIALS to enable checking of all dymos component partials.')
 
 options.declare('plots', default='bokeh', values=['matplotlib', 'bokeh'],
                 desc='The plot library used to generate output plots for Dymos.')

--- a/dymos/examples/battery_multibranch/test/test_multibranch_trajectory.py
+++ b/dymos/examples/battery_multibranch/test/test_multibranch_trajectory.py
@@ -17,11 +17,6 @@ optimizer = os.environ.get('DYMOS_DEFAULT_OPT', 'SLSQP')
 
 @use_tempdirs
 class TestBatteryBranchingPhases(unittest.TestCase):
-    def setUp(self):
-        dm.options['include_check_partials'] = True
-
-    def tearDown(self):
-        dm.options['include_check_partials'] = False
 
     @require_pyoptsparse(optimizer='SLSQP')
     def test_optimizer_defects(self):

--- a/dymos/examples/brachistochrone/test/ex_brachistochrone.py
+++ b/dymos/examples/brachistochrone/test/ex_brachistochrone.py
@@ -125,7 +125,6 @@ def brachistochrone_min_time(transcription='gauss-lobatto', num_segments=8, tran
 
 if __name__ == '__main__':
 
-    with dm.options.temporary(include_check_partials=True):
-        p = brachistochrone_min_time(transcription='birkhoff', num_segments=1, run_driver=True,
-                                     transcription_order=19, compressed=False, optimizer='SLSQP',
-                                     solve_segments=False, force_alloc_complex=True)
+    p = brachistochrone_min_time(transcription='birkhoff', num_segments=1, run_driver=True,
+                                    transcription_order=19, compressed=False, optimizer='SLSQP',
+                                    solve_segments=False, force_alloc_complex=True)

--- a/dymos/examples/brachistochrone/test/test_ex_brachistochrone.py
+++ b/dymos/examples/brachistochrone/test/test_ex_brachistochrone.py
@@ -112,13 +112,12 @@ class TestBrachistochroneExample(unittest.TestCase):
 
     def test_ex_brachistochrone_shooting_radau_uncompressed(self):
         import dymos
-        with dymos.options.temporary(include_check_partials=True):
-            ex_brachistochrone.SHOW_PLOTS = True
-            p = ex_brachistochrone.brachistochrone_min_time(transcription='shooting-radau',
-                                                            optimizer='IPOPT',
-                                                            compressed=False)
-            self.run_asserts(p)
-            self.tearDown()
+        ex_brachistochrone.SHOW_PLOTS = True
+        p = ex_brachistochrone.brachistochrone_min_time(transcription='shooting-radau',
+                                                        optimizer='IPOPT',
+                                                        compressed=False)
+        self.run_asserts(p)
+        self.tearDown()
 
 
 if __name__ == '__main__':

--- a/dymos/examples/moon_landing/test/test_moon_landing_problem.py
+++ b/dymos/examples/moon_landing/test/test_moon_landing_problem.py
@@ -4,7 +4,7 @@ import dymos as dm
 import unittest
 
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse, set_env_vars_context
 from dymos.examples.moon_landing import MoonLandingProblemODE
 
 
@@ -52,13 +52,13 @@ class TestMoonLandingProblem(unittest.TestCase):
 
     def test_problem_lgl(self):
 
-        with dm.options.temporary(include_check_partials=True):
+        with set_env_vars_context(OPENMDAO_CHECK_ALL_PARTIALS='1'):
             self.make_problem(grid_type='lgl')
             dm.run_problem(self.p, simulate=True, simulate_kwargs={'times_per_seg': 100},
                            make_plots=True)
 
             with np.printoptions(linewidth=1024):
-                self.p.check_partials(compact_print=True, method='cs')
+                self.p.check_partials(compact_print=True, method='cs', out_stream=None)
 
         h = self.p.get_val('traj.phase.timeseries.h')
         v = self.p.get_val('traj.phase.timeseries.v')

--- a/dymos/models/eom/test/test_flight_path_eom_2d.py
+++ b/dymos/models/eom/test/test_flight_path_eom_2d.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse, set_env_vars_context
 from dymos.utils.testing_utils import assert_check_partials
 
 import dymos as dm
@@ -105,8 +105,8 @@ class TestFlightPathEOM2D(unittest.TestCase):
         self.p.run_driver()
 
         with np.printoptions(linewidth=1024):
-            dm.options['include_check_partials'] = True
-            self.p.check_partials(method='cs')
+            with set_env_vars_context(OPENMDAO_CHECK_ALL_PARTIALS='1'):
+                self.p.check_partials(method='cs')
 
         exp_out = phase.simulate(times_per_seg=None)
 

--- a/dymos/test/test_check_partials.py
+++ b/dymos/test/test_check_partials.py
@@ -367,14 +367,12 @@ class TestCheckPartials(unittest.TestCase):
 
         return cpd
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_check_partials_yes(self):
         """
         Run check_partials on a series of dymos problems and verify that partials information
         is displayed for core Dymos components when DYMOS_CHECK_PARTIALS == 'True'.
         """
-        cp_save = dm.options['include_check_partials']
-        dm.options['include_check_partials'] = True
-
         cases = [self.brach_explicit_partials,
                  self.balanced_field_partials_radau,
                  self.min_time_climb_partials_gl]
@@ -383,27 +381,25 @@ class TestCheckPartials(unittest.TestCase):
         for c in cases:
             partials.update(c())
 
-        dm.options['include_check_partials'] = cp_save
-
         assert len(partials.keys()) > 0
 
-    @set_env_vars(CI='0')  # Make sure _no_check_partials isn't disabled
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='0')
     def test_check_partials_no(self):
         """
         Run check_partials on a series of dymos problems and verify that partials information
         is not displayed for core Dymos components when DYMOS_CHECK_PARTIALS == 'False'.
         """
-        with dm.options.temporary(include_check_partials=False):
-            cases = [self.brach_explicit_partials,
-                     self.balanced_field_partials_radau,
-                     self.min_time_climb_partials_gl]
+        cases = [self.brach_explicit_partials,
+                 self.balanced_field_partials_radau,
+                 self.min_time_climb_partials_gl]
 
-            partials = {}
-            for c in cases:
-                partials.update(c())
+        partials = {}
+        for c in cases:
+            partials.update(c())
 
-            for pathname in set(partials.keys()):
-                self.assertTrue('ode' in pathname or 'rhs' in pathname)
+        for pathname in set(partials.keys()):
+            print(pathname)
+            self.assertTrue('ode' in pathname or 'rhs' in pathname)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/test/test_options.py
+++ b/dymos/test/test_options.py
@@ -9,9 +9,8 @@ from dymos.examples.brachistochrone.test.ex_brachistochrone import brachistochro
 @use_tempdirs
 class TestOptions(unittest.TestCase):
 
-    @set_env_vars(CI='0')
+    @set_env_vars(CI='0', OPENMDAO_CHECK_ALL_PARTIALS='0')
     def test_include_check_partials_false_radau(self):
-        dm.options['include_check_partials'] = False
         p = brachistochrone_min_time(transcription='radau-ps', compressed=False,
                                      run_driver=False, force_alloc_complex=True)
         cpd = p.check_partials(out_stream=None)
@@ -21,24 +20,23 @@ class TestOptions(unittest.TestCase):
         else:
             self.assertSetEqual(set(cpd.keys()), {'traj0.phases.phase0.rhs_all'})
 
-    @set_env_vars(CI='0')
+    @set_env_vars(CI='0', OPENMDAO_CHECK_ALL_PARTIALS='0')
     def test_include_check_partials_false_gl(self):
-        dm.options['include_check_partials'] = False
         p = brachistochrone_min_time(transcription='gauss-lobatto', compressed=False,
                                      run_driver=False, force_alloc_complex=True)
         cpd = p.check_partials(out_stream=None, method='fd')
         self.assertSetEqual(set(cpd.keys()), {'traj0.phases.phase0.rhs_disc',
                                               'traj0.phases.phase0.rhs_col'})
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_include_check_partials_true_radau(self):
-        dm.options['include_check_partials'] = True
         p = brachistochrone_min_time(transcription='radau-ps', compressed=False,
                                      run_driver=False, force_alloc_complex=True)
         cpd = p.check_partials(out_stream=None, method='fd')
         self.assertTrue(len(list(cpd.keys())) > 1)
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_include_check_partials_true_gl(self):
-        dm.options['include_check_partials'] = True
         p = brachistochrone_min_time(transcription='gauss-lobatto', compressed=False,
                                      run_driver=False, force_alloc_complex=True)
         cpd = p.check_partials(out_stream=None, method='fd')

--- a/dymos/trajectory/phase_linkage_comp.py
+++ b/dymos/trajectory/phase_linkage_comp.py
@@ -2,7 +2,6 @@ import numpy as np
 
 import openmdao.api as om
 
-from .._options import options as dymos_options
 from ..utils.misc import _unspecified
 
 
@@ -25,7 +24,7 @@ class PhaseLinkageComp(om.ExplicitComponent):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/dymos/trajectory/test/test_link_phases.py
+++ b/dymos/trajectory/test/test_link_phases.py
@@ -32,7 +32,6 @@ class TestPhaseLinkageComp(unittest.TestCase):
 
     @staticmethod
     def make_problem(link_all_vars=False, connected=True):
-        dm.options['include_check_partials'] = True
         p = om.Problem(model=om.Group())
         p.driver = om.ScipyOptimizeDriver()
         p.driver.options['optimizer'] = 'SLSQP'

--- a/dymos/trajectory/test/test_phase_linkage_comp.py
+++ b/dymos/trajectory/test/test_phase_linkage_comp.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 
 import openmdao.api as om
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, set_env_vars
 
 import dymos as dm
 from dymos.trajectory.phase_linkage_comp import PhaseLinkageComp
@@ -16,7 +16,6 @@ from dymos.utils.testing_utils import assert_check_partials
 class TestPhaseLinkageComp(unittest.TestCase):
 
     def setUp(self):
-        dm.options['include_check_partials'] = True
         self.p = om.Problem(model=om.Group())
 
         ivp = self.p.model.add_subsystem('ivc', subsys=om.IndepVarComp(), promotes_outputs=['*'])
@@ -103,9 +102,6 @@ class TestPhaseLinkageComp(unittest.TestCase):
 
         self.p.run_model()
 
-    def tearDown(self):
-        dm.options['include_check_partials'] = False
-
     def test_results(self):
 
         assert_almost_equal(-self.p['phase1:x'][0, ...] + self.p['phase0:x'][-1, ...],
@@ -117,6 +113,7 @@ class TestPhaseLinkageComp(unittest.TestCase):
         assert_almost_equal(-self.p['phase1:v'][0, ...] + self.p['phase0:v'][-1, ...],
                             self.p['linkage_comp.phase0:v_final|phase1:v_initial'])
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_partials(self):
         cpd = self.p.check_partials(out_stream=None)
         assert_check_partials(cpd)

--- a/dymos/transcriptions/common/continuity_comp.py
+++ b/dymos/transcriptions/common/continuity_comp.py
@@ -3,7 +3,6 @@ import openmdao.api as om
 
 from ..grid_data import GridData
 from ...utils.misc import get_rate_units
-from ..._options import options as dymos_options
 
 
 class ContinuityCompBase(om.ExplicitComponent):
@@ -18,7 +17,7 @@ class ContinuityCompBase(om.ExplicitComponent):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/dymos/transcriptions/common/control_comp.py
+++ b/dymos/transcriptions/common/control_comp.py
@@ -12,7 +12,6 @@ from dymos.utils.misc import get_rate_units, CoerceDesvar, reshape_val
 from dymos.utils.lgl import lgl
 from dymos.utils.lagrange import lagrange_matrices
 from dymos.utils.indexing import get_desvar_indices
-from dymos._options import options as dymos_options
 
 
 class ControlInterpComp(om.ExplicitComponent):
@@ -52,7 +51,7 @@ class ControlInterpComp(om.ExplicitComponent):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/dymos/transcriptions/common/parameter_comp.py
+++ b/dymos/transcriptions/common/parameter_comp.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from openmdao.core.explicitcomponent import ExplicitComponent
 from dymos.utils.misc import is_none_or_unspecified
-from dymos._options import options as dymos_options
 
 
 class ParameterComp(ExplicitComponent):
@@ -34,7 +33,7 @@ class ParameterComp(ExplicitComponent):
         super().__init__(**kwargs)
         self.time_options = time_options
 
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def setup(self):
         """

--- a/dymos/transcriptions/common/test/test_continuity_comp.py
+++ b/dymos/transcriptions/common/test/test_continuity_comp.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, set_env_vars
 
 import dymos as dm
 from dymos.transcriptions.grid_data import GridData
@@ -26,11 +26,11 @@ params_list = itertools.product(['gauss-lobatto', 'radau-ps'],  # transcription
 @use_tempdirs
 class TestContinuityComp(unittest.TestCase):
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_continuity_comp(self):
         for transcription, compressed in params_list:
             with self.subTest():
 
-                dm.options['include_check_partials'] = True
                 num_seg = 3
 
                 if transcription == 'gauss-lobatto':

--- a/dymos/transcriptions/common/test/test_control_interp_comp.py
+++ b/dymos/transcriptions/common/test/test_control_interp_comp.py
@@ -4,6 +4,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal
 import openmdao.api as om
+from openmdao.utils.testing_utils import set_env_vars
 from dymos.utils.testing_utils import assert_check_partials
 
 import dymos as dm
@@ -71,12 +72,7 @@ def f2_d(t):
 
 class TestControlRateComp(unittest.TestCase):
 
-    def setUp(self):
-        dm.options['include_check_partials'] = True
-
-    def tearDown(self):
-        dm.options['include_check_partials'] = False
-
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_control_interp_scalar(self):
         param_list = itertools.product(['gauss-lobatto', 'radau-ps'],  # transcription
                                        [False, True],  # compressed
@@ -250,6 +246,7 @@ class TestControlRateComp(unittest.TestCase):
                                        out_stream=None)
                 assert_check_partials(cpd)
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_control_interp_scalar_10_seg(self):
         param_list = itertools.product(['gauss-lobatto', 'radau-ps'],  # transcription
                                        [False, True],  # compressed
@@ -423,6 +420,7 @@ class TestControlRateComp(unittest.TestCase):
                                        out_stream=None)
                 assert_check_partials(cpd)
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_control_interp_vector(self, transcription='gauss-lobatto', compressed=True):
         param_list = itertools.product(['gauss-lobatto', 'radau-ps'],  # transcription
                                        [True, False],  # compressed
@@ -574,6 +572,7 @@ class TestControlRateComp(unittest.TestCase):
 
                 assert_check_partials(cpd)
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_control_interp_matrix_3x1(self, transcription='gauss-lobatto', compressed=True):
         param_list = itertools.product(['gauss-lobatto', 'radau-ps'],  # transcription
                                        [True, False],  # compressed
@@ -684,6 +683,7 @@ class TestControlRateComp(unittest.TestCase):
 
                 assert_check_partials(cpd)
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_control_interp_matrix_2x2(self):
         param_list = itertools.product(['gauss-lobatto', 'radau-ps'],  # transcription
                                        [True, False],  # compressed

--- a/dymos/transcriptions/common/time_comp.py
+++ b/dymos/transcriptions/common/time_comp.py
@@ -2,8 +2,6 @@ import numpy as np
 
 import openmdao.api as om
 
-from ..._options import options as dymos_options
-
 
 class TimeComp(om.ExplicitComponent):
     """
@@ -17,7 +15,7 @@ class TimeComp(om.ExplicitComponent):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/dymos/transcriptions/common/timeseries_output_comp.py
+++ b/dymos/transcriptions/common/timeseries_output_comp.py
@@ -3,7 +3,6 @@ import openmdao.api as om
 from scipy import sparse as sp
 
 from ...transcriptions.grid_data import GridData
-from ..._options import options as dymos_options
 from ...utils.lagrange import lagrange_matrices
 
 
@@ -20,7 +19,7 @@ class TimeseriesOutputComp(om.ExplicitComponent):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
         # _vars keeps track of the name of each output and maps to its metadata;
         # a tuple of (input_name, name, shape, rate)

--- a/dymos/transcriptions/explicit_shooting/ode_integration_comp.py
+++ b/dymos/transcriptions/explicit_shooting/ode_integration_comp.py
@@ -3,7 +3,6 @@ from scipy.integrate import solve_ivp
 
 import openmdao.api as om
 
-from ..._options import options as dymos_options
 
 from .ode_evaluation_group import ODEEvaluationGroup
 from dymos.utils.misc import create_subprob
@@ -75,7 +74,7 @@ class ODEIntegrationComp(om.ExplicitComponent):
         self._totals_of_names = []
         self._totals_wrt_names = []
 
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
         self._num_control_input_nodes = input_grid_data.subset_num_nodes['control_input']
 
         self._calc_exprs = {} if calc_exprs is None else calc_exprs

--- a/dymos/transcriptions/explicit_shooting/state_rate_collector_comp.py
+++ b/dymos/transcriptions/explicit_shooting/state_rate_collector_comp.py
@@ -3,7 +3,6 @@ import numpy as np
 import openmdao.api as om
 
 from dymos.utils.misc import get_rate_units
-from ..._options import options as dymos_options
 
 
 class StateRateCollectorComp(om.ExplicitComponent):
@@ -29,7 +28,7 @@ class StateRateCollectorComp(om.ExplicitComponent):
 
         self._vec_size = vec_size
 
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/dymos/transcriptions/explicit_shooting/tau_comp.py
+++ b/dymos/transcriptions/explicit_shooting/tau_comp.py
@@ -2,8 +2,6 @@ import numpy as np
 
 import openmdao.api as om
 
-from ..._options import options as dymos_options
-
 
 class TauComp(om.ExplicitComponent):
     """
@@ -22,7 +20,7 @@ class TauComp(om.ExplicitComponent):
     def __init__(self, grid_data=None, **kwargs):
         super().__init__(**kwargs)
         self._grid_data = grid_data
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/dymos/transcriptions/explicit_shooting/test/test_explicit_shooting.py
+++ b/dymos/transcriptions/explicit_shooting/test/test_explicit_shooting.py
@@ -5,10 +5,9 @@ import numpy as np
 
 import openmdao.api as om
 import dymos as dm
-from dymos import options as dymos_options
 
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, set_env_vars
 
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 
@@ -84,9 +83,8 @@ class Simple1StateODE(om.ExplicitComponent):
 @use_tempdirs
 class TestExplicitShooting(unittest.TestCase):
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_1_state_run_model(self):
-
-        dymos_options['include_check_partials'] = True
 
         prob = om.Problem()
 
@@ -115,11 +113,8 @@ class TestExplicitShooting(unittest.TestCase):
 
         assert_check_partials(cpd, rtol=1.0E-5)
 
-        dymos_options['include_check_partials'] = False
-
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_2_states_run_model(self):
-
-        dymos_options['include_check_partials'] = True
 
         prob = om.Problem()
 
@@ -160,11 +155,8 @@ class TestExplicitShooting(unittest.TestCase):
             cpd = prob.check_partials(compact_print=True, method='fd', out_stream=None)
             assert_check_partials(cpd, atol=1.0E-5, rtol=1.0E-5)
 
-        dymos_options['include_check_partials'] = False
-
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_brachistochrone_explicit_shooting(self):
-
-        dymos_options['include_check_partials'] = True
 
         input_grid = dm.GaussLobattoGrid(num_segments=3, nodes_per_seg=3, compressed=False)
 
@@ -236,11 +228,8 @@ class TestExplicitShooting(unittest.TestCase):
                                               out_stream=None)
                     assert_check_partials(cpd, atol=1.0E-5, rtol=1.0E-5)
 
-        dymos_options['include_check_partials'] = False
-
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_brachistochrone_explicit_shooting_path_constraint(self):
-
-        dymos_options['include_check_partials'] = True
 
         input_grid = dm.GaussLobattoGrid(num_segments=3, nodes_per_seg=3, compressed=True)
 
@@ -306,11 +295,8 @@ class TestExplicitShooting(unittest.TestCase):
                                               includes=['traj0.phases.phase0.integrator'])
                     assert_check_partials(cpd, atol=1.0E-5, rtol=1.0E-5)
 
-        dymos_options['include_check_partials'] = False
-
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_brachistochrone_explicit_shooting_path_constraint_polynomial_control(self):
-
-        dymos_options['include_check_partials'] = True
 
         for output_grid_type in ('same', 'more_dense', 'radau', 'uniform'):
             for compressed in (True, False):
@@ -385,11 +371,8 @@ class TestExplicitShooting(unittest.TestCase):
                                                       includes=['traj0.phases.phase0.integrator'])
                             assert_check_partials(cpd, atol=1.0E-5, rtol=1.0E-5)
 
-        dymos_options['include_check_partials'] = False
-
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_brachistochrone_explicit_shooting_path_constraint_invalid_renamed(self):
-
-        dymos_options['include_check_partials'] = True
 
         for output_grid_type in ('same', 'more_dense', 'radau', 'uniform'):
             prob = om.Problem()
@@ -432,11 +415,8 @@ class TestExplicitShooting(unittest.TestCase):
                           "Option 'constraint_name' on path constraint y is only valid for "
                           "ODE outputs. The option is being ignored.", [str(w.message) for w in ctx])
 
-        dymos_options['include_check_partials'] = False
-
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_explicit_shooting_timeseries_ode_output(self):
-
-        dymos_options['include_check_partials'] = True
 
         for output_grid_type in ('same', 'more_dense', 'radau', 'uniform'):
             prob = om.Problem()
@@ -505,8 +485,7 @@ class TestExplicitShooting(unittest.TestCase):
                 cpd = prob.check_partials(method='fd', out_stream=None, includes=['phase0.integrator'])
                 assert_check_partials(cpd, atol=1.0E-5, rtol=1.0E-5)
 
-            dymos_options['include_check_partials'] = False
-
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_explicit_shooting_unknown_timeseries(self):
 
         for output_grid_type in ('same', 'more_dense', 'radau', 'uniform'):

--- a/dymos/transcriptions/explicit_shooting/test/test_ode_integration_comp.py
+++ b/dymos/transcriptions/explicit_shooting/test/test_ode_integration_comp.py
@@ -3,10 +3,10 @@ import unittest
 import numpy as np
 import openmdao.api as om
 import dymos as dm
-from dymos import options as dymos_options
 from dymos.utils.misc import om_version
 
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
+from openmdao.utils.testing_utils import set_env_vars
 from dymos.examples.brachistochrone.brachistochrone_ode import BrachistochroneODE
 from dymos.transcriptions.explicit_shooting.ode_integration_comp import ODEIntegrationComp
 
@@ -17,10 +17,10 @@ from dymos.utils.testing_utils import SimpleODE
 
 class TestODEIntegrationComp(unittest.TestCase):
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     @unittest.skipIf(om_version()[0] >= (3, 36, 0) and om_version()[0] < (3, 37, 0),
                      reason='Test skipped due to an issue in OpenMDAO 3.36.x')
     def test_integrate_scalar_ode(self):
-        dymos_options['include_check_partials'] = True
 
         for ogd_eq_igd in (True, False):
             with self.subTest('input_grid_data = output_grid_data'
@@ -78,16 +78,13 @@ class TestODEIntegrationComp(unittest.TestCase):
 
                 assert_near_equal(x, expected, tolerance=1.0E-5)
 
-                cpd = prob.check_partials(compact_print=True)
+                cpd = prob.check_partials(compact_print=True, out_stream=None)
                 assert_check_partials(cpd, atol=1.0E-4, rtol=1.0E-5)
 
-        dymos_options['include_check_partials'] = False
-
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     @unittest.skipIf(om_version()[0] >= (3, 36, 0) and om_version()[0] < (3, 37, 0),
                      reason='Test skipped due to an issue in OpenMDAO 3.36.x')
     def test_integrate_with_controls(self):
-
-        dymos_options['include_check_partials'] = True
 
         gd = dm.GaussLobattoGrid(num_segments=5, nodes_per_seg=3, compressed=True)
 
@@ -161,14 +158,13 @@ class TestODEIntegrationComp(unittest.TestCase):
         assert_near_equal(v[-1, ...], 9.9, tolerance=0.1)
 
         with np.printoptions(linewidth=1024):
-            cpd = p.check_partials(compact_print=False, method='fd')
+            cpd = p.check_partials(compact_print=False, method='fd', out_stream=None)
             assert_check_partials(cpd, atol=1.0E-4, rtol=1.0E-4)
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     @unittest.skipIf(om_version()[0] >= (3, 36, 0) and om_version()[0] < (3, 37, 0),
                      reason='Test skipped due to an issue in OpenMDAO 3.36.x')
     def test_integrate_with_polynomial_controls(self):
-
-        dymos_options['include_check_partials'] = True
 
         gd = dm.GaussLobattoGrid(num_segments=5, nodes_per_seg=3, compressed=True)
 
@@ -245,10 +241,8 @@ class TestODEIntegrationComp(unittest.TestCase):
         assert_near_equal(v[-1, ...], 9.9, tolerance=0.1)
 
         with np.printoptions(linewidth=1024):
-            cpd = p.check_partials(compact_print=False, method='fd')
+            cpd = p.check_partials(compact_print=False, method='fd', out_stream=None)
             assert_check_partials(cpd, atol=1.0E-4, rtol=1.0E-4)
-
-        dymos_options['include_check_partials'] = False
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/dymos/transcriptions/picard_shooting/birkhoff_picard_update_comp.py
+++ b/dymos/transcriptions/picard_shooting/birkhoff_picard_update_comp.py
@@ -6,7 +6,6 @@ import openmdao.api as om
 
 from dymos.transcriptions.grid_data import GridData
 from dymos.utils.misc import get_rate_units
-# from dymos._options import options as dymos_options
 from dymos.utils.birkhoff import birkhoff_matrix
 
 
@@ -26,7 +25,7 @@ class PicardUpdateComp(om.ExplicitComponent):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        # self._no_check_partials = not dymos_options['include_check_partials']
+        # self._no_check_partials = True
 
     def initialize(self):
         """

--- a/dymos/transcriptions/picard_shooting/multiple_shooting_update_comp.py
+++ b/dymos/transcriptions/picard_shooting/multiple_shooting_update_comp.py
@@ -4,7 +4,6 @@ import scipy.sparse as sp
 import openmdao.api as om
 
 from dymos.transcriptions.grid_data import GridData
-from dymos._options import options as dymos_options
 
 
 class MultipleShootingUpdateComp(om.ExplicitComponent):
@@ -34,7 +33,7 @@ class MultipleShootingUpdateComp(om.ExplicitComponent):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
         self._M_fwd = None
         self._M_bkwd = None
 

--- a/dymos/transcriptions/picard_shooting/states_comp.py
+++ b/dymos/transcriptions/picard_shooting/states_comp.py
@@ -3,7 +3,6 @@ import numpy as np
 
 from openmdao.core.explicitcomponent import ExplicitComponent
 from dymos.transcriptions.grid_data import GridData
-from dymos._options import options as dymos_options
 
 
 class StatesComp(ExplicitComponent):
@@ -33,7 +32,7 @@ class StatesComp(ExplicitComponent):
         """
         super().__init__(**kwargs)
 
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/dymos/transcriptions/picard_shooting/test/test_birkhoff_picard_iter_group.py
+++ b/dymos/transcriptions/picard_shooting/test/test_birkhoff_picard_iter_group.py
@@ -207,75 +207,75 @@ class TestBirkhoffPicardIterGroup(unittest.TestCase):
             for grid_type in ['lgl']:
                 with self.subTest(msg=grid_type):
 
-                        state_options = {'x': StateOptionsDictionary(),
-                                         'y': StateOptionsDictionary(),
-                                         'z': StateOptionsDictionary()}
+                    state_options = {'x': StateOptionsDictionary(),
+                                        'y': StateOptionsDictionary(),
+                                        'z': StateOptionsDictionary()}
 
-                        state_options['x']['shape'] = (1,)
-                        state_options['x']['units'] = None
-                        state_options['x']['targets'] = ['x']
-                        state_options['x']['initial_bounds'] = (None, None)
-                        state_options['x']['final_bounds'] = (None, None)
-                        state_options['x']['solve_segments'] = direction
-                        state_options['x']['rate_source'] = 'x_dot'
+                    state_options['x']['shape'] = (1,)
+                    state_options['x']['units'] = None
+                    state_options['x']['targets'] = ['x']
+                    state_options['x']['initial_bounds'] = (None, None)
+                    state_options['x']['final_bounds'] = (None, None)
+                    state_options['x']['solve_segments'] = direction
+                    state_options['x']['rate_source'] = 'x_dot'
 
-                        state_options['y']['shape'] = (1,)
-                        state_options['y']['units'] = None
-                        state_options['y']['targets'] = ['y']
-                        state_options['y']['initial_bounds'] = (None, None)
-                        state_options['y']['final_bounds'] = (None, None)
-                        state_options['y']['solve_segments'] = direction
-                        state_options['y']['rate_source'] = 'y_dot'
+                    state_options['y']['shape'] = (1,)
+                    state_options['y']['units'] = None
+                    state_options['y']['targets'] = ['y']
+                    state_options['y']['initial_bounds'] = (None, None)
+                    state_options['y']['final_bounds'] = (None, None)
+                    state_options['y']['solve_segments'] = direction
+                    state_options['y']['rate_source'] = 'y_dot'
 
-                        state_options['z']['shape'] = (1,)
-                        state_options['z']['units'] = None
-                        state_options['z']['targets'] = ['z']
-                        state_options['z']['initial_bounds'] = (None, None)
-                        state_options['z']['final_bounds'] = (None, None)
-                        state_options['z']['solve_segments'] = direction
-                        state_options['z']['rate_source'] = 'z_dot'
+                    state_options['z']['shape'] = (1,)
+                    state_options['z']['units'] = None
+                    state_options['z']['targets'] = ['z']
+                    state_options['z']['initial_bounds'] = (None, None)
+                    state_options['z']['final_bounds'] = (None, None)
+                    state_options['z']['solve_segments'] = direction
+                    state_options['z']['rate_source'] = 'z_dot'
 
-                        time_options = TimeOptionsDictionary()
-                        grid_data = BirkhoffGrid(num_nodes=300, grid_type=grid_type)
-                        nn = grid_data.subset_num_nodes['all']
-                        ode_class = LorenzAttractorODE
+                    time_options = TimeOptionsDictionary()
+                    grid_data = BirkhoffGrid(num_nodes=300, grid_type=grid_type)
+                    nn = grid_data.subset_num_nodes['all']
+                    ode_class = LorenzAttractorODE
 
-                        p = om.Problem()
-                        p.model.add_subsystem('birkhoff', BirkhoffPicardIterGroup(state_options=state_options,
-                                                                                  time_options=time_options,
-                                                                                  grid_data=grid_data,
-                                                                                  ode_class=ode_class))
+                    p = om.Problem()
+                    p.model.add_subsystem('birkhoff', BirkhoffPicardIterGroup(state_options=state_options,
+                                                                                time_options=time_options,
+                                                                                grid_data=grid_data,
+                                                                                ode_class=ode_class))
 
-                        birkhoff = p.model._get_subsystem('birkhoff')
+                    birkhoff = p.model._get_subsystem('birkhoff')
 
-                        birkhoff.nonlinear_solver = om.NewtonSolver(solve_subsystems=True, maxiter=100, iprint=0)
-                        birkhoff.nonlinear_solver = om.NonlinearBlockGS(maxiter=500, use_aitken=True, iprint=0)
-                        birkhoff.linear_solver = om.DirectSolver()
+                    birkhoff.nonlinear_solver = om.NewtonSolver(solve_subsystems=True, maxiter=100, iprint=0)
+                    birkhoff.nonlinear_solver = om.NonlinearBlockGS(maxiter=500, use_aitken=True, iprint=0)
+                    birkhoff.linear_solver = om.DirectSolver()
 
-                        p.setup(force_alloc_complex=True)
+                    p.setup(force_alloc_complex=True)
 
-                        # Instead of using the TimeComp just transform the node segment taus onto [0, 100]
-                        times = (grid_data.node_stau + 1) * 0.3
-                        dt_dstau = (times[-1] / 2.0) * np.ones(nn)
+                    # Instead of using the TimeComp just transform the node segment taus onto [0, 100]
+                    times = (grid_data.node_stau + 1) * 0.3
+                    dt_dstau = (times[-1] / 2.0) * np.ones(nn)
 
-                        if direction == 'forward':
-                            p.set_val('birkhoff.initial_states:x', 0.0)
-                            p.set_val('birkhoff.initial_states:y', 1.0)
-                            p.set_val('birkhoff.initial_states:z', 1.05)
+                    if direction == 'forward':
+                        p.set_val('birkhoff.initial_states:x', 0.0)
+                        p.set_val('birkhoff.initial_states:y', 1.0)
+                        p.set_val('birkhoff.initial_states:z', 1.05)
 
-                            p.set_val('birkhoff.states:x', 0.0)
-                            p.set_val('birkhoff.states:y', 1.0)
-                            p.set_val('birkhoff.states:z', 1.05)
-                        else:
-                            raise ValueError('not set up for backwards prop yet')
-                            # p.set_val('birkhoff.final_states:x', solution[-1])
-                        p.set_val('birkhoff.dt_dstau', dt_dstau)
-                        p.set_val('birkhoff.ode_all.s', 10.0)
-                        p.set_val('birkhoff.ode_all.r', 28.0)
-                        p.set_val('birkhoff.ode_all.b', 2.667)
+                        p.set_val('birkhoff.states:x', 0.0)
+                        p.set_val('birkhoff.states:y', 1.0)
+                        p.set_val('birkhoff.states:z', 1.05)
+                    else:
+                        raise ValueError('not set up for backwards prop yet')
+                        # p.set_val('birkhoff.final_states:x', solution[-1])
+                    p.set_val('birkhoff.dt_dstau', dt_dstau)
+                    p.set_val('birkhoff.ode_all.s', 10.0)
+                    p.set_val('birkhoff.ode_all.r', 28.0)
+                    p.set_val('birkhoff.ode_all.b', 2.667)
 
-                        p.final_setup()
-                        p.run_model()
+                    p.final_setup()
+                    p.run_model()
 
                     p.model.list_vars()
 
@@ -283,10 +283,10 @@ class TestBirkhoffPicardIterGroup(unittest.TestCase):
                     y = p.get_val('birkhoff.states:y')
                     z = p.get_val('birkhoff.states:z')
 
-                    import matplotlib.pyplot as plt
-                    ax = plt.figure().add_subplot(projection='3d')
-                    ax.plot(x, y, z, '-')
-                    plt.show()
+                    # import matplotlib.pyplot as plt
+                    # ax = plt.figure().add_subplot(projection='3d')
+                    # ax.plot(x, y, z, '-')
+                    # plt.show()
 
                     # assert_near_equal(solution, p.get_val('birkhoff.states:x'), tolerance=1.0E-9)
                     # assert_near_equal(dsolution_dt.ravel(), p.get_val('birkhoff.state_rates:x'), tolerance=1.0E-9)

--- a/dymos/transcriptions/picard_shooting/test/test_birkhoff_picard_iter_group.py
+++ b/dymos/transcriptions/picard_shooting/test/test_birkhoff_picard_iter_group.py
@@ -7,7 +7,7 @@ import openmdao.api as om
 
 import dymos
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, set_env_vars
 
 from dymos.utils.misc import GroupWrapperConfig, om_version
 from dymos.utils.testing_utils import PhaseStub, SimpleODE
@@ -23,13 +23,13 @@ BirkhoffPicardIterGroup = GroupWrapperConfig(BirkhoffPicardIterGroup, [PhaseStub
 @unittest.skipIf(om_version()[0] < (3, 37, 0), 'Requires OpenMDAO version later than 3.37.0')
 class TestBirkhoffPicardIterGroup(unittest.TestCase):
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_birkhoff_picard_solve_segments(self):
         for direction in ['forward', 'backward']:
             for grid_type in ['lgl', 'cgl']:
                 for nl_solver in ['newton', 'nlbgs']:
                     for num_segments, nodes_per_seg in [(1, 11)]:
                         with self.subTest(msg=f'{direction=} {grid_type=} {nl_solver=}'):
-                            with dymos.options.temporary(include_check_partials=True):
 
                                 state_options = {'x': StateOptionsDictionary()}
 
@@ -206,7 +206,6 @@ class TestBirkhoffPicardIterGroup(unittest.TestCase):
         for direction in ['forward']:
             for grid_type in ['lgl']:
                 with self.subTest(msg=grid_type):
-                    with dymos.options.temporary(include_check_partials=True):
 
                         state_options = {'x': StateOptionsDictionary(),
                                          'y': StateOptionsDictionary(),

--- a/dymos/transcriptions/picard_shooting/test/test_multiple_shooting_iter_group.py
+++ b/dymos/transcriptions/picard_shooting/test/test_multiple_shooting_iter_group.py
@@ -7,7 +7,7 @@ import openmdao.api as om
 
 import dymos
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, set_env_vars
 
 from dymos.utils.misc import GroupWrapperConfig
 from dymos.utils.testing_utils import PhaseStub, SimpleODE
@@ -126,6 +126,7 @@ class LorenzAttractorODE(om.JaxExplicitComponent):
 @use_tempdirs
 class TestMultipleShootingIterGroup(unittest.TestCase):
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_multiple_shooting_iter_group(self):
         for direction in ['forward', 'backward']:
             for grid_type in [GaussLobattoGrid, ChebyshevGaussLobattoGrid]:
@@ -134,7 +135,6 @@ class TestMultipleShootingIterGroup(unittest.TestCase):
                     for nl_solver in [om.NonlinearBlockGS(use_aitken=True, maxiter=100, iprint=0),
                                       om.NewtonSolver(solve_subsystems=True, maxiter=100, iprint=0)]:
                         with self.subTest(msg=f'{direction=} grid={grid_data}'):
-                            with dymos.options.temporary(include_check_partials=True):
 
                                 state_options = {'x': StateOptionsDictionary()}
 

--- a/dymos/transcriptions/pseudospectral/components/birkhoff_boundary_group.py
+++ b/dymos/transcriptions/pseudospectral/components/birkhoff_boundary_group.py
@@ -2,7 +2,6 @@ import numpy as np
 import openmdao.api as om
 
 from ....utils.ode_utils import _make_ode_system
-from dymos._options import options as dymos_options
 
 
 class BirkhoffBoundaryMuxComp(om.ExplicitComponent):
@@ -26,7 +25,7 @@ class BirkhoffBoundaryMuxComp(om.ExplicitComponent):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._io_names = {}
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def configure_io(self, state_options):
         """
@@ -102,7 +101,7 @@ class BirkhoffBoundaryGroup(om.Group):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/dymos/transcriptions/pseudospectral/components/birkhoff_defect_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/birkhoff_defect_comp.py
@@ -6,7 +6,6 @@ import openmdao.api as om
 
 from dymos.transcriptions.grid_data import GridData
 from dymos.utils.misc import get_rate_units
-from dymos._options import options as dymos_options
 from dymos.utils.lgl import lgl
 from dymos.utils.cgl import cgl
 from dymos.utils.birkhoff import birkhoff_matrix
@@ -33,7 +32,7 @@ class BirkhoffDefectComp(om.ExplicitComponent):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/dymos/transcriptions/pseudospectral/components/collocation_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/collocation_comp.py
@@ -5,7 +5,6 @@ import openmdao.api as om
 
 from ...grid_data import GridData
 from ....utils.misc import get_rate_units
-from ...._options import options as dymos_options
 
 
 class CollocationComp(om.ExplicitComponent):
@@ -24,7 +23,7 @@ class CollocationComp(om.ExplicitComponent):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/dymos/transcriptions/pseudospectral/components/control_endpoint_defect_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/control_endpoint_defect_comp.py
@@ -1,7 +1,6 @@
 import numpy as np
 import openmdao.api as om
 from ...grid_data import GridData
-from ...._options import options as dymos_options
 
 
 class ControlEndpointDefectComp(om.ExplicitComponent):
@@ -23,7 +22,7 @@ class ControlEndpointDefectComp(om.ExplicitComponent):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/dymos/transcriptions/pseudospectral/components/gauss_lobatto_interleave_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/gauss_lobatto_interleave_comp.py
@@ -2,7 +2,6 @@ import numpy as np
 import openmdao.api as om
 
 from ...grid_data import GridData
-from ...._options import options as dymos_options
 
 
 class GaussLobattoInterleaveComp(om.ExplicitComponent):
@@ -20,7 +19,7 @@ class GaussLobattoInterleaveComp(om.ExplicitComponent):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/dymos/transcriptions/pseudospectral/components/radau_boundary_group.py
+++ b/dymos/transcriptions/pseudospectral/components/radau_boundary_group.py
@@ -1,7 +1,6 @@
 import numpy as np
 import openmdao.api as om
 
-from dymos._options import options as dymos_options
 from dymos.utils.ode_utils import _make_ode_system
 
 
@@ -26,7 +25,7 @@ class RadauBoundaryMuxComp(om.ExplicitComponent):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._io_names = {}
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def configure_io(self, state_options):
         """
@@ -95,7 +94,7 @@ class RadauBoundaryGroup(om.Group):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/dymos/transcriptions/pseudospectral/components/radau_defect_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/radau_defect_comp.py
@@ -5,7 +5,6 @@ import scipy.sparse as sp
 
 from openmdao.utils.units import unit_conversion
 
-from dymos._options import options as dymos_options
 from dymos.transcriptions.grid_data import GridData
 from dymos.utils.misc import get_rate_units
 
@@ -32,7 +31,7 @@ class RadauDefectComp(om.ExplicitComponent):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
         # When a state has another state as its rate source, we have to explicitly convert
         # from the units of that other state to the units being expected by the current state.

--- a/dymos/transcriptions/pseudospectral/components/state_independents.py
+++ b/dymos/transcriptions/pseudospectral/components/state_independents.py
@@ -5,7 +5,6 @@ import numpy as np
 import openmdao.api as om
 
 from ....transcriptions.grid_data import GridData
-from ...._options import options as dymos_options
 
 
 class StateIndependentsComp(om.ImplicitComponent):
@@ -23,7 +22,7 @@ class StateIndependentsComp(om.ImplicitComponent):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/dymos/transcriptions/pseudospectral/components/state_interp_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/state_interp_comp.py
@@ -3,7 +3,6 @@ import scipy.sparse as sp
 import openmdao.api as om
 from ...grid_data import GridData
 from ....utils.misc import get_rate_units
-from ...._options import options as dymos_options
 
 
 class StateInterpComp(om.ExplicitComponent):
@@ -31,7 +30,7 @@ class StateInterpComp(om.ExplicitComponent):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/dymos/transcriptions/pseudospectral/components/test/test_birkhoff_collocation_defect.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_birkhoff_collocation_defect.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 
 import openmdao.api as om
+from openmdao.utils.testing_utils import set_env_vars
 from dymos.utils.testing_utils import assert_check_partials
 
 import dymos as dm
@@ -29,7 +30,6 @@ CollocationComp = CompWrapperConfig(BirkhoffDefectComp, [_PhaseStub()])
 class TestCollocationComp(unittest.TestCase):
 
     def make_problem(self, grid_type='lgl'):
-        dm.options['include_check_partials'] = True
 
         gd = BirkhoffGrid(num_nodes=21, grid_type=grid_type)
         n = gd.subset_num_nodes['col']
@@ -105,9 +105,6 @@ class TestCollocationComp(unittest.TestCase):
 
         self.p.run_model()
 
-    def tearDown(self):
-        dm.options['include_check_partials'] = False
-
     def test_results(self):
         for grid_type in ('lgl', 'cgl'):
             with self.subTest(msg=grid_type):
@@ -117,6 +114,7 @@ class TestCollocationComp(unittest.TestCase):
                 assert_almost_equal(self.p['defect_comp.state_defects:y'], 0.0)
                 assert_almost_equal(self.p['defect_comp.state_rate_defects:y'], 0.0)
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_partials(self):
         for grid_type in ('lgl', 'cgl'):
             with self.subTest(msg=grid_type):

--- a/dymos/transcriptions/pseudospectral/components/test/test_birkhoff_iter_group.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_birkhoff_iter_group.py
@@ -6,7 +6,7 @@ import openmdao.api as om
 
 import dymos
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, set_env_vars
 
 from dymos.utils.misc import GroupWrapperConfig
 from dymos.utils.testing_utils import PhaseStub, SimpleODE
@@ -21,70 +21,70 @@ BirkhoffIterGroup = GroupWrapperConfig(BirkhoffIterGroup, [PhaseStub()])
 @use_tempdirs
 class TestBirkhoffIterGroup(unittest.TestCase):
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_solve_segments_gl_fwd(self):
         for grid_type in ['lgl', 'cgl']:
             with self.subTest(msg=grid_type):
-                with dymos.options.temporary(include_check_partials=True):
 
-                    state_options = {'x': StateOptionsDictionary()}
+                state_options = {'x': StateOptionsDictionary()}
 
-                    state_options['x']['shape'] = (1,)
-                    state_options['x']['units'] = 's**2'
-                    state_options['x']['targets'] = ['x']
-                    state_options['x']['initial_bounds'] = (None, None)
-                    state_options['x']['final_bounds'] = (None, None)
-                    state_options['x']['solve_segments'] = 'forward'
-                    state_options['x']['rate_source'] = 'x_dot'
+                state_options['x']['shape'] = (1,)
+                state_options['x']['units'] = 's**2'
+                state_options['x']['targets'] = ['x']
+                state_options['x']['initial_bounds'] = (None, None)
+                state_options['x']['final_bounds'] = (None, None)
+                state_options['x']['solve_segments'] = 'forward'
+                state_options['x']['rate_source'] = 'x_dot'
 
-                    time_options = TimeOptionsDictionary()
-                    grid_data = BirkhoffGrid(num_nodes=31, grid_type=grid_type)
-                    nn = grid_data.subset_num_nodes['all']
-                    ode_class = SimpleODE
+                time_options = TimeOptionsDictionary()
+                grid_data = BirkhoffGrid(num_nodes=31, grid_type=grid_type)
+                nn = grid_data.subset_num_nodes['all']
+                ode_class = SimpleODE
 
-                    p = om.Problem()
-                    p.model.add_subsystem('birkhoff', BirkhoffIterGroup(state_options=state_options,
-                                                                        time_options=time_options,
-                                                                        grid_data=grid_data,
-                                                                        ode_class=ode_class))
+                p = om.Problem()
+                p.model.add_subsystem('birkhoff', BirkhoffIterGroup(state_options=state_options,
+                                                                    time_options=time_options,
+                                                                    grid_data=grid_data,
+                                                                    ode_class=ode_class))
 
-                    birkhoff = p.model._get_subsystem('birkhoff')
+                birkhoff = p.model._get_subsystem('birkhoff')
 
-                    birkhoff.nonlinear_solver = om.NewtonSolver(solve_subsystems=True)
-                    birkhoff.linear_solver = om.DirectSolver()
+                birkhoff.nonlinear_solver = om.NewtonSolver(solve_subsystems=True)
+                birkhoff.linear_solver = om.DirectSolver()
 
-                    p.setup(force_alloc_complex=True)
+                p.setup(force_alloc_complex=True)
 
-                    # Instead of using the TimeComp just transform the node segment taus onto [0, 2]
-                    times = grid_data.node_stau + 1
+                # Instead of using the TimeComp just transform the node segment taus onto [0, 2]
+                times = grid_data.node_stau + 1
 
-                    solution = np.reshape(times**2 + 2 * times + 1 - 0.5 * np.exp(times), (nn, 1))
-                    dsolution_dt = np.reshape(2 * times + 2 - 0.5 * np.exp(times), (nn, 1))
+                solution = np.reshape(times**2 + 2 * times + 1 - 0.5 * np.exp(times), (nn, 1))
+                dsolution_dt = np.reshape(2 * times + 2 - 0.5 * np.exp(times), (nn, 1))
 
-                    p.set_val('birkhoff.initial_states:x', 0.5)
-                    p.set_val('birkhoff.ode_all.t', times)
-                    p.set_val('birkhoff.ode_all.p', 1.0)
+                p.set_val('birkhoff.initial_states:x', 0.5)
+                p.set_val('birkhoff.ode_all.t', times)
+                p.set_val('birkhoff.ode_all.p', 1.0)
 
-                    # We don't need to provide guesses for these values in this case
-                    # p.set_val('birkhoff.final_states:x', solution[-1])
-                    # p.set_val('birkhoff.states:x', solution)
-                    # p.set_val('birkhoff.state_rates:x', dsolution_dt)
+                # We don't need to provide guesses for these values in this case
+                # p.set_val('birkhoff.final_states:x', solution[-1])
+                # p.set_val('birkhoff.states:x', solution)
+                # p.set_val('birkhoff.state_rates:x', dsolution_dt)
 
-                    p.final_setup()
-                    p.run_model()
+                p.final_setup()
+                p.run_model()
 
-                    assert_near_equal(solution, p.get_val('birkhoff.states:x'), tolerance=1.0E-9)
-                    assert_near_equal(dsolution_dt, p.get_val('birkhoff.state_rates:x'), tolerance=1.0E-9)
-                    assert_near_equal(solution[np.newaxis, 0], p.get_val('birkhoff.initial_states:x'), tolerance=1.0E-9)
-                    assert_near_equal(solution[np.newaxis, -1], p.get_val('birkhoff.final_states:x'), tolerance=1.0E-9)
+                assert_near_equal(solution, p.get_val('birkhoff.states:x'), tolerance=1.0E-9)
+                assert_near_equal(dsolution_dt, p.get_val('birkhoff.state_rates:x'), tolerance=1.0E-9)
+                assert_near_equal(solution[np.newaxis, 0], p.get_val('birkhoff.initial_states:x'), tolerance=1.0E-9)
+                assert_near_equal(solution[np.newaxis, -1], p.get_val('birkhoff.final_states:x'), tolerance=1.0E-9)
 
-                    cpd = p.check_partials(method='cs', compact_print=True, out_stream=None)
-                    assert_check_partials(cpd)
+                cpd = p.check_partials(method='cs', compact_print=True, out_stream=None)
+                assert_check_partials(cpd)
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_solve_segments_gl_bkwd(self):
 
         for grid_type in ['lgl', 'cgl']:
             with self.subTest(msg=grid_type):
-                with dymos.options.temporary(include_check_partials=True):
 
                     state_options = {'x': StateOptionsDictionary()}
 

--- a/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_opt.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_opt.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 
 import openmdao.api as om
+from openmdao.utils.testing_utils import set_env_vars
 from dymos.utils.testing_utils import assert_check_partials
 
 import dymos as dm
@@ -18,8 +19,6 @@ CollocationComp = CompWrapperConfig(CollocationComp)
 class TestCollocationComp(unittest.TestCase):
 
     def setUp(self):
-        dm.options['include_check_partials'] = True
-        transcription = 'gauss-lobatto'
 
         gd = dm.GaussLobattoGrid(num_segments=4,
                                  segment_ends=np.array([0., 2., 4., 5., 12.]),
@@ -78,9 +77,6 @@ class TestCollocationComp(unittest.TestCase):
 
         self.p.run_model()
 
-    def tearDown(self):
-        dm.options['include_check_partials'] = False
-
     def test_results(self):
         dt_dstau = self.p['dt_dstau']
 
@@ -91,6 +87,7 @@ class TestCollocationComp(unittest.TestCase):
                             dt_dstau[:, np.newaxis, np.newaxis] *
                             (self.p['f_approx:v']-self.p['f_computed:v']))
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = self.p.check_partials(compact_print=False, method='fd', out_stream=None)

--- a/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_sol_opt.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_sol_opt.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 
 import openmdao.api as om
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, set_env_vars
 
 import dymos as dm
 from dymos.transcriptions.grid_data import GridData
@@ -20,12 +20,6 @@ StateIndependentsComp = CompWrapperConfig(StateIndependentsComp)
 
 @use_tempdirs
 class TestCollocationCompSolOpt(unittest.TestCase):
-
-    def setUp(self):
-        dm.options['include_check_partials'] = True
-
-    def tearDown(self):
-        dm.options['include_check_partials'] = False
 
     def _make_state_idx_map(self, state_name, options, grid_data, state_idx_map):
         """
@@ -189,6 +183,7 @@ class TestCollocationCompSolOpt(unittest.TestCase):
                             dt_dstau[:, np.newaxis, np.newaxis] *
                             (p['f_approx:v']-p['f_computed:v']))
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_partials(self):
         np.set_printoptions(linewidth=1024, edgeitems=1e1000)
 

--- a/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_solver.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_collocation_defect_solver.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_almost_equal
 
 import openmdao.api as om
 from openmdao.utils.general_utils import env_truthy
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, set_env_vars
 
 
 # Modify class so we can run it standalone.
@@ -22,12 +22,6 @@ class TestCollocationBalanceIndex(unittest.TestCase):
     """
     Test that the indices used in the StateIndependentsComp are as expected.
     """
-
-    def setUp(self):
-        dm.options['include_check_partials'] = True
-
-    def tearDown(self):
-        dm.options['include_check_partials'] = False
 
     def test_3_lgl(self):
         """
@@ -266,9 +260,6 @@ class TestCollocationBalanceIndex(unittest.TestCase):
 @use_tempdirs
 class TestCollocationBalanceApplyNL(unittest.TestCase):
 
-    def tearDown(self):
-        dm.options['include_check_partials'] = False
-
     def make_prob(self, transcription, num_segments, transcription_order, compressed):
 
         p = om.Problem(model=om.Group())
@@ -319,7 +310,6 @@ class TestCollocationBalanceApplyNL(unittest.TestCase):
         return p
 
     def test_apply_nonlinear_gl(self):
-        dm.options['include_check_partials'] = True
         p = self.make_prob(transcription='gauss-lobatto', num_segments=3, transcription_order=3,
                            compressed=True)
 
@@ -336,7 +326,6 @@ class TestCollocationBalanceApplyNL(unittest.TestCase):
 
     @unittest.skipIf(_DYMOS_2, 'Test invalid for updated Radau transcription')
     def test_apply_nonlinear_radau(self):
-        dm.options['include_check_partials'] = True
         p = self.make_prob(transcription='radau-ps', num_segments=3, transcription_order=3,
                            compressed=True)
 
@@ -351,8 +340,8 @@ class TestCollocationBalanceApplyNL(unittest.TestCase):
         assert_almost_equal(resids['states:x'], expected)
         assert_almost_equal(resids['states:v'], expected)
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_partials_gl(self):
-        dm.options['include_check_partials'] = True
         p = self.make_prob(transcription='gauss-lobatto', num_segments=3, transcription_order=3,
                            compressed=True)
 
@@ -371,9 +360,9 @@ class TestCollocationBalanceApplyNL(unittest.TestCase):
         data = cpd['traj0.phases.phase0.indep_states']
         assert_partials(data)
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     @unittest.skipIf(_DYMOS_2, 'Test invalid for updated Radau transcription')
     def test_partials_radau(self):
-        dm.options['include_check_partials'] = True
         p = self.make_prob(transcription='radau-ps', num_segments=3, transcription_order=3,
                            compressed=True)
 

--- a/dymos/transcriptions/pseudospectral/components/test/test_control_endpoint_defect_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_control_endpoint_defect_comp.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import set_env_vars
 from dymos.utils.testing_utils import assert_check_partials
 
 import dymos as dm
@@ -14,7 +15,6 @@ from dymos.transcriptions.grid_data import GridData
 class TestControlEndpointDefectComp(unittest.TestCase):
 
     def setUp(self):
-        dm.options['include_check_partials'] = True
 
         gd = dm.RadauGrid(num_segments=2, segment_ends=np.array([0., 2., 4.,]), nodes_per_seg=4)
 
@@ -48,9 +48,6 @@ class TestControlEndpointDefectComp(unittest.TestCase):
 
         self.p.run_model()
 
-    def tearDown(self):
-        dm.options['include_check_partials'] = False
-
     def test_results(self):
 
         u_coefs = np.polyfit(self.gd.node_ptau[-4:-1], self.p['controls:u'][-4:-1], deg=2)
@@ -61,6 +58,7 @@ class TestControlEndpointDefectComp(unittest.TestCase):
                           np.ravel(u_given - u_interp),
                           tolerance=1.0E-9)
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_partials(self):
         cpd = self.p.check_partials(compact_print=False, method='cs', out_stream=None)
         assert_check_partials(cpd)

--- a/dymos/transcriptions/pseudospectral/components/test/test_gauss_lobatto_interleave_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_gauss_lobatto_interleave_comp.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import set_env_vars
 from dymos.utils.testing_utils import assert_check_partials
 
 import dymos as dm
@@ -14,7 +15,6 @@ from dymos.transcriptions.grid_data import GridData
 class TestGaussLobattoInterleaveComp(unittest.TestCase):
 
     def setUp(self):
-        dm.options['include_check_partials'] = True
 
         self.grid_data = gd = dm.GaussLobattoGrid(num_segments=3, segment_ends=np.array([0., 2., 4., 10.0]),
                                                   nodes_per_seg=[3, 3, 3])
@@ -74,9 +74,6 @@ class TestGaussLobattoInterleaveComp(unittest.TestCase):
 
         self.p.run_model()
 
-    def tearDown(self):
-        dm.options['include_check_partials'] = False
-
     def test_results(self):
 
         u_disc = self.p.get_val('state_disc:u')
@@ -99,8 +96,9 @@ class TestGaussLobattoInterleaveComp(unittest.TestCase):
         assert_near_equal(v_all[self.grid_data.subset_node_indices['col'], ...],
                           v_col)
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_partials(self):
-        cpd = self.p.check_partials(compact_print=True, method='cs', out_stream=None)
+        cpd = self.p.check_partials(compact_print=False, method='cs', out_stream=None)
         assert_check_partials(cpd)
 
 

--- a/dymos/transcriptions/pseudospectral/components/test/test_radau_iter_group.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_radau_iter_group.py
@@ -6,7 +6,7 @@ import openmdao.api as om
 
 import dymos
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, set_env_vars
 
 from dymos.examples.brachistochrone.brachistochrone_vector_states_ode import BrachistochroneVectorStatesODE
 from dymos.utils.misc import GroupWrapperConfig
@@ -22,103 +22,36 @@ RadauIterGroup = GroupWrapperConfig(RadauIterGroup, [PhaseStub()])
 @use_tempdirs
 class TestRadauIterGroup(unittest.TestCase):
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_solve_segments(self):
-        with dymos.options.temporary(include_check_partials=True):
-            for direction in ['forward', 'backward']:
-                for compressed in [True, False]:
-                    with self.subTest(msg=f'{direction=} {compressed=}'):
+        for direction in ['forward', 'backward']:
+            for compressed in [True, False]:
+                with self.subTest(msg=f'{direction=} {compressed=}'):
 
-                        state_options = {'x': StateOptionsDictionary()}
+                    state_options = {'x': StateOptionsDictionary()}
 
-                        state_options['x']['shape'] = (1,)
-                        state_options['x']['units'] = 's**2'
-                        state_options['x']['targets'] = ['x']
-                        state_options['x']['initial_bounds'] = (None, None)
-                        state_options['x']['final_bounds'] = (None, None)
-                        state_options['x']['solve_segments'] = direction
-                        state_options['x']['rate_source'] = 'x_dot'
-
-                        time_options = TimeOptionsDictionary()
-                        grid_data = RadauGrid(num_segments=2, nodes_per_seg=8, compressed=compressed)
-                        nn = grid_data.subset_num_nodes['all']
-                        ode_class = SimpleODE
-
-                        p = om.Problem()
-                        p.model.add_subsystem('radau', RadauIterGroup(state_options=state_options,
-                                                                      time_options=time_options,
-                                                                      grid_data=grid_data,
-                                                                      ode_class=ode_class))
-
-                        radau = p.model._get_subsystem('radau')
-
-                        radau.nonlinear_solver = om.NewtonSolver(solve_subsystems=True, iprint=-1)
-                        radau.linear_solver = om.DirectSolver()
-
-                        p.setup(force_alloc_complex=True)
-
-                        # Instead of using the TimeComp just transform the node segment taus onto [0, 2]
-                        times = grid_data.node_ptau + 1
-
-                        solution = np.reshape(times**2 + 2 * times + 1 - 0.5 * np.exp(times), (nn, 1))
-
-                        # Each segment is of the same length, so dt_dstau is constant.
-                        # dt_dstau is (tf - t0) / 2.0 / num_seg
-                        p.set_val('radau.dt_dstau', (times[-1] / 2.0 / grid_data.num_segments))
-
-                        if direction == 'forward':
-                            p.set_val('radau.initial_states:x', 0.5)
-                        else:
-                            p.set_val('radau.final_states:x', solution[-1])
-
-                        p.set_val('radau.states:x', 0.0)
-                        p.set_val('radau.ode_all.t', times)
-                        p.set_val('radau.ode_all.p', 1.0)
-
-                        p.run_model()
-
-                        x = p.get_val('radau.states:x')
-                        x_0 = p.get_val('radau.initial_states:x')
-                        x_f = p.get_val('radau.final_states:x')
-
-                        idxs = grid_data.subset_node_indices['state_input']
-                        assert_near_equal(solution[idxs], x, tolerance=1.0E-5)
-                        assert_near_equal(solution[np.newaxis, 0], x_0, tolerance=1.0E-7)
-                        assert_near_equal(solution[np.newaxis, -1], x_f, tolerance=1.0E-7)
-
-                        cpd = p.check_partials(method='cs', compact_print=False, out_stream=None)
-                        assert_check_partials(cpd)
-
-    def test_solve_segments_vector_states(self):
-        with dymos.options.temporary(include_check_partials=True):
-            for direction in ['forward', 'backward']:
-                with self.subTest(msg=f'{direction=}'):
-
-                    state_options = {'z': StateOptionsDictionary()}
-
-                    state_options['z']['shape'] = (2,)
-                    state_options['z']['units'] = 's**2'
-                    state_options['z']['targets'] = ['z']
-                    state_options['z']['initial_bounds'] = (None, None)
-                    state_options['z']['final_bounds'] = (None, None)
-                    state_options['z']['solve_segments'] = direction
-                    state_options['z']['rate_source'] = 'z_dot'
+                    state_options['x']['shape'] = (1,)
+                    state_options['x']['units'] = 's**2'
+                    state_options['x']['targets'] = ['x']
+                    state_options['x']['initial_bounds'] = (None, None)
+                    state_options['x']['final_bounds'] = (None, None)
+                    state_options['x']['solve_segments'] = direction
+                    state_options['x']['rate_source'] = 'x_dot'
 
                     time_options = TimeOptionsDictionary()
-                    grid_data = RadauGrid(num_segments=5, nodes_per_seg=4, compressed=False)
+                    grid_data = RadauGrid(num_segments=2, nodes_per_seg=8, compressed=compressed)
                     nn = grid_data.subset_num_nodes['all']
-                    ode_class = SimpleVectorizedODE
+                    ode_class = SimpleODE
 
                     p = om.Problem()
                     p.model.add_subsystem('radau', RadauIterGroup(state_options=state_options,
-                                                                  time_options=time_options,
-                                                                  grid_data=grid_data,
-                                                                  ode_class=ode_class))
+                                                                    time_options=time_options,
+                                                                    grid_data=grid_data,
+                                                                    ode_class=ode_class))
 
                     radau = p.model._get_subsystem('radau')
 
-                    radau.nonlinear_solver = om.NewtonSolver(solve_subsystems=True, maxiter=100,
-                                                             iprint=-1, atol=1.0E-10, rtol=1.0E-10)
-                    radau.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='vector')
+                    radau.nonlinear_solver = om.NewtonSolver(solve_subsystems=True, iprint=-1)
                     radau.linear_solver = om.DirectSolver()
 
                     p.setup(force_alloc_complex=True)
@@ -133,97 +66,163 @@ class TestRadauIterGroup(unittest.TestCase):
                     p.set_val('radau.dt_dstau', (times[-1] / 2.0 / grid_data.num_segments))
 
                     if direction == 'forward':
-                        p.set_val('radau.initial_states:z', [0.5, 0.0])
+                        p.set_val('radau.initial_states:x', 0.5)
                     else:
-                        p.set_val('radau.final_states:z', solution[-1], indices=om.slicer[:, 0])
-                        p.set_val('radau.final_states:z', 20.0, indices=om.slicer[:, 1])
+                        p.set_val('radau.final_states:x', solution[-1])
 
-                    p.set_val('radau.states:z', 0.0)
+                    p.set_val('radau.states:x', 0.0)
                     p.set_val('radau.ode_all.t', times)
                     p.set_val('radau.ode_all.p', 1.0)
 
                     p.run_model()
 
-                    x = p.get_val('radau.states:z')
-                    x_0 = p.get_val('radau.initial_states:z')
-                    x_f = p.get_val('radau.final_states:z')
+                    x = p.get_val('radau.states:x')
+                    x_0 = p.get_val('radau.initial_states:x')
+                    x_f = p.get_val('radau.final_states:x')
 
                     idxs = grid_data.subset_node_indices['state_input']
-                    assert_near_equal(solution[idxs], x[np.newaxis, :, 0].T, tolerance=1.0E-5)
-                    assert_near_equal(solution[0], x_0[:, 0], tolerance=1.0E-5)
-                    assert_near_equal(solution[-1], x_f[:, 0], tolerance=1.0E-5)
+                    assert_near_equal(solution[idxs], x, tolerance=1.0E-5)
+                    assert_near_equal(solution[np.newaxis, 0], x_0, tolerance=1.0E-7)
+                    assert_near_equal(solution[np.newaxis, -1], x_f, tolerance=1.0E-7)
 
-                    with np.printoptions(linewidth=1024, edgeitems=1024):
-                        cpd = p.check_partials(method='cs', compact_print=False, show_only_incorrect=True, out_stream=None)
-                    assert_check_partials(cpd, atol=1.0E-5, rtol=1.0)
+                    cpd = p.check_partials(method='cs', compact_print=False, out_stream=None)
+                    assert_check_partials(cpd)
+
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
+    def test_solve_segments_vector_states(self):
+        for direction in ['forward', 'backward']:
+            with self.subTest(msg=f'{direction=}'):
+
+                state_options = {'z': StateOptionsDictionary()}
+
+                state_options['z']['shape'] = (2,)
+                state_options['z']['units'] = 's**2'
+                state_options['z']['targets'] = ['z']
+                state_options['z']['initial_bounds'] = (None, None)
+                state_options['z']['final_bounds'] = (None, None)
+                state_options['z']['solve_segments'] = direction
+                state_options['z']['rate_source'] = 'z_dot'
+
+                time_options = TimeOptionsDictionary()
+                grid_data = RadauGrid(num_segments=5, nodes_per_seg=4, compressed=False)
+                nn = grid_data.subset_num_nodes['all']
+                ode_class = SimpleVectorizedODE
+
+                p = om.Problem()
+                p.model.add_subsystem('radau', RadauIterGroup(state_options=state_options,
+                                                                time_options=time_options,
+                                                                grid_data=grid_data,
+                                                                ode_class=ode_class))
+
+                radau = p.model._get_subsystem('radau')
+
+                radau.nonlinear_solver = om.NewtonSolver(solve_subsystems=True, maxiter=100,
+                                                            iprint=-1, atol=1.0E-10, rtol=1.0E-10)
+                radau.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='vector')
+                radau.linear_solver = om.DirectSolver()
+
+                p.setup(force_alloc_complex=True)
+
+                # Instead of using the TimeComp just transform the node segment taus onto [0, 2]
+                times = grid_data.node_ptau + 1
+
+                solution = np.reshape(times**2 + 2 * times + 1 - 0.5 * np.exp(times), (nn, 1))
+
+                # Each segment is of the same length, so dt_dstau is constant.
+                # dt_dstau is (tf - t0) / 2.0 / num_seg
+                p.set_val('radau.dt_dstau', (times[-1] / 2.0 / grid_data.num_segments))
+
+                if direction == 'forward':
+                    p.set_val('radau.initial_states:z', [0.5, 0.0])
+                else:
+                    p.set_val('radau.final_states:z', solution[-1], indices=om.slicer[:, 0])
+                    p.set_val('radau.final_states:z', 20.0, indices=om.slicer[:, 1])
+
+                p.set_val('radau.states:z', 0.0)
+                p.set_val('radau.ode_all.t', times)
+                p.set_val('radau.ode_all.p', 1.0)
+
+                p.run_model()
+
+                x = p.get_val('radau.states:z')
+                x_0 = p.get_val('radau.initial_states:z')
+                x_f = p.get_val('radau.final_states:z')
+
+                idxs = grid_data.subset_node_indices['state_input']
+                assert_near_equal(solution[idxs], x[np.newaxis, :, 0].T, tolerance=1.0E-5)
+                assert_near_equal(solution[0], x_0[:, 0], tolerance=1.0E-5)
+                assert_near_equal(solution[-1], x_f[:, 0], tolerance=1.0E-5)
+
+                with np.printoptions(linewidth=1024, edgeitems=1024):
+                    cpd = p.check_partials(method='cs', compact_print=False, show_only_incorrect=True, out_stream=None)
+                assert_check_partials(cpd, atol=1.0E-5, rtol=1.0)
 
     def test_autoivc_no_solve(self):
-        with dymos.options.temporary(include_check_partials=True):
-            for direction in ['forward', 'backward']:
-                for compressed in [True, False]:
-                    with self.subTest(msg=f'{direction=} {compressed=}'):
+        for direction in ['forward', 'backward']:
+            for compressed in [True, False]:
+                with self.subTest(msg=f'{direction=} {compressed=}'):
 
-                        state_options = {'x': StateOptionsDictionary()}
+                    state_options = {'x': StateOptionsDictionary()}
 
-                        state_options['x']['shape'] = (1,)
-                        state_options['x']['units'] = 's**2'
-                        state_options['x']['targets'] = ['x']
-                        state_options['x']['initial_bounds'] = (None, None)
-                        state_options['x']['final_bounds'] = (None, None)
-                        state_options['x']['solve_segments'] = False
-                        state_options['x']['rate_source'] = 'x_dot'
+                    state_options['x']['shape'] = (1,)
+                    state_options['x']['units'] = 's**2'
+                    state_options['x']['targets'] = ['x']
+                    state_options['x']['initial_bounds'] = (None, None)
+                    state_options['x']['final_bounds'] = (None, None)
+                    state_options['x']['solve_segments'] = False
+                    state_options['x']['rate_source'] = 'x_dot'
 
-                        time_options = TimeOptionsDictionary()
-                        grid_data = RadauGrid(num_segments=2, nodes_per_seg=8, compressed=compressed)
-                        nn = grid_data.subset_num_nodes['all']
-                        ode_class = SimpleODE
+                    time_options = TimeOptionsDictionary()
+                    grid_data = RadauGrid(num_segments=2, nodes_per_seg=8, compressed=compressed)
+                    nn = grid_data.subset_num_nodes['all']
+                    ode_class = SimpleODE
 
-                        p = om.Problem()
-                        p.model.add_subsystem('radau', RadauIterGroup(state_options=state_options,
-                                                                      time_options=time_options,
-                                                                      grid_data=grid_data,
-                                                                      ode_class=ode_class))
+                    p = om.Problem()
+                    p.model.add_subsystem('radau', RadauIterGroup(state_options=state_options,
+                                                                    time_options=time_options,
+                                                                    grid_data=grid_data,
+                                                                    ode_class=ode_class))
 
-                        radau = p.model._get_subsystem('radau')
+                    radau = p.model._get_subsystem('radau')
 
-                        p.setup(force_alloc_complex=True)
+                    p.setup(force_alloc_complex=True)
 
-                        # Instead of using the TimeComp just transform the node segment taus onto [0, 2]
-                        times = grid_data.node_ptau + 1
+                    # Instead of using the TimeComp just transform the node segment taus onto [0, 2]
+                    times = grid_data.node_ptau + 1
 
-                        solution = np.reshape(times**2 + 2 * times + 1 - 0.5 * np.exp(times), (nn, 1))
-                        seg_end_idxs = grid_data.subset_node_indices['segment_ends'][1::2][:-1]
-                        solution_input_nodes = np.delete(solution, seg_end_idxs)
+                    solution = np.reshape(times**2 + 2 * times + 1 - 0.5 * np.exp(times), (nn, 1))
+                    seg_end_idxs = grid_data.subset_node_indices['segment_ends'][1::2][:-1]
+                    solution_input_nodes = np.delete(solution, seg_end_idxs)
 
-                        # Each segment is of the same length, so dt_dstau is constant.
-                        # dt_dstau is (tf - t0) / 2.0 / num_seg
-                        p.set_val('radau.dt_dstau', (times[-1] / 2.0 / grid_data.num_segments))
+                    # Each segment is of the same length, so dt_dstau is constant.
+                    # dt_dstau is (tf - t0) / 2.0 / num_seg
+                    p.set_val('radau.dt_dstau', (times[-1] / 2.0 / grid_data.num_segments))
 
-                        p.set_val('radau.initial_states:x', 0.5)
-                        p.set_val('radau.final_states:x', solution[-1])
+                    p.set_val('radau.initial_states:x', 0.5)
+                    p.set_val('radau.final_states:x', solution[-1])
 
-                        if compressed:
-                            # Solution is definted at all nodes, need to only provide the input node values.
-                            p.set_val('radau.states:x', solution_input_nodes)
-                        else:
-                            p.set_val('radau.states:x', solution)
+                    if compressed:
+                        # Solution is definted at all nodes, need to only provide the input node values.
+                        p.set_val('radau.states:x', solution_input_nodes)
+                    else:
+                        p.set_val('radau.states:x', solution)
 
-                        p.set_val('radau.ode_all.t', times)
-                        p.set_val('radau.ode_all.p', 1.0)
+                    p.set_val('radau.ode_all.t', times)
+                    p.set_val('radau.ode_all.p', 1.0)
 
-                        p.run_model()
+                    p.run_model()
 
-                        x = p.get_val('radau.states:x')
-                        x_0 = p.get_val('radau.initial_states:x')
-                        x_f = p.get_val('radau.final_states:x')
+                    x = p.get_val('radau.states:x')
+                    x_0 = p.get_val('radau.initial_states:x')
+                    x_f = p.get_val('radau.final_states:x')
 
-                        idxs = grid_data.subset_node_indices['state_input']
-                        assert_near_equal(solution[idxs], x, tolerance=1.0E-5)
-                        assert_near_equal(solution[np.newaxis, 0], x_0, tolerance=1.0E-7)
-                        assert_near_equal(solution[np.newaxis, -1], x_f, tolerance=1.0E-7)
+                    idxs = grid_data.subset_node_indices['state_input']
+                    assert_near_equal(solution[idxs], x, tolerance=1.0E-5)
+                    assert_near_equal(solution[np.newaxis, 0], x_0, tolerance=1.0E-7)
+                    assert_near_equal(solution[np.newaxis, -1], x_f, tolerance=1.0E-7)
 
-                        cpd = p.check_partials(method='cs', compact_print=False, out_stream=None)
-                        assert_check_partials(cpd)
+                    cpd = p.check_partials(method='cs', compact_print=False, out_stream=None)
+                    assert_check_partials(cpd)
 
 
 if __name__ == '__main__':

--- a/dymos/transcriptions/pseudospectral/components/test/test_state_interp_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/test/test_state_interp_comp.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal
 import openmdao.api as om
+from openmdao.utils.testing_utils import set_env_vars
 from dymos.utils.testing_utils import assert_check_partials
 
 from dymos.transcriptions.pseudospectral.components import StateInterpComp
@@ -40,12 +41,7 @@ def f_v(t):
 
 class TestStateInterpComp(unittest.TestCase):
 
-    def setUp(self):
-        dm.options['include_check_partials'] = True
-
-    def tearDown(self):
-        dm.options['include_check_partials'] = False
-
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_state_interp_comp_lobatto(self):
 
         segends = np.array([0.0, 3.0, 10.0])
@@ -155,6 +151,7 @@ class TestStateInterpComp(unittest.TestCase):
         cpd = p.check_partials(compact_print=True, method='cs', out_stream=None)
         assert_check_partials(cpd, atol=5.0E-5)
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_state_interp_comp_lobatto_vectorized(self):
 
         segends = np.array([0.0, 3.0, 10.0])
@@ -262,6 +259,7 @@ class TestStateInterpComp(unittest.TestCase):
         cpd = p.check_partials(compact_print=True, method='cs', out_stream=None)
         assert_check_partials(cpd, atol=5.0E-5)
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_state_interp_comp_lobatto_vectorized_different_orders(self):
 
         segends = np.array([0.0, 3.0, 10.0])
@@ -320,6 +318,7 @@ class TestStateInterpComp(unittest.TestCase):
         cpd = p.check_partials(compact_print=True, method='cs', out_stream=None)
         assert_check_partials(cpd, atol=5.0E-5)
 
+    @set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS='1')
     def test_state_interp_comp_radau(self):
 
         gd = GridData(num_segments=1,

--- a/dymos/transcriptions/pseudospectral/components/time_duration_comp.py
+++ b/dymos/transcriptions/pseudospectral/components/time_duration_comp.py
@@ -2,7 +2,6 @@ import numpy as np
 import openmdao.api as om
 
 from dymos.transcriptions.grid_data import GridData
-from dymos._options import options as dymos_options
 
 
 class TimeDurationComp(om.ImplicitComponent):
@@ -20,7 +19,7 @@ class TimeDurationComp(om.ImplicitComponent):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._no_check_partials = not dymos_options['include_check_partials']
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/dymos/utils/testing_utils.py
+++ b/dymos/utils/testing_utils.py
@@ -16,7 +16,7 @@ def assert_check_partials(data, atol=1.0E-6, rtol=1.0E-6):
     Wrap OpenMDAO's assert_check_partials with a dymos-specific message.
 
     Calls OpenMDAO's assert_check_partials but verifies that the dictionary of assertion data is
-    not empty due to dymos.options['include_check_partials'] being False.
+    not empty due to OPENMDAO_CHECK_ALL_PARTIALS being "falsey".
 
     Parameters
     ----------
@@ -38,7 +38,7 @@ def assert_check_partials(data, atol=1.0E-6, rtol=1.0E-6):
         Relative error. Default is 1e-6.
     """
     assert len(data) >= 1, "No check partials data found.  Is " \
-                           "dymos.options['include_check_partials'] set to True?"
+                           "environment variable OPENMDAO_CHECK_ALL_PARTIALS set to '1'?"
     _om_assert_utils.assert_check_partials(data, atol, rtol)
 
 


### PR DESCRIPTION
### Summary

The OpenMDAO method is cleaner and evaluated at the time of the partials check, rather than upon component setup.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
